### PR TITLE
Fix interface conversion checks.

### DIFF
--- a/arraycontainer.go
+++ b/arraycontainer.go
@@ -105,8 +105,8 @@ func (ac *arrayContainer) not(firstOfRange, lastOfRange int) container {
 }
 
 func (ac *arrayContainer) equals(o interface{}) bool {
-	srb := o.(*arrayContainer)
-	if srb != nil {
+	srb, ok := o.(*arrayContainer)
+	if ok {
 		if len(srb.content) != len(ac.content) {
 			return false
 		}

--- a/bitmapcontainer.go
+++ b/bitmapcontainer.go
@@ -111,8 +111,8 @@ func (bc *bitmapContainer) fillLeastSignificant16bits(x []int, i, mask int) {
 }
 
 func (bc *bitmapContainer) equals(o interface{}) bool {
-	srb := o.(*bitmapContainer)
-	if srb != nil {
+	srb, ok := o.(*bitmapContainer)
+	if ok {
 		if srb.cardinality != bc.cardinality {
 			return false
 		}

--- a/roaring.go
+++ b/roaring.go
@@ -154,8 +154,8 @@ func (rb *RoaringBitmap) Contains(x int) bool {
 
 // Equals returns true if the two bitmaps contain the same integers
 func (rb *RoaringBitmap) Equals(o interface{}) bool {
-	srb := o.(*RoaringBitmap)
-	if srb != nil {
+	srb, ok := o.(*RoaringBitmap)
+	if ok {
 		return srb.highlowcontainer.equals(rb.highlowcontainer)
 	}
 	return false


### PR DESCRIPTION
I think the comma, ok idiom rather than nil is the correct way to check whether an interface was able to be converted to the desired type. I think this change will remove a runtime crash. I haven't worked up a test case to demonstrate a time when an arrayContainer would be compared against a bitmapContainer, but it seems like the code tries to account for that possibility.
