### PR TITLE
Remove unneeded line from TestSetUtilIntersection.

### DIFF
--- a/setutil_test.go
+++ b/setutil_test.go
@@ -84,7 +84,6 @@ func TestSetUtilIntersection(t *testing.T) {
 	expectedresult = data1
 	nl = intersection2by2(data1, data2, result)
 	result = result[:nl]
-	result = result[:len(expectedresult)]
 
 	if !equal(result, expectedresult) {
 		t.Errorf("Long intersection is broken")


### PR DESCRIPTION
This line was not breaking anything in the code as it exists today, but seems like a mistake to include it. Leaving the line has the potential to cover over a wrong result in the future.
