### PR TITLE
Bitmap.Stats() method proposal

### DIFF
--- a/roaring_test.go
+++ b/roaring_test.go
@@ -1738,3 +1738,40 @@ func TestAndNot(t *testing.T) {
 		So(correct.Equals(rr), ShouldEqual, true)
 	})
 }
+
+func TestStats(t *testing.T) {
+	Convey("Test Stats with empty bitmap", t, func() {
+		expectedStats := Statistics{}
+		rr := NewBitmap()
+		So(rr.Stats(), ShouldResemble, expectedStats)
+	})
+	Convey("Test Stats with Bitmap Container", t, func() {
+		// Given a bitmap that should have a single bitmap container
+		expectedStats := Statistics {
+			Cardinality: 60000,
+			Containers: 1,
+
+			BitmapContainers: 1,
+			BitmapContainerValues: 60000,
+			BitmapContainerBytes: 8192,
+		}
+		rr := NewBitmap()
+		rr.AddRange(0, 60000)
+		So(rr.Stats(), ShouldResemble, expectedStats)
+	})
+	Convey("Test Stats with Array Container", t, func() {
+		// Given a bitmap that should have a single array container
+		expectedStats := Statistics {
+			Cardinality: 2,
+			Containers: 1,
+
+			ArrayContainers: 1,
+			ArrayContainerValues: 2,
+			ArrayContainerBytes: 28,
+		}
+		rr := NewBitmap()
+		rr.Add(2)
+		rr.Add(4)
+		So(rr.Stats(), ShouldResemble, expectedStats)
+	})
+}


### PR DESCRIPTION
Hi,

Here is a proposal of a `Stats()` method, similar to one in [gocroaring][goc-stats].

It gathers the same statistics, however unlike the _gocroaring_ version it returns a struct instead of a `map[string]uint64`. I think there are two advantages of this approach:
* discoverability of the gathered statistics when using an editor with auto-complete
* a mistyped statistic name in the client application will result in a compile time error instead of a runtime one

I'm hoping for comments on this PR. I'll add missing tests once the method interface is agreed on. :-)

[goc-stats]: https://github.com/RoaringBitmap/gocroaring/blob/master/gocroaring.go#L239