### PR TITLE
private runIterators, msgpack docs++

### DIFF
--- a/arraycontainer.go
+++ b/arraycontainer.go
@@ -11,9 +11,9 @@ type arrayContainer struct {
 	content []uint16
 }
 
-func (c *arrayContainer) String() string {
-	var s string = "{"
-	for it := c.getShortIterator(); it.hasNext(); {
+func (ac *arrayContainer) String() string {
+	s := "{"
+	for it := ac.getShortIterator(); it.hasNext(); {
 		s += fmt.Sprintf("%v, ", it.next())
 	}
 	return s + "}"
@@ -901,6 +901,6 @@ func (ac *arrayContainer) toEfficientContainer() container {
 	return ac.toBitmapContainer()
 }
 
-func (bc *arrayContainer) containerType() contype {
+func (ac *arrayContainer) containerType() contype {
 	return arrayContype
 }

--- a/arraycontainer_test.go
+++ b/arraycontainer_test.go
@@ -278,3 +278,53 @@ func TestArrayContainerIaddRangeNearMax068(t *testing.T) {
 
 	})
 }
+
+func TestArrayContainerEtc070(t *testing.T) {
+
+	Convey("arrayContainer rarely exercised code paths should get some coverage", t, func() {
+
+		iv := []interval16{{65525, 65527}, {65530, 65530}, {65534, 65535}}
+		rc := newRunContainer16TakeOwnership(iv)
+		ac := rc.toArrayContainer()
+
+		// not when nothing to do just returns a clone
+		So(ac.equals(ac.not(0, 0)), ShouldBeTrue)
+		So(ac.equals(ac.notClose(1, 0)), ShouldBeTrue)
+
+		// not will promote to bitmapContainer if card is big enough
+
+		ac = newArrayContainer()
+		ac.inot(0, MaxUint16+1)
+		rc = newRunContainer16Range(0, MaxUint16)
+
+		p("ac.card = %v", ac.getCardinality())
+		p("rc.card = %v", rc.getCardinality())
+		So(rc.equals(ac), ShouldBeTrue)
+
+		// comparing two array containers with different card
+		ac2 := newArrayContainer()
+		So(ac2.equals(ac), ShouldBeFalse)
+
+		// comparing two arrays with same card but different content
+		ac3 := newArrayContainer()
+		ac4 := newArrayContainer()
+		ac3.iadd(1)
+		ac3.iadd(2)
+		ac4.iadd(1)
+		So(ac3.equals(ac4), ShouldBeFalse)
+
+		// compare array vs other with different card
+		So(ac3.equals(rc), ShouldBeFalse)
+
+		// compare array vs other, same card, different content
+		rc = newRunContainer16Range(0, 0)
+		So(ac4.equals(rc), ShouldBeFalse)
+
+		// remove from middle of array
+		ac5 := newArrayContainer()
+		ac5.iaddRange(0, 10)
+		So(ac5.getCardinality(), ShouldEqual, 10)
+		ac6 := ac5.remove(5)
+		So(ac6.getCardinality(), ShouldEqual, 9)
+	})
+}

--- a/arraycontainer_test.go
+++ b/arraycontainer_test.go
@@ -326,5 +326,26 @@ func TestArrayContainerEtc070(t *testing.T) {
 		So(ac5.getCardinality(), ShouldEqual, 10)
 		ac6 := ac5.remove(5)
 		So(ac6.getCardinality(), ShouldEqual, 9)
+
+		// lazyorArray that converts to bitmap
+		ac5.iaddRange(0, arrayLazyLowerBound-1)
+		ac6.iaddRange(arrayLazyLowerBound, 2*arrayLazyLowerBound-2)
+		ac6a := ac6.(*arrayContainer)
+		bc := ac5.lazyorArray(ac6a)
+		_, isBitmap := bc.(*bitmapContainer)
+		So(isBitmap, ShouldBeTrue)
+
+		// andBitmap
+		ac = newArrayContainer()
+		ac.iaddRange(0, 10)
+		bc9 := newBitmapContainer()
+		bc9.iaddRange(0, 5)
+		and := ac.andBitmap(bc9)
+		So(and.getCardinality(), ShouldEqual, 5)
+
+		// numberOfRuns with 1 member
+		ac10 := newArrayContainer()
+		ac10.iadd(1)
+		So(ac10.numberOfRuns(), ShouldEqual, 1)
 	})
 }

--- a/bitmapcontainer.go
+++ b/bitmapcontainer.go
@@ -12,9 +12,9 @@ type bitmapContainer struct {
 	bitmap      []uint64
 }
 
-func (c bitmapContainer) String() string {
+func (bc bitmapContainer) String() string {
 	var s string
-	for it := c.getShortIterator(); it.hasNext(); {
+	for it := bc.getShortIterator(); it.hasNext(); {
 		s += fmt.Sprintf("%v, ", it.next())
 	}
 	return s

--- a/example_roaring_test.go
+++ b/example_roaring_test.go
@@ -21,7 +21,7 @@ func TestExample_roaring060(t *testing.T) {
 
 	fmt.Println("Cardinality: ", rb1.GetCardinality())
 	if rb1.GetCardinality() != 7 {
-		t.Errorf("Bad cardinality.", rb1.GetCardinality())
+		t.Errorf("Bad cardinality: %v", rb1.GetCardinality())
 	}
 
 	fmt.Println("Contains 3? ", rb1.Contains(3))
@@ -90,14 +90,14 @@ func TestExample2_roaring061(t *testing.T) {
 	if cardinality != r1.GetCardinality() {
 		t.Errorf("RunOptimize should not change cardinality.")
 	}
-	compact_size := r1.GetSizeInBytes()
-	if compact_size >= size {
+	compactSize := r1.GetSizeInBytes()
+	if compactSize >= size {
 		t.Errorf("Run optimized size should be smaller.")
 	}
 	if !r1.Equals(rb2) {
 		t.Errorf("RunOptimize should not affect equality.")
 	}
-	fmt.Print("size before run optimize: ", size, " bytes, and after: ", compact_size, " bytes.\n")
+	fmt.Print("size before run optimize: ", size, " bytes, and after: ", compactSize, " bytes.\n")
 	rb3 := New()
 	rb3.AddRange(1, 10000000)
 	r1.Or(rb3)

--- a/example_roaring_test.go
+++ b/example_roaring_test.go
@@ -97,7 +97,7 @@ func TestExample2_roaring061(t *testing.T) {
 	if !r1.Equals(rb2) {
 		t.Errorf("RunOptimize should not affect equality.")
 	}
-	fmt.Print("size before run optimize ", size, " bytes, and after ", compact_size, " bytes")
+	fmt.Print("size before run optimize: ", size, " bytes, and after: ", compact_size, " bytes.\n")
 	rb3 := New()
 	rb3.AddRange(1, 10000000)
 	r1.Or(rb3)
@@ -112,7 +112,7 @@ func TestExample2_roaring061(t *testing.T) {
 	for i := uint32(0); i < 10000; i += 3 {
 		rb1.Add(i)
 	}
-	fmt.Printf("\n rb1card before doing AndNot(rb3): %v, rb3card=%v\n",
+	p("rb1card before doing AndNot(rb3): %v, rb3card=%v",
 		rb1.GetCardinality(), rb3.GetCardinality())
 	rb1.AndNot(rb3)
 	rb1card := rb1.GetCardinality()

--- a/rle.go
+++ b/rle.go
@@ -1192,44 +1192,44 @@ func (rc *runContainer32) invert() *runContainer32 {
 	return &runContainer32{iv: m}
 }
 
-func (a interval32) equal(b interval32) bool {
-	if a.start == b.start {
-		return a.last == b.last
+func (iv interval32) equal(b interval32) bool {
+	if iv.start == b.start {
+		return iv.last == b.last
 	}
 	return false
 }
 
-func (a interval32) isSuperSetOf(b interval32) bool {
-	return a.start <= b.start && b.last <= a.last
+func (iv interval32) isSuperSetOf(b interval32) bool {
+	return iv.start <= b.start && b.last <= iv.last
 }
 
-func (cur interval32) subtractInterval(del interval32) (left []interval32, delcount int64) {
+func (iv interval32) subtractInterval(del interval32) (left []interval32, delcount int64) {
 	defer func() {
-		//p("returning from subtractInterval of cur - del with cur=%s and del=%s, returning left=%s, delcount=%v", cur, del, ivalString32(left), delcount)
+		//p("returning from subtractInterval of iv - del with iv=%s and del=%s, returning left=%s, delcount=%v", iv, del, ivalString32(left), delcount)
 	}()
-	isect, isEmpty := intersectInterval32s(cur, del)
+	isect, isEmpty := intersectInterval32s(iv, del)
 
 	if isEmpty {
 		//p("isEmpty")
 		return nil, 0
 	}
-	if del.isSuperSetOf(cur) {
-		return nil, cur.runlen()
+	if del.isSuperSetOf(iv) {
+		return nil, iv.runlen()
 	}
 
 	switch {
-	case isect.start > cur.start && isect.last < cur.last:
+	case isect.start > iv.start && isect.last < iv.last:
 		//p("split into two")
-		new0 := interval32{start: cur.start, last: isect.start - 1}
-		new1 := interval32{start: isect.last + 1, last: cur.last}
+		new0 := interval32{start: iv.start, last: isect.start - 1}
+		new1 := interval32{start: isect.last + 1, last: iv.last}
 		return []interval32{new0, new1}, isect.runlen()
-	case isect.start == cur.start:
-		//p("removal of only the first half or so of cur interval. isect: %s, cur: %s, del: %s", isect, cur, del)
-		return []interval32{{start: isect.last + 1, last: cur.last}}, isect.runlen()
+	case isect.start == iv.start:
+		//p("removal of only the first half or so of iv interval. isect: %s, iv: %s, del: %s", isect, iv, del)
+		return []interval32{{start: isect.last + 1, last: iv.last}}, isect.runlen()
 	default:
-		//p("isect.end == cur.end")
-		//p("removal of only the last half or so of cur interval")
-		return []interval32{{start: cur.start, last: isect.start - 1}}, isect.runlen()
+		//p("isect.end == iv.end")
+		//p("removal of only the last half or so of iv interval")
+		return []interval32{{start: iv.start, last: isect.start - 1}}, isect.runlen()
 	}
 }
 
@@ -1481,6 +1481,6 @@ func (rc *runContainer32) numberOfRuns() (nr int) {
 	return len(rc.iv)
 }
 
-func (bc *runContainer32) containerType() contype {
+func (rc *runContainer32) containerType() contype {
 	return run32Contype
 }

--- a/rle.go
+++ b/rle.go
@@ -907,34 +907,27 @@ func (rc *runContainer32) Add(k uint32) (wasNew bool) {
 	return
 }
 
-//msgp:ignore RunIterator
+//msgp:ignore runIterator
 
-// RunIterator32 advice: you must call Next() at least once
+// runIterator32 advice: you must call Next() at least once
 // before calling Cur(); and you should call HasNext()
 // before calling Next() to insure there are contents.
-type RunIterator32 struct {
+type runIterator32 struct {
 	rc            *runContainer32
 	curIndex      int64
 	curPosInIndex uint32
 	curSeq        int64
 }
 
-// NewRunIterator32 returns a new empty run container.
-func (rc *runContainer32) NewRunIterator32() *RunIterator32 {
-	return &RunIterator32{rc: rc, curIndex: -1}
-}
-
-func (ri *RunIterator32) hasNext() bool {
-	return ri.HasNext()
-}
-func (ri *RunIterator32) next() uint32 {
-	return ri.Next()
+// newRunIterator32 returns a new empty run container.
+func (rc *runContainer32) newRunIterator32() *runIterator32 {
+	return &runIterator32{rc: rc, curIndex: -1}
 }
 
 // HasNext returns false if calling Next will panic. It
 // returns true when there is at least one more value
 // available in the iteration sequence.
-func (ri *RunIterator32) HasNext() bool {
+func (ri *runIterator32) hasNext() bool {
 	if len(ri.rc.iv) == 0 {
 		return false
 	}
@@ -944,19 +937,19 @@ func (ri *RunIterator32) HasNext() bool {
 	return ri.curSeq+1 < ri.rc.cardinality()
 }
 
-// Cur returns the current value pointed to by the iterator.
-func (ri *RunIterator32) Cur() uint32 {
+// cur returns the current value pointed to by the iterator.
+func (ri *runIterator32) cur() uint32 {
 	//p("in Cur, curIndex=%v, curPosInIndex=%v", ri.curIndex, ri.curPosInIndex)
 	return ri.rc.iv[ri.curIndex].start + ri.curPosInIndex
 }
 
 // Next returns the next value in the iteration sequence.
-func (ri *RunIterator32) Next() uint32 {
-	if !ri.HasNext() {
+func (ri *runIterator32) next() uint32 {
+	if !ri.hasNext() {
 		panic("no Next available")
 	}
 	if ri.curIndex >= int64(len(ri.rc.iv)) {
-		panic("RunIterator.Next() going beyond what is available")
+		panic("runIterator.Next() going beyond what is available")
 	}
 	if ri.curIndex == -1 {
 		// first time is special
@@ -972,19 +965,19 @@ func (ri *RunIterator32) Next() uint32 {
 		}
 		ri.curSeq++
 	}
-	return ri.Cur()
+	return ri.cur()
 }
 
-// Remove removes the element that the iterator
+// remove removes the element that the iterator
 // is on from the run container. You can use
 // Cur if you want to double check what is about
 // to be deleted.
-func (ri *RunIterator32) Remove() uint32 {
+func (ri *runIterator32) remove() uint32 {
 	n := ri.rc.cardinality()
 	if n == 0 {
-		panic("RunIterator.Remove called on empty runContainer32")
+		panic("runIterator.Remove called on empty runContainer32")
 	}
-	cur := ri.Cur()
+	cur := ri.cur()
 
 	ri.rc.deleteAt(&ri.curIndex, &ri.curPosInIndex, &ri.curSeq)
 	return cur

--- a/rle.go
+++ b/rle.go
@@ -1484,3 +1484,26 @@ func (rc *runContainer32) numberOfRuns() (nr int) {
 func (rc *runContainer32) containerType() contype {
 	return run32Contype
 }
+
+func (rc *runContainer32) equals32(srb *runContainer32) bool {
+	//p("both rc32")
+	// Check if the containers are the same object.
+	if rc == srb {
+		//p("same object")
+		return true
+	}
+
+	if len(srb.iv) != len(rc.iv) {
+		//p("iv len differ")
+		return false
+	}
+
+	for i, v := range rc.iv {
+		if v != srb.iv[i] {
+			//p("differ at iv i=%v, srb.iv[i]=%v, rc.iv[i]=%v", i, srb.iv[i], rc.iv[i])
+			return false
+		}
+	}
+	//p("all intervals same, returning true")
+	return true
+}

--- a/rle16.go
+++ b/rle16.go
@@ -907,34 +907,27 @@ func (rc *runContainer16) Add(k uint16) (wasNew bool) {
 	return
 }
 
-//msgp:ignore RunIterator
+//msgp:ignore runIterator
 
-// RunIterator16 advice: you must call Next() at least once
+// runIterator16 advice: you must call Next() at least once
 // before calling Cur(); and you should call HasNext()
 // before calling Next() to insure there are contents.
-type RunIterator16 struct {
+type runIterator16 struct {
 	rc            *runContainer16
 	curIndex      int64
 	curPosInIndex uint16
 	curSeq        int64
 }
 
-// NewRunIterator16 returns a new empty run container.
-func (rc *runContainer16) NewRunIterator16() *RunIterator16 {
-	return &RunIterator16{rc: rc, curIndex: -1}
-}
-
-func (ri *RunIterator16) hasNext() bool {
-	return ri.HasNext()
-}
-func (ri *RunIterator16) next() uint16 {
-	return ri.Next()
+// newRunIterator16 returns a new empty run container.
+func (rc *runContainer16) newRunIterator16() *runIterator16 {
+	return &runIterator16{rc: rc, curIndex: -1}
 }
 
 // HasNext returns false if calling Next will panic. It
 // returns true when there is at least one more value
 // available in the iteration sequence.
-func (ri *RunIterator16) HasNext() bool {
+func (ri *runIterator16) hasNext() bool {
 	if len(ri.rc.iv) == 0 {
 		return false
 	}
@@ -944,19 +937,19 @@ func (ri *RunIterator16) HasNext() bool {
 	return ri.curSeq+1 < ri.rc.cardinality()
 }
 
-// Cur returns the current value pointed to by the iterator.
-func (ri *RunIterator16) Cur() uint16 {
+// cur returns the current value pointed to by the iterator.
+func (ri *runIterator16) cur() uint16 {
 	//p("in Cur, curIndex=%v, curPosInIndex=%v", ri.curIndex, ri.curPosInIndex)
 	return ri.rc.iv[ri.curIndex].start + ri.curPosInIndex
 }
 
 // Next returns the next value in the iteration sequence.
-func (ri *RunIterator16) Next() uint16 {
-	if !ri.HasNext() {
+func (ri *runIterator16) next() uint16 {
+	if !ri.hasNext() {
 		panic("no Next available")
 	}
 	if ri.curIndex >= int64(len(ri.rc.iv)) {
-		panic("RunIterator.Next() going beyond what is available")
+		panic("runIterator.Next() going beyond what is available")
 	}
 	if ri.curIndex == -1 {
 		// first time is special
@@ -972,19 +965,19 @@ func (ri *RunIterator16) Next() uint16 {
 		}
 		ri.curSeq++
 	}
-	return ri.Cur()
+	return ri.cur()
 }
 
-// Remove removes the element that the iterator
+// remove removes the element that the iterator
 // is on from the run container. You can use
 // Cur if you want to double check what is about
 // to be deleted.
-func (ri *RunIterator16) Remove() uint16 {
+func (ri *runIterator16) remove() uint16 {
 	n := ri.rc.cardinality()
 	if n == 0 {
-		panic("RunIterator.Remove called on empty runContainer16")
+		panic("runIterator.Remove called on empty runContainer16")
 	}
-	cur := ri.Cur()
+	cur := ri.cur()
 
 	ri.rc.deleteAt(&ri.curIndex, &ri.curPosInIndex, &ri.curSeq)
 	return cur

--- a/rle16.go
+++ b/rle16.go
@@ -1484,3 +1484,26 @@ func (rc *runContainer16) numberOfRuns() (nr int) {
 func (rc *runContainer16) containerType() contype {
 	return run16Contype
 }
+
+func (rc *runContainer16) equals16(srb *runContainer16) bool {
+	//p("both rc16")
+	// Check if the containers are the same object.
+	if rc == srb {
+		//p("same object")
+		return true
+	}
+
+	if len(srb.iv) != len(rc.iv) {
+		//p("iv len differ")
+		return false
+	}
+
+	for i, v := range rc.iv {
+		if v != srb.iv[i] {
+			//p("differ at iv i=%v, srb.iv[i]=%v, rc.iv[i]=%v", i, srb.iv[i], rc.iv[i])
+			return false
+		}
+	}
+	//p("all intervals same, returning true")
+	return true
+}

--- a/rle16.go
+++ b/rle16.go
@@ -1192,44 +1192,44 @@ func (rc *runContainer16) invert() *runContainer16 {
 	return &runContainer16{iv: m}
 }
 
-func (a interval16) equal(b interval16) bool {
-	if a.start == b.start {
-		return a.last == b.last
+func (iv interval16) equal(b interval16) bool {
+	if iv.start == b.start {
+		return iv.last == b.last
 	}
 	return false
 }
 
-func (a interval16) isSuperSetOf(b interval16) bool {
-	return a.start <= b.start && b.last <= a.last
+func (iv interval16) isSuperSetOf(b interval16) bool {
+	return iv.start <= b.start && b.last <= iv.last
 }
 
-func (cur interval16) subtractInterval(del interval16) (left []interval16, delcount int64) {
+func (iv interval16) subtractInterval(del interval16) (left []interval16, delcount int64) {
 	defer func() {
-		//p("returning from subtractInterval of cur - del with cur=%s and del=%s, returning left=%s, delcount=%v", cur, del, ivalString16(left), delcount)
+		//p("returning from subtractInterval of iv - del with iv=%s and del=%s, returning left=%s, delcount=%v", iv, del, ivalString16(left), delcount)
 	}()
-	isect, isEmpty := intersectInterval16s(cur, del)
+	isect, isEmpty := intersectInterval16s(iv, del)
 
 	if isEmpty {
 		//p("isEmpty")
 		return nil, 0
 	}
-	if del.isSuperSetOf(cur) {
-		return nil, cur.runlen()
+	if del.isSuperSetOf(iv) {
+		return nil, iv.runlen()
 	}
 
 	switch {
-	case isect.start > cur.start && isect.last < cur.last:
+	case isect.start > iv.start && isect.last < iv.last:
 		//p("split into two")
-		new0 := interval16{start: cur.start, last: isect.start - 1}
-		new1 := interval16{start: isect.last + 1, last: cur.last}
+		new0 := interval16{start: iv.start, last: isect.start - 1}
+		new1 := interval16{start: isect.last + 1, last: iv.last}
 		return []interval16{new0, new1}, isect.runlen()
-	case isect.start == cur.start:
-		//p("removal of only the first half or so of cur interval. isect: %s, cur: %s, del: %s", isect, cur, del)
-		return []interval16{{start: isect.last + 1, last: cur.last}}, isect.runlen()
+	case isect.start == iv.start:
+		//p("removal of only the first half or so of iv interval. isect: %s, iv: %s, del: %s", isect, iv, del)
+		return []interval16{{start: isect.last + 1, last: iv.last}}, isect.runlen()
 	default:
-		//p("isect.end == cur.end")
-		//p("removal of only the last half or so of cur interval")
-		return []interval16{{start: cur.start, last: isect.start - 1}}, isect.runlen()
+		//p("isect.end == iv.end")
+		//p("removal of only the last half or so of iv interval")
+		return []interval16{{start: iv.start, last: isect.start - 1}}, isect.runlen()
 	}
 }
 
@@ -1481,6 +1481,6 @@ func (rc *runContainer16) numberOfRuns() (nr int) {
 	return len(rc.iv)
 }
 
-func (bc *runContainer16) containerType() contype {
+func (rc *runContainer16) containerType() contype {
 	return run16Contype
 }

--- a/rle16_gen.go
+++ b/rle16_gen.go
@@ -7,218 +7,16 @@ package roaring
 import "github.com/tinylib/msgp/msgp"
 
 // DecodeMsg implements msgp.Decodable
-func (z *RunIterator16) DecodeMsg(dc *msgp.Reader) (err error) {
-	var field []byte
-	_ = field
-	var zxvk uint32
-	zxvk, err = dc.ReadMapHeader()
-	if err != nil {
-		return
-	}
-	for zxvk > 0 {
-		zxvk--
-		field, err = dc.ReadMapKeyPtr()
-		if err != nil {
-			return
-		}
-		switch msgp.UnsafeString(field) {
-		case "rc":
-			if dc.IsNil() {
-				err = dc.ReadNil()
-				if err != nil {
-					return
-				}
-				z.rc = nil
-			} else {
-				if z.rc == nil {
-					z.rc = new(runContainer16)
-				}
-				err = z.rc.DecodeMsg(dc)
-				if err != nil {
-					return
-				}
-			}
-		case "curIndex":
-			z.curIndex, err = dc.ReadInt64()
-			if err != nil {
-				return
-			}
-		case "curPosInIndex":
-			z.curPosInIndex, err = dc.ReadUint16()
-			if err != nil {
-				return
-			}
-		case "curSeq":
-			z.curSeq, err = dc.ReadInt64()
-			if err != nil {
-				return
-			}
-		default:
-			err = dc.Skip()
-			if err != nil {
-				return
-			}
-		}
-	}
-	return
-}
-
-// EncodeMsg implements msgp.Encodable
-func (z *RunIterator16) EncodeMsg(en *msgp.Writer) (err error) {
-	// map header, size 4
-	// write "rc"
-	err = en.Append(0x84, 0xa2, 0x72, 0x63)
-	if err != nil {
-		return err
-	}
-	if z.rc == nil {
-		err = en.WriteNil()
-		if err != nil {
-			return
-		}
-	} else {
-		err = z.rc.EncodeMsg(en)
-		if err != nil {
-			return
-		}
-	}
-	// write "curIndex"
-	err = en.Append(0xa8, 0x63, 0x75, 0x72, 0x49, 0x6e, 0x64, 0x65, 0x78)
-	if err != nil {
-		return err
-	}
-	err = en.WriteInt64(z.curIndex)
-	if err != nil {
-		return
-	}
-	// write "curPosInIndex"
-	err = en.Append(0xad, 0x63, 0x75, 0x72, 0x50, 0x6f, 0x73, 0x49, 0x6e, 0x49, 0x6e, 0x64, 0x65, 0x78)
-	if err != nil {
-		return err
-	}
-	err = en.WriteUint16(z.curPosInIndex)
-	if err != nil {
-		return
-	}
-	// write "curSeq"
-	err = en.Append(0xa6, 0x63, 0x75, 0x72, 0x53, 0x65, 0x71)
-	if err != nil {
-		return err
-	}
-	err = en.WriteInt64(z.curSeq)
-	if err != nil {
-		return
-	}
-	return
-}
-
-// MarshalMsg implements msgp.Marshaler
-func (z *RunIterator16) MarshalMsg(b []byte) (o []byte, err error) {
-	o = msgp.Require(b, z.Msgsize())
-	// map header, size 4
-	// string "rc"
-	o = append(o, 0x84, 0xa2, 0x72, 0x63)
-	if z.rc == nil {
-		o = msgp.AppendNil(o)
-	} else {
-		o, err = z.rc.MarshalMsg(o)
-		if err != nil {
-			return
-		}
-	}
-	// string "curIndex"
-	o = append(o, 0xa8, 0x63, 0x75, 0x72, 0x49, 0x6e, 0x64, 0x65, 0x78)
-	o = msgp.AppendInt64(o, z.curIndex)
-	// string "curPosInIndex"
-	o = append(o, 0xad, 0x63, 0x75, 0x72, 0x50, 0x6f, 0x73, 0x49, 0x6e, 0x49, 0x6e, 0x64, 0x65, 0x78)
-	o = msgp.AppendUint16(o, z.curPosInIndex)
-	// string "curSeq"
-	o = append(o, 0xa6, 0x63, 0x75, 0x72, 0x53, 0x65, 0x71)
-	o = msgp.AppendInt64(o, z.curSeq)
-	return
-}
-
-// UnmarshalMsg implements msgp.Unmarshaler
-func (z *RunIterator16) UnmarshalMsg(bts []byte) (o []byte, err error) {
-	var field []byte
-	_ = field
-	var zbzg uint32
-	zbzg, bts, err = msgp.ReadMapHeaderBytes(bts)
-	if err != nil {
-		return
-	}
-	for zbzg > 0 {
-		zbzg--
-		field, bts, err = msgp.ReadMapKeyZC(bts)
-		if err != nil {
-			return
-		}
-		switch msgp.UnsafeString(field) {
-		case "rc":
-			if msgp.IsNil(bts) {
-				bts, err = msgp.ReadNilBytes(bts)
-				if err != nil {
-					return
-				}
-				z.rc = nil
-			} else {
-				if z.rc == nil {
-					z.rc = new(runContainer16)
-				}
-				bts, err = z.rc.UnmarshalMsg(bts)
-				if err != nil {
-					return
-				}
-			}
-		case "curIndex":
-			z.curIndex, bts, err = msgp.ReadInt64Bytes(bts)
-			if err != nil {
-				return
-			}
-		case "curPosInIndex":
-			z.curPosInIndex, bts, err = msgp.ReadUint16Bytes(bts)
-			if err != nil {
-				return
-			}
-		case "curSeq":
-			z.curSeq, bts, err = msgp.ReadInt64Bytes(bts)
-			if err != nil {
-				return
-			}
-		default:
-			bts, err = msgp.Skip(bts)
-			if err != nil {
-				return
-			}
-		}
-	}
-	o = bts
-	return
-}
-
-// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
-func (z *RunIterator16) Msgsize() (s int) {
-	s = 1 + 3
-	if z.rc == nil {
-		s += msgp.NilSize
-	} else {
-		s += z.rc.Msgsize()
-	}
-	s += 9 + msgp.Int64Size + 14 + msgp.Uint16Size + 7 + msgp.Int64Size
-	return
-}
-
-// DecodeMsg implements msgp.Decodable
 func (z *addHelper16) DecodeMsg(dc *msgp.Reader) (err error) {
 	var field []byte
 	_ = field
-	var zcmr uint32
-	zcmr, err = dc.ReadMapHeader()
+	var zbai uint32
+	zbai, err = dc.ReadMapHeader()
 	if err != nil {
 		return
 	}
-	for zcmr > 0 {
-		zcmr--
+	for zbai > 0 {
+		zbai--
 		field, err = dc.ReadMapKeyPtr()
 		if err != nil {
 			return
@@ -240,36 +38,36 @@ func (z *addHelper16) DecodeMsg(dc *msgp.Reader) (err error) {
 				return
 			}
 		case "m":
-			var zajw uint32
-			zajw, err = dc.ReadArrayHeader()
+			var zcmr uint32
+			zcmr, err = dc.ReadArrayHeader()
 			if err != nil {
 				return
 			}
-			if cap(z.m) >= int(zajw) {
-				z.m = (z.m)[:zajw]
+			if cap(z.m) >= int(zcmr) {
+				z.m = (z.m)[:zcmr]
 			} else {
-				z.m = make([]interval16, zajw)
+				z.m = make([]interval16, zcmr)
 			}
-			for zbai := range z.m {
-				var zwht uint32
-				zwht, err = dc.ReadMapHeader()
+			for zxvk := range z.m {
+				var zajw uint32
+				zajw, err = dc.ReadMapHeader()
 				if err != nil {
 					return
 				}
-				for zwht > 0 {
-					zwht--
+				for zajw > 0 {
+					zajw--
 					field, err = dc.ReadMapKeyPtr()
 					if err != nil {
 						return
 					}
 					switch msgp.UnsafeString(field) {
 					case "start":
-						z.m[zbai].start, err = dc.ReadUint16()
+						z.m[zxvk].start, err = dc.ReadUint16()
 						if err != nil {
 							return
 						}
 					case "last":
-						z.m[zbai].last, err = dc.ReadUint16()
+						z.m[zxvk].last, err = dc.ReadUint16()
 						if err != nil {
 							return
 						}
@@ -292,9 +90,71 @@ func (z *addHelper16) DecodeMsg(dc *msgp.Reader) (err error) {
 				if z.rc == nil {
 					z.rc = new(runContainer16)
 				}
-				err = z.rc.DecodeMsg(dc)
+				var zwht uint32
+				zwht, err = dc.ReadMapHeader()
 				if err != nil {
 					return
+				}
+				for zwht > 0 {
+					zwht--
+					field, err = dc.ReadMapKeyPtr()
+					if err != nil {
+						return
+					}
+					switch msgp.UnsafeString(field) {
+					case "iv":
+						var zhct uint32
+						zhct, err = dc.ReadArrayHeader()
+						if err != nil {
+							return
+						}
+						if cap(z.rc.iv) >= int(zhct) {
+							z.rc.iv = (z.rc.iv)[:zhct]
+						} else {
+							z.rc.iv = make([]interval16, zhct)
+						}
+						for zbzg := range z.rc.iv {
+							var zcua uint32
+							zcua, err = dc.ReadMapHeader()
+							if err != nil {
+								return
+							}
+							for zcua > 0 {
+								zcua--
+								field, err = dc.ReadMapKeyPtr()
+								if err != nil {
+									return
+								}
+								switch msgp.UnsafeString(field) {
+								case "start":
+									z.rc.iv[zbzg].start, err = dc.ReadUint16()
+									if err != nil {
+										return
+									}
+								case "last":
+									z.rc.iv[zbzg].last, err = dc.ReadUint16()
+									if err != nil {
+										return
+									}
+								default:
+									err = dc.Skip()
+									if err != nil {
+										return
+									}
+								}
+							}
+						}
+					case "card":
+						z.rc.card, err = dc.ReadInt64()
+						if err != nil {
+							return
+						}
+					default:
+						err = dc.Skip()
+						if err != nil {
+							return
+						}
+					}
 				}
 			}
 		default:
@@ -346,14 +206,14 @@ func (z *addHelper16) EncodeMsg(en *msgp.Writer) (err error) {
 	if err != nil {
 		return
 	}
-	for zbai := range z.m {
+	for zxvk := range z.m {
 		// map header, size 2
 		// write "start"
 		err = en.Append(0x82, 0xa5, 0x73, 0x74, 0x61, 0x72, 0x74)
 		if err != nil {
 			return err
 		}
-		err = en.WriteUint16(z.m[zbai].start)
+		err = en.WriteUint16(z.m[zxvk].start)
 		if err != nil {
 			return
 		}
@@ -362,7 +222,7 @@ func (z *addHelper16) EncodeMsg(en *msgp.Writer) (err error) {
 		if err != nil {
 			return err
 		}
-		err = en.WriteUint16(z.m[zbai].last)
+		err = en.WriteUint16(z.m[zxvk].last)
 		if err != nil {
 			return
 		}
@@ -378,7 +238,43 @@ func (z *addHelper16) EncodeMsg(en *msgp.Writer) (err error) {
 			return
 		}
 	} else {
-		err = z.rc.EncodeMsg(en)
+		// map header, size 2
+		// write "iv"
+		err = en.Append(0x82, 0xa2, 0x69, 0x76)
+		if err != nil {
+			return err
+		}
+		err = en.WriteArrayHeader(uint32(len(z.rc.iv)))
+		if err != nil {
+			return
+		}
+		for zbzg := range z.rc.iv {
+			// map header, size 2
+			// write "start"
+			err = en.Append(0x82, 0xa5, 0x73, 0x74, 0x61, 0x72, 0x74)
+			if err != nil {
+				return err
+			}
+			err = en.WriteUint16(z.rc.iv[zbzg].start)
+			if err != nil {
+				return
+			}
+			// write "last"
+			err = en.Append(0xa4, 0x6c, 0x61, 0x73, 0x74)
+			if err != nil {
+				return err
+			}
+			err = en.WriteUint16(z.rc.iv[zbzg].last)
+			if err != nil {
+				return
+			}
+		}
+		// write "card"
+		err = en.Append(0xa4, 0x63, 0x61, 0x72, 0x64)
+		if err != nil {
+			return err
+		}
+		err = en.WriteInt64(z.rc.card)
 		if err != nil {
 			return
 		}
@@ -402,24 +298,36 @@ func (z *addHelper16) MarshalMsg(b []byte) (o []byte, err error) {
 	// string "m"
 	o = append(o, 0xa1, 0x6d)
 	o = msgp.AppendArrayHeader(o, uint32(len(z.m)))
-	for zbai := range z.m {
+	for zxvk := range z.m {
 		// map header, size 2
 		// string "start"
 		o = append(o, 0x82, 0xa5, 0x73, 0x74, 0x61, 0x72, 0x74)
-		o = msgp.AppendUint16(o, z.m[zbai].start)
+		o = msgp.AppendUint16(o, z.m[zxvk].start)
 		// string "last"
 		o = append(o, 0xa4, 0x6c, 0x61, 0x73, 0x74)
-		o = msgp.AppendUint16(o, z.m[zbai].last)
+		o = msgp.AppendUint16(o, z.m[zxvk].last)
 	}
 	// string "rc"
 	o = append(o, 0xa2, 0x72, 0x63)
 	if z.rc == nil {
 		o = msgp.AppendNil(o)
 	} else {
-		o, err = z.rc.MarshalMsg(o)
-		if err != nil {
-			return
+		// map header, size 2
+		// string "iv"
+		o = append(o, 0x82, 0xa2, 0x69, 0x76)
+		o = msgp.AppendArrayHeader(o, uint32(len(z.rc.iv)))
+		for zbzg := range z.rc.iv {
+			// map header, size 2
+			// string "start"
+			o = append(o, 0x82, 0xa5, 0x73, 0x74, 0x61, 0x72, 0x74)
+			o = msgp.AppendUint16(o, z.rc.iv[zbzg].start)
+			// string "last"
+			o = append(o, 0xa4, 0x6c, 0x61, 0x73, 0x74)
+			o = msgp.AppendUint16(o, z.rc.iv[zbzg].last)
 		}
+		// string "card"
+		o = append(o, 0xa4, 0x63, 0x61, 0x72, 0x64)
+		o = msgp.AppendInt64(o, z.rc.card)
 	}
 	return
 }
@@ -428,13 +336,13 @@ func (z *addHelper16) MarshalMsg(b []byte) (o []byte, err error) {
 func (z *addHelper16) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	var field []byte
 	_ = field
-	var zhct uint32
-	zhct, bts, err = msgp.ReadMapHeaderBytes(bts)
+	var zxhx uint32
+	zxhx, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if err != nil {
 		return
 	}
-	for zhct > 0 {
-		zhct--
+	for zxhx > 0 {
+		zxhx--
 		field, bts, err = msgp.ReadMapKeyZC(bts)
 		if err != nil {
 			return
@@ -456,36 +364,36 @@ func (z *addHelper16) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				return
 			}
 		case "m":
-			var zcua uint32
-			zcua, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zlqf uint32
+			zlqf, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				return
 			}
-			if cap(z.m) >= int(zcua) {
-				z.m = (z.m)[:zcua]
+			if cap(z.m) >= int(zlqf) {
+				z.m = (z.m)[:zlqf]
 			} else {
-				z.m = make([]interval16, zcua)
+				z.m = make([]interval16, zlqf)
 			}
-			for zbai := range z.m {
-				var zxhx uint32
-				zxhx, bts, err = msgp.ReadMapHeaderBytes(bts)
+			for zxvk := range z.m {
+				var zdaf uint32
+				zdaf, bts, err = msgp.ReadMapHeaderBytes(bts)
 				if err != nil {
 					return
 				}
-				for zxhx > 0 {
-					zxhx--
+				for zdaf > 0 {
+					zdaf--
 					field, bts, err = msgp.ReadMapKeyZC(bts)
 					if err != nil {
 						return
 					}
 					switch msgp.UnsafeString(field) {
 					case "start":
-						z.m[zbai].start, bts, err = msgp.ReadUint16Bytes(bts)
+						z.m[zxvk].start, bts, err = msgp.ReadUint16Bytes(bts)
 						if err != nil {
 							return
 						}
 					case "last":
-						z.m[zbai].last, bts, err = msgp.ReadUint16Bytes(bts)
+						z.m[zxvk].last, bts, err = msgp.ReadUint16Bytes(bts)
 						if err != nil {
 							return
 						}
@@ -508,9 +416,71 @@ func (z *addHelper16) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				if z.rc == nil {
 					z.rc = new(runContainer16)
 				}
-				bts, err = z.rc.UnmarshalMsg(bts)
+				var zpks uint32
+				zpks, bts, err = msgp.ReadMapHeaderBytes(bts)
 				if err != nil {
 					return
+				}
+				for zpks > 0 {
+					zpks--
+					field, bts, err = msgp.ReadMapKeyZC(bts)
+					if err != nil {
+						return
+					}
+					switch msgp.UnsafeString(field) {
+					case "iv":
+						var zjfb uint32
+						zjfb, bts, err = msgp.ReadArrayHeaderBytes(bts)
+						if err != nil {
+							return
+						}
+						if cap(z.rc.iv) >= int(zjfb) {
+							z.rc.iv = (z.rc.iv)[:zjfb]
+						} else {
+							z.rc.iv = make([]interval16, zjfb)
+						}
+						for zbzg := range z.rc.iv {
+							var zcxo uint32
+							zcxo, bts, err = msgp.ReadMapHeaderBytes(bts)
+							if err != nil {
+								return
+							}
+							for zcxo > 0 {
+								zcxo--
+								field, bts, err = msgp.ReadMapKeyZC(bts)
+								if err != nil {
+									return
+								}
+								switch msgp.UnsafeString(field) {
+								case "start":
+									z.rc.iv[zbzg].start, bts, err = msgp.ReadUint16Bytes(bts)
+									if err != nil {
+										return
+									}
+								case "last":
+									z.rc.iv[zbzg].last, bts, err = msgp.ReadUint16Bytes(bts)
+									if err != nil {
+										return
+									}
+								default:
+									bts, err = msgp.Skip(bts)
+									if err != nil {
+										return
+									}
+								}
+							}
+						}
+					case "card":
+						z.rc.card, bts, err = msgp.ReadInt64Bytes(bts)
+						if err != nil {
+							return
+						}
+					default:
+						bts, err = msgp.Skip(bts)
+						if err != nil {
+							return
+						}
+					}
 				}
 			}
 		default:
@@ -530,7 +500,7 @@ func (z *addHelper16) Msgsize() (s int) {
 	if z.rc == nil {
 		s += msgp.NilSize
 	} else {
-		s += z.rc.Msgsize()
+		s += 1 + 3 + msgp.ArrayHeaderSize + (len(z.rc.iv) * (12 + msgp.Uint16Size + msgp.Uint16Size)) + 5 + msgp.Int64Size
 	}
 	return
 }
@@ -539,13 +509,13 @@ func (z *addHelper16) Msgsize() (s int) {
 func (z *interval16) DecodeMsg(dc *msgp.Reader) (err error) {
 	var field []byte
 	_ = field
-	var zlqf uint32
-	zlqf, err = dc.ReadMapHeader()
+	var zeff uint32
+	zeff, err = dc.ReadMapHeader()
 	if err != nil {
 		return
 	}
-	for zlqf > 0 {
-		zlqf--
+	for zeff > 0 {
+		zeff--
 		field, err = dc.ReadMapKeyPtr()
 		if err != nil {
 			return
@@ -612,13 +582,13 @@ func (z interval16) MarshalMsg(b []byte) (o []byte, err error) {
 func (z *interval16) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	var field []byte
 	_ = field
-	var zdaf uint32
-	zdaf, bts, err = msgp.ReadMapHeaderBytes(bts)
+	var zrsw uint32
+	zrsw, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if err != nil {
 		return
 	}
-	for zdaf > 0 {
-		zdaf--
+	for zrsw > 0 {
+		zrsw--
 		field, bts, err = msgp.ReadMapKeyZC(bts)
 		if err != nil {
 			return
@@ -655,49 +625,49 @@ func (z interval16) Msgsize() (s int) {
 func (z *runContainer16) DecodeMsg(dc *msgp.Reader) (err error) {
 	var field []byte
 	_ = field
-	var zjfb uint32
-	zjfb, err = dc.ReadMapHeader()
+	var zdnj uint32
+	zdnj, err = dc.ReadMapHeader()
 	if err != nil {
 		return
 	}
-	for zjfb > 0 {
-		zjfb--
+	for zdnj > 0 {
+		zdnj--
 		field, err = dc.ReadMapKeyPtr()
 		if err != nil {
 			return
 		}
 		switch msgp.UnsafeString(field) {
 		case "iv":
-			var zcxo uint32
-			zcxo, err = dc.ReadArrayHeader()
+			var zobc uint32
+			zobc, err = dc.ReadArrayHeader()
 			if err != nil {
 				return
 			}
-			if cap(z.iv) >= int(zcxo) {
-				z.iv = (z.iv)[:zcxo]
+			if cap(z.iv) >= int(zobc) {
+				z.iv = (z.iv)[:zobc]
 			} else {
-				z.iv = make([]interval16, zcxo)
+				z.iv = make([]interval16, zobc)
 			}
-			for zpks := range z.iv {
-				var zeff uint32
-				zeff, err = dc.ReadMapHeader()
+			for zxpk := range z.iv {
+				var zsnv uint32
+				zsnv, err = dc.ReadMapHeader()
 				if err != nil {
 					return
 				}
-				for zeff > 0 {
-					zeff--
+				for zsnv > 0 {
+					zsnv--
 					field, err = dc.ReadMapKeyPtr()
 					if err != nil {
 						return
 					}
 					switch msgp.UnsafeString(field) {
 					case "start":
-						z.iv[zpks].start, err = dc.ReadUint16()
+						z.iv[zxpk].start, err = dc.ReadUint16()
 						if err != nil {
 							return
 						}
 					case "last":
-						z.iv[zpks].last, err = dc.ReadUint16()
+						z.iv[zxpk].last, err = dc.ReadUint16()
 						if err != nil {
 							return
 						}
@@ -736,14 +706,14 @@ func (z *runContainer16) EncodeMsg(en *msgp.Writer) (err error) {
 	if err != nil {
 		return
 	}
-	for zpks := range z.iv {
+	for zxpk := range z.iv {
 		// map header, size 2
 		// write "start"
 		err = en.Append(0x82, 0xa5, 0x73, 0x74, 0x61, 0x72, 0x74)
 		if err != nil {
 			return err
 		}
-		err = en.WriteUint16(z.iv[zpks].start)
+		err = en.WriteUint16(z.iv[zxpk].start)
 		if err != nil {
 			return
 		}
@@ -752,7 +722,7 @@ func (z *runContainer16) EncodeMsg(en *msgp.Writer) (err error) {
 		if err != nil {
 			return err
 		}
-		err = en.WriteUint16(z.iv[zpks].last)
+		err = en.WriteUint16(z.iv[zxpk].last)
 		if err != nil {
 			return
 		}
@@ -776,14 +746,14 @@ func (z *runContainer16) MarshalMsg(b []byte) (o []byte, err error) {
 	// string "iv"
 	o = append(o, 0x82, 0xa2, 0x69, 0x76)
 	o = msgp.AppendArrayHeader(o, uint32(len(z.iv)))
-	for zpks := range z.iv {
+	for zxpk := range z.iv {
 		// map header, size 2
 		// string "start"
 		o = append(o, 0x82, 0xa5, 0x73, 0x74, 0x61, 0x72, 0x74)
-		o = msgp.AppendUint16(o, z.iv[zpks].start)
+		o = msgp.AppendUint16(o, z.iv[zxpk].start)
 		// string "last"
 		o = append(o, 0xa4, 0x6c, 0x61, 0x73, 0x74)
-		o = msgp.AppendUint16(o, z.iv[zpks].last)
+		o = msgp.AppendUint16(o, z.iv[zxpk].last)
 	}
 	// string "card"
 	o = append(o, 0xa4, 0x63, 0x61, 0x72, 0x64)
@@ -795,49 +765,49 @@ func (z *runContainer16) MarshalMsg(b []byte) (o []byte, err error) {
 func (z *runContainer16) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	var field []byte
 	_ = field
-	var zrsw uint32
-	zrsw, bts, err = msgp.ReadMapHeaderBytes(bts)
+	var zkgt uint32
+	zkgt, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if err != nil {
 		return
 	}
-	for zrsw > 0 {
-		zrsw--
+	for zkgt > 0 {
+		zkgt--
 		field, bts, err = msgp.ReadMapKeyZC(bts)
 		if err != nil {
 			return
 		}
 		switch msgp.UnsafeString(field) {
 		case "iv":
-			var zxpk uint32
-			zxpk, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zema uint32
+			zema, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				return
 			}
-			if cap(z.iv) >= int(zxpk) {
-				z.iv = (z.iv)[:zxpk]
+			if cap(z.iv) >= int(zema) {
+				z.iv = (z.iv)[:zema]
 			} else {
-				z.iv = make([]interval16, zxpk)
+				z.iv = make([]interval16, zema)
 			}
-			for zpks := range z.iv {
-				var zdnj uint32
-				zdnj, bts, err = msgp.ReadMapHeaderBytes(bts)
+			for zxpk := range z.iv {
+				var zpez uint32
+				zpez, bts, err = msgp.ReadMapHeaderBytes(bts)
 				if err != nil {
 					return
 				}
-				for zdnj > 0 {
-					zdnj--
+				for zpez > 0 {
+					zpez--
 					field, bts, err = msgp.ReadMapKeyZC(bts)
 					if err != nil {
 						return
 					}
 					switch msgp.UnsafeString(field) {
 					case "start":
-						z.iv[zpks].start, bts, err = msgp.ReadUint16Bytes(bts)
+						z.iv[zxpk].start, bts, err = msgp.ReadUint16Bytes(bts)
 						if err != nil {
 							return
 						}
 					case "last":
-						z.iv[zpks].last, bts, err = msgp.ReadUint16Bytes(bts)
+						z.iv[zxpk].last, bts, err = msgp.ReadUint16Bytes(bts)
 						if err != nil {
 							return
 						}
@@ -872,19 +842,221 @@ func (z *runContainer16) Msgsize() (s int) {
 }
 
 // DecodeMsg implements msgp.Decodable
-func (z *uint16Slice) DecodeMsg(dc *msgp.Reader) (err error) {
-	var zkgt uint32
-	zkgt, err = dc.ReadArrayHeader()
+func (z *runIterator16) DecodeMsg(dc *msgp.Reader) (err error) {
+	var field []byte
+	_ = field
+	var zqke uint32
+	zqke, err = dc.ReadMapHeader()
 	if err != nil {
 		return
 	}
-	if cap((*z)) >= int(zkgt) {
-		(*z) = (*z)[:zkgt]
-	} else {
-		(*z) = make(uint16Slice, zkgt)
+	for zqke > 0 {
+		zqke--
+		field, err = dc.ReadMapKeyPtr()
+		if err != nil {
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "rc":
+			if dc.IsNil() {
+				err = dc.ReadNil()
+				if err != nil {
+					return
+				}
+				z.rc = nil
+			} else {
+				if z.rc == nil {
+					z.rc = new(runContainer16)
+				}
+				err = z.rc.DecodeMsg(dc)
+				if err != nil {
+					return
+				}
+			}
+		case "curIndex":
+			z.curIndex, err = dc.ReadInt64()
+			if err != nil {
+				return
+			}
+		case "curPosInIndex":
+			z.curPosInIndex, err = dc.ReadUint16()
+			if err != nil {
+				return
+			}
+		case "curSeq":
+			z.curSeq, err = dc.ReadInt64()
+			if err != nil {
+				return
+			}
+		default:
+			err = dc.Skip()
+			if err != nil {
+				return
+			}
+		}
 	}
-	for zsnv := range *z {
-		(*z)[zsnv], err = dc.ReadUint16()
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z *runIterator16) EncodeMsg(en *msgp.Writer) (err error) {
+	// map header, size 4
+	// write "rc"
+	err = en.Append(0x84, 0xa2, 0x72, 0x63)
+	if err != nil {
+		return err
+	}
+	if z.rc == nil {
+		err = en.WriteNil()
+		if err != nil {
+			return
+		}
+	} else {
+		err = z.rc.EncodeMsg(en)
+		if err != nil {
+			return
+		}
+	}
+	// write "curIndex"
+	err = en.Append(0xa8, 0x63, 0x75, 0x72, 0x49, 0x6e, 0x64, 0x65, 0x78)
+	if err != nil {
+		return err
+	}
+	err = en.WriteInt64(z.curIndex)
+	if err != nil {
+		return
+	}
+	// write "curPosInIndex"
+	err = en.Append(0xad, 0x63, 0x75, 0x72, 0x50, 0x6f, 0x73, 0x49, 0x6e, 0x49, 0x6e, 0x64, 0x65, 0x78)
+	if err != nil {
+		return err
+	}
+	err = en.WriteUint16(z.curPosInIndex)
+	if err != nil {
+		return
+	}
+	// write "curSeq"
+	err = en.Append(0xa6, 0x63, 0x75, 0x72, 0x53, 0x65, 0x71)
+	if err != nil {
+		return err
+	}
+	err = en.WriteInt64(z.curSeq)
+	if err != nil {
+		return
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *runIterator16) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// map header, size 4
+	// string "rc"
+	o = append(o, 0x84, 0xa2, 0x72, 0x63)
+	if z.rc == nil {
+		o = msgp.AppendNil(o)
+	} else {
+		o, err = z.rc.MarshalMsg(o)
+		if err != nil {
+			return
+		}
+	}
+	// string "curIndex"
+	o = append(o, 0xa8, 0x63, 0x75, 0x72, 0x49, 0x6e, 0x64, 0x65, 0x78)
+	o = msgp.AppendInt64(o, z.curIndex)
+	// string "curPosInIndex"
+	o = append(o, 0xad, 0x63, 0x75, 0x72, 0x50, 0x6f, 0x73, 0x49, 0x6e, 0x49, 0x6e, 0x64, 0x65, 0x78)
+	o = msgp.AppendUint16(o, z.curPosInIndex)
+	// string "curSeq"
+	o = append(o, 0xa6, 0x63, 0x75, 0x72, 0x53, 0x65, 0x71)
+	o = msgp.AppendInt64(o, z.curSeq)
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *runIterator16) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zqyh uint32
+	zqyh, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		return
+	}
+	for zqyh > 0 {
+		zqyh--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "rc":
+			if msgp.IsNil(bts) {
+				bts, err = msgp.ReadNilBytes(bts)
+				if err != nil {
+					return
+				}
+				z.rc = nil
+			} else {
+				if z.rc == nil {
+					z.rc = new(runContainer16)
+				}
+				bts, err = z.rc.UnmarshalMsg(bts)
+				if err != nil {
+					return
+				}
+			}
+		case "curIndex":
+			z.curIndex, bts, err = msgp.ReadInt64Bytes(bts)
+			if err != nil {
+				return
+			}
+		case "curPosInIndex":
+			z.curPosInIndex, bts, err = msgp.ReadUint16Bytes(bts)
+			if err != nil {
+				return
+			}
+		case "curSeq":
+			z.curSeq, bts, err = msgp.ReadInt64Bytes(bts)
+			if err != nil {
+				return
+			}
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				return
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *runIterator16) Msgsize() (s int) {
+	s = 1 + 3
+	if z.rc == nil {
+		s += msgp.NilSize
+	} else {
+		s += z.rc.Msgsize()
+	}
+	s += 9 + msgp.Int64Size + 14 + msgp.Uint16Size + 7 + msgp.Int64Size
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
+func (z *uint16Slice) DecodeMsg(dc *msgp.Reader) (err error) {
+	var zjpj uint32
+	zjpj, err = dc.ReadArrayHeader()
+	if err != nil {
+		return
+	}
+	if cap((*z)) >= int(zjpj) {
+		(*z) = (*z)[:zjpj]
+	} else {
+		(*z) = make(uint16Slice, zjpj)
+	}
+	for zywj := range *z {
+		(*z)[zywj], err = dc.ReadUint16()
 		if err != nil {
 			return
 		}
@@ -898,8 +1070,8 @@ func (z uint16Slice) EncodeMsg(en *msgp.Writer) (err error) {
 	if err != nil {
 		return
 	}
-	for zema := range z {
-		err = en.WriteUint16(z[zema])
+	for zzpf := range z {
+		err = en.WriteUint16(z[zzpf])
 		if err != nil {
 			return
 		}
@@ -911,26 +1083,26 @@ func (z uint16Slice) EncodeMsg(en *msgp.Writer) (err error) {
 func (z uint16Slice) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
 	o = msgp.AppendArrayHeader(o, uint32(len(z)))
-	for zema := range z {
-		o = msgp.AppendUint16(o, z[zema])
+	for zzpf := range z {
+		o = msgp.AppendUint16(o, z[zzpf])
 	}
 	return
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
 func (z *uint16Slice) UnmarshalMsg(bts []byte) (o []byte, err error) {
-	var zqke uint32
-	zqke, bts, err = msgp.ReadArrayHeaderBytes(bts)
+	var zgmo uint32
+	zgmo, bts, err = msgp.ReadArrayHeaderBytes(bts)
 	if err != nil {
 		return
 	}
-	if cap((*z)) >= int(zqke) {
-		(*z) = (*z)[:zqke]
+	if cap((*z)) >= int(zgmo) {
+		(*z) = (*z)[:zgmo]
 	} else {
-		(*z) = make(uint16Slice, zqke)
+		(*z) = make(uint16Slice, zgmo)
 	}
-	for zpez := range *z {
-		(*z)[zpez], bts, err = msgp.ReadUint16Bytes(bts)
+	for zrfe := range *z {
+		(*z)[zrfe], bts, err = msgp.ReadUint16Bytes(bts)
 		if err != nil {
 			return
 		}

--- a/rle16_gen_test.go
+++ b/rle16_gen_test.go
@@ -11,119 +11,6 @@ import (
 	"github.com/tinylib/msgp/msgp"
 )
 
-func TestMarshalUnmarshalRunIterator16(t *testing.T) {
-	v := RunIterator16{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	left, err := v.UnmarshalMsg(bts)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(left) > 0 {
-		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
-	}
-
-	left, err = msgp.Skip(bts)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(left) > 0 {
-		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
-	}
-}
-
-func BenchmarkMarshalMsgRunIterator16(b *testing.B) {
-	v := RunIterator16{}
-	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		v.MarshalMsg(nil)
-	}
-}
-
-func BenchmarkAppendMsgRunIterator16(b *testing.B) {
-	v := RunIterator16{}
-	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
-	b.SetBytes(int64(len(bts)))
-	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
-	}
-}
-
-func BenchmarkUnmarshalRunIterator16(b *testing.B) {
-	v := RunIterator16{}
-	bts, _ := v.MarshalMsg(nil)
-	b.ReportAllocs()
-	b.SetBytes(int64(len(bts)))
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		_, err := v.UnmarshalMsg(bts)
-		if err != nil {
-			b.Fatal(err)
-		}
-	}
-}
-
-func TestEncodeDecodeRunIterator16(t *testing.T) {
-	v := RunIterator16{}
-	var buf bytes.Buffer
-	msgp.Encode(&buf, &v)
-
-	m := v.Msgsize()
-	if buf.Len() > m {
-		t.Logf("WARNING: Msgsize() for %v is inaccurate", v)
-	}
-
-	vn := RunIterator16{}
-	err := msgp.Decode(&buf, &vn)
-	if err != nil {
-		t.Error(err)
-	}
-
-	buf.Reset()
-	msgp.Encode(&buf, &v)
-	err = msgp.NewReader(&buf).Skip()
-	if err != nil {
-		t.Error(err)
-	}
-}
-
-func BenchmarkEncodeRunIterator16(b *testing.B) {
-	v := RunIterator16{}
-	var buf bytes.Buffer
-	msgp.Encode(&buf, &v)
-	b.SetBytes(int64(buf.Len()))
-	en := msgp.NewWriter(msgp.Nowhere)
-	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		v.EncodeMsg(en)
-	}
-	en.Flush()
-}
-
-func BenchmarkDecodeRunIterator16(b *testing.B) {
-	v := RunIterator16{}
-	var buf bytes.Buffer
-	msgp.Encode(&buf, &v)
-	b.SetBytes(int64(buf.Len()))
-	rd := msgp.NewEndlessReader(buf.Bytes(), b)
-	dc := msgp.NewReader(rd)
-	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		err := v.DecodeMsg(dc)
-		if err != nil {
-			b.Fatal(err)
-		}
-	}
-}
-
 func TestMarshalUnmarshaladdHelper16(t *testing.T) {
 	v := addHelper16{}
 	bts, err := v.MarshalMsg(nil)
@@ -448,6 +335,119 @@ func BenchmarkEncoderunContainer16(b *testing.B) {
 
 func BenchmarkDecoderunContainer16(b *testing.B) {
 	v := runContainer16{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	rd := msgp.NewEndlessReader(buf.Bytes(), b)
+	dc := msgp.NewReader(rd)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := v.DecodeMsg(dc)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestMarshalUnmarshalrunIterator16(t *testing.T) {
+	v := runIterator16{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgrunIterator16(b *testing.B) {
+	v := runIterator16{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgrunIterator16(b *testing.B) {
+	v := runIterator16{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalrunIterator16(b *testing.B) {
+	v := runIterator16{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestEncodeDecoderunIterator16(t *testing.T) {
+	v := runIterator16{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+
+	m := v.Msgsize()
+	if buf.Len() > m {
+		t.Logf("WARNING: Msgsize() for %v is inaccurate", v)
+	}
+
+	vn := runIterator16{}
+	err := msgp.Decode(&buf, &vn)
+	if err != nil {
+		t.Error(err)
+	}
+
+	buf.Reset()
+	msgp.Encode(&buf, &v)
+	err = msgp.NewReader(&buf).Skip()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkEncoderunIterator16(b *testing.B) {
+	v := runIterator16{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	en := msgp.NewWriter(msgp.Nowhere)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.EncodeMsg(en)
+	}
+	en.Flush()
+}
+
+func BenchmarkDecoderunIterator16(b *testing.B) {
+	v := runIterator16{}
 	var buf bytes.Buffer
 	msgp.Encode(&buf, &v)
 	b.SetBytes(int64(buf.Len()))

--- a/rle16_test.go
+++ b/rle16_test.go
@@ -77,26 +77,26 @@ func TestRleRunIterator16(t *testing.T) {
 			_ = msg
 			p("an empty container: '%s'\n", msg)
 			So(rc.cardinality(), ShouldEqual, 0)
-			it := rc.NewRunIterator16()
-			So(it.HasNext(), ShouldBeFalse)
+			it := rc.newRunIterator16()
+			So(it.hasNext(), ShouldBeFalse)
 		}
 		{
 			rc := newRunContainer16TakeOwnership([]interval16{{start: 4, last: 4}})
 			So(rc.cardinality(), ShouldEqual, 1)
-			it := rc.NewRunIterator16()
-			So(it.HasNext(), ShouldBeTrue)
-			So(it.Next(), ShouldResemble, uint16(4))
-			So(it.Cur(), ShouldResemble, uint16(4))
+			it := rc.newRunIterator16()
+			So(it.hasNext(), ShouldBeTrue)
+			So(it.next(), ShouldResemble, uint16(4))
+			So(it.cur(), ShouldResemble, uint16(4))
 		}
 		{
 			rc := newRunContainer16CopyIv([]interval16{{start: 4, last: 9}})
 			So(rc.cardinality(), ShouldEqual, 6)
-			it := rc.NewRunIterator16()
-			So(it.HasNext(), ShouldBeTrue)
+			it := rc.newRunIterator16()
+			So(it.hasNext(), ShouldBeTrue)
 			for i := 4; i < 10; i++ {
-				So(it.Next(), ShouldEqual, uint16(i))
+				So(it.next(), ShouldEqual, uint16(i))
 			}
-			So(it.HasNext(), ShouldBeFalse)
+			So(it.hasNext(), ShouldBeFalse)
 		}
 
 		{
@@ -105,25 +105,25 @@ func TestRleRunIterator16(t *testing.T) {
 			So(card, ShouldEqual, 6)
 			//So(rc.serializedSizeInBytes(), ShouldEqual, 2+4*rc.numberOfRuns())
 
-			it := rc.NewRunIterator16()
-			So(it.HasNext(), ShouldBeTrue)
+			it := rc.newRunIterator16()
+			So(it.hasNext(), ShouldBeTrue)
 			for i := 4; i < 6; i++ {
-				So(it.Next(), ShouldEqual, uint16(i))
+				So(it.next(), ShouldEqual, uint16(i))
 			}
-			So(it.Cur(), ShouldEqual, uint16(5))
+			So(it.cur(), ShouldEqual, uint16(5))
 
 			p("before Remove of 5, rc = '%s'", rc)
 
-			So(it.Remove(), ShouldEqual, uint16(5))
+			So(it.remove(), ShouldEqual, uint16(5))
 
 			p("after Remove of 5, rc = '%s'", rc)
 			So(rc.cardinality(), ShouldEqual, 5)
 
-			it2 := rc.NewRunIterator16()
+			it2 := rc.newRunIterator16()
 			So(rc.cardinality(), ShouldEqual, 5)
-			So(it2.Next(), ShouldEqual, uint16(4))
+			So(it2.next(), ShouldEqual, uint16(4))
 			for i := 6; i < 10; i++ {
-				So(it2.Next(), ShouldEqual, uint16(i))
+				So(it2.next(), ShouldEqual, uint16(i))
 			}
 		}
 		{
@@ -141,16 +141,16 @@ func TestRleRunIterator16(t *testing.T) {
 			rc = rc.union(rc1)
 
 			So(rc.cardinality(), ShouldEqual, 8)
-			it := rc.NewRunIterator16()
-			So(it.Next(), ShouldEqual, uint16(0))
-			So(it.Next(), ShouldEqual, uint16(2))
-			So(it.Next(), ShouldEqual, uint16(4))
-			So(it.Next(), ShouldEqual, uint16(6))
-			So(it.Next(), ShouldEqual, uint16(7))
-			So(it.Next(), ShouldEqual, uint16(10))
-			So(it.Next(), ShouldEqual, uint16(11))
-			So(it.Next(), ShouldEqual, uint16(MaxUint16))
-			So(it.HasNext(), ShouldEqual, false)
+			it := rc.newRunIterator16()
+			So(it.next(), ShouldEqual, uint16(0))
+			So(it.next(), ShouldEqual, uint16(2))
+			So(it.next(), ShouldEqual, uint16(4))
+			So(it.next(), ShouldEqual, uint16(6))
+			So(it.next(), ShouldEqual, uint16(7))
+			So(it.next(), ShouldEqual, uint16(10))
+			So(it.next(), ShouldEqual, uint16(11))
+			So(it.next(), ShouldEqual, uint16(MaxUint16))
+			So(it.hasNext(), ShouldEqual, false)
 
 			rc2 := newRunContainer16TakeOwnership([]interval16{
 				{start: 0, last: MaxUint16},
@@ -636,17 +636,17 @@ func TestRleCoverageOddsAndEnds16(t *testing.T) {
 			ra.Add(5)
 			So(ra.cardinality(), ShouldEqual, 2)
 
-			// NewRunIterator16()
+			// newRunIterator16()
 			empty := newRunContainer16()
-			it := empty.NewRunIterator16()
-			So(func() { it.Next() }, ShouldPanic)
-			it2 := ra.NewRunIterator16()
+			it := empty.newRunIterator16()
+			So(func() { it.next() }, ShouldPanic)
+			it2 := ra.newRunIterator16()
 			it2.curIndex = int64(len(it2.rc.iv))
-			So(func() { it2.Next() }, ShouldPanic)
+			So(func() { it2.next() }, ShouldPanic)
 
-			// RunIterator16.Remove()
-			emptyIt := empty.NewRunIterator16()
-			So(func() { emptyIt.Remove() }, ShouldPanic)
+			// runIterator16.remove()
+			emptyIt := empty.newRunIterator16()
+			So(func() { emptyIt.remove() }, ShouldPanic)
 
 			// newRunContainer16FromArray
 			arr := newArrayContainerRange(1, 6)
@@ -672,16 +672,16 @@ func TestRleCoverageOddsAndEnds16(t *testing.T) {
 			rc3.Add(10)
 			rc3.Add(12)
 			So(rc3.cardinality(), ShouldEqual, 5)
-			it3 := rc3.NewRunIterator16()
-			it3.Next()
-			it3.Next()
-			it3.Next()
-			it3.Next()
+			it3 := rc3.newRunIterator16()
+			it3.next()
+			it3.next()
+			it3.next()
+			it3.next()
 			//p("rc3 = %v", rc3) // 5, 6, 9, 10, 12
-			So(it3.Cur(), ShouldEqual, uint16(10))
-			it3.Remove()
+			So(it3.cur(), ShouldEqual, uint16(10))
+			it3.remove()
 			//p("after Remove of 10, rc3 = %v", rc3) // 5, 6, 9, 12
-			So(it3.Next(), ShouldEqual, uint16(12))
+			So(it3.next(), ShouldEqual, uint16(12))
 		}
 	})
 }

--- a/rle16_test.go
+++ b/rle16_test.go
@@ -683,6 +683,17 @@ func TestRleCoverageOddsAndEnds16(t *testing.T) {
 			//p("after Remove of 10, rc3 = %v", rc3) // 5, 6, 9, 12
 			So(it3.next(), ShouldEqual, uint16(12))
 		}
+
+		// runContainer16.equals
+		{
+			rc16 := newRunContainer16()
+			So(rc16.equals16(rc16), ShouldBeTrue)
+			rc16b := newRunContainer16()
+			So(rc16.equals16(rc16b), ShouldBeTrue)
+			rc16.Add(1)
+			rc16b.Add(2)
+			So(rc16.equals16(rc16b), ShouldBeFalse)
+		}
 	})
 }
 

--- a/rle_gen.go
+++ b/rle_gen.go
@@ -7,218 +7,16 @@ package roaring
 import "github.com/tinylib/msgp/msgp"
 
 // DecodeMsg implements msgp.Decodable
-func (z *RunIterator32) DecodeMsg(dc *msgp.Reader) (err error) {
-	var field []byte
-	_ = field
-	var zxvk uint32
-	zxvk, err = dc.ReadMapHeader()
-	if err != nil {
-		return
-	}
-	for zxvk > 0 {
-		zxvk--
-		field, err = dc.ReadMapKeyPtr()
-		if err != nil {
-			return
-		}
-		switch msgp.UnsafeString(field) {
-		case "rc":
-			if dc.IsNil() {
-				err = dc.ReadNil()
-				if err != nil {
-					return
-				}
-				z.rc = nil
-			} else {
-				if z.rc == nil {
-					z.rc = new(runContainer32)
-				}
-				err = z.rc.DecodeMsg(dc)
-				if err != nil {
-					return
-				}
-			}
-		case "curIndex":
-			z.curIndex, err = dc.ReadInt64()
-			if err != nil {
-				return
-			}
-		case "curPosInIndex":
-			z.curPosInIndex, err = dc.ReadUint32()
-			if err != nil {
-				return
-			}
-		case "curSeq":
-			z.curSeq, err = dc.ReadInt64()
-			if err != nil {
-				return
-			}
-		default:
-			err = dc.Skip()
-			if err != nil {
-				return
-			}
-		}
-	}
-	return
-}
-
-// EncodeMsg implements msgp.Encodable
-func (z *RunIterator32) EncodeMsg(en *msgp.Writer) (err error) {
-	// map header, size 4
-	// write "rc"
-	err = en.Append(0x84, 0xa2, 0x72, 0x63)
-	if err != nil {
-		return err
-	}
-	if z.rc == nil {
-		err = en.WriteNil()
-		if err != nil {
-			return
-		}
-	} else {
-		err = z.rc.EncodeMsg(en)
-		if err != nil {
-			return
-		}
-	}
-	// write "curIndex"
-	err = en.Append(0xa8, 0x63, 0x75, 0x72, 0x49, 0x6e, 0x64, 0x65, 0x78)
-	if err != nil {
-		return err
-	}
-	err = en.WriteInt64(z.curIndex)
-	if err != nil {
-		return
-	}
-	// write "curPosInIndex"
-	err = en.Append(0xad, 0x63, 0x75, 0x72, 0x50, 0x6f, 0x73, 0x49, 0x6e, 0x49, 0x6e, 0x64, 0x65, 0x78)
-	if err != nil {
-		return err
-	}
-	err = en.WriteUint32(z.curPosInIndex)
-	if err != nil {
-		return
-	}
-	// write "curSeq"
-	err = en.Append(0xa6, 0x63, 0x75, 0x72, 0x53, 0x65, 0x71)
-	if err != nil {
-		return err
-	}
-	err = en.WriteInt64(z.curSeq)
-	if err != nil {
-		return
-	}
-	return
-}
-
-// MarshalMsg implements msgp.Marshaler
-func (z *RunIterator32) MarshalMsg(b []byte) (o []byte, err error) {
-	o = msgp.Require(b, z.Msgsize())
-	// map header, size 4
-	// string "rc"
-	o = append(o, 0x84, 0xa2, 0x72, 0x63)
-	if z.rc == nil {
-		o = msgp.AppendNil(o)
-	} else {
-		o, err = z.rc.MarshalMsg(o)
-		if err != nil {
-			return
-		}
-	}
-	// string "curIndex"
-	o = append(o, 0xa8, 0x63, 0x75, 0x72, 0x49, 0x6e, 0x64, 0x65, 0x78)
-	o = msgp.AppendInt64(o, z.curIndex)
-	// string "curPosInIndex"
-	o = append(o, 0xad, 0x63, 0x75, 0x72, 0x50, 0x6f, 0x73, 0x49, 0x6e, 0x49, 0x6e, 0x64, 0x65, 0x78)
-	o = msgp.AppendUint32(o, z.curPosInIndex)
-	// string "curSeq"
-	o = append(o, 0xa6, 0x63, 0x75, 0x72, 0x53, 0x65, 0x71)
-	o = msgp.AppendInt64(o, z.curSeq)
-	return
-}
-
-// UnmarshalMsg implements msgp.Unmarshaler
-func (z *RunIterator32) UnmarshalMsg(bts []byte) (o []byte, err error) {
-	var field []byte
-	_ = field
-	var zbzg uint32
-	zbzg, bts, err = msgp.ReadMapHeaderBytes(bts)
-	if err != nil {
-		return
-	}
-	for zbzg > 0 {
-		zbzg--
-		field, bts, err = msgp.ReadMapKeyZC(bts)
-		if err != nil {
-			return
-		}
-		switch msgp.UnsafeString(field) {
-		case "rc":
-			if msgp.IsNil(bts) {
-				bts, err = msgp.ReadNilBytes(bts)
-				if err != nil {
-					return
-				}
-				z.rc = nil
-			} else {
-				if z.rc == nil {
-					z.rc = new(runContainer32)
-				}
-				bts, err = z.rc.UnmarshalMsg(bts)
-				if err != nil {
-					return
-				}
-			}
-		case "curIndex":
-			z.curIndex, bts, err = msgp.ReadInt64Bytes(bts)
-			if err != nil {
-				return
-			}
-		case "curPosInIndex":
-			z.curPosInIndex, bts, err = msgp.ReadUint32Bytes(bts)
-			if err != nil {
-				return
-			}
-		case "curSeq":
-			z.curSeq, bts, err = msgp.ReadInt64Bytes(bts)
-			if err != nil {
-				return
-			}
-		default:
-			bts, err = msgp.Skip(bts)
-			if err != nil {
-				return
-			}
-		}
-	}
-	o = bts
-	return
-}
-
-// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
-func (z *RunIterator32) Msgsize() (s int) {
-	s = 1 + 3
-	if z.rc == nil {
-		s += msgp.NilSize
-	} else {
-		s += z.rc.Msgsize()
-	}
-	s += 9 + msgp.Int64Size + 14 + msgp.Uint32Size + 7 + msgp.Int64Size
-	return
-}
-
-// DecodeMsg implements msgp.Decodable
 func (z *addHelper32) DecodeMsg(dc *msgp.Reader) (err error) {
 	var field []byte
 	_ = field
-	var zcmr uint32
-	zcmr, err = dc.ReadMapHeader()
+	var zbai uint32
+	zbai, err = dc.ReadMapHeader()
 	if err != nil {
 		return
 	}
-	for zcmr > 0 {
-		zcmr--
+	for zbai > 0 {
+		zbai--
 		field, err = dc.ReadMapKeyPtr()
 		if err != nil {
 			return
@@ -240,36 +38,36 @@ func (z *addHelper32) DecodeMsg(dc *msgp.Reader) (err error) {
 				return
 			}
 		case "m":
-			var zajw uint32
-			zajw, err = dc.ReadArrayHeader()
+			var zcmr uint32
+			zcmr, err = dc.ReadArrayHeader()
 			if err != nil {
 				return
 			}
-			if cap(z.m) >= int(zajw) {
-				z.m = (z.m)[:zajw]
+			if cap(z.m) >= int(zcmr) {
+				z.m = (z.m)[:zcmr]
 			} else {
-				z.m = make([]interval32, zajw)
+				z.m = make([]interval32, zcmr)
 			}
-			for zbai := range z.m {
-				var zwht uint32
-				zwht, err = dc.ReadMapHeader()
+			for zxvk := range z.m {
+				var zajw uint32
+				zajw, err = dc.ReadMapHeader()
 				if err != nil {
 					return
 				}
-				for zwht > 0 {
-					zwht--
+				for zajw > 0 {
+					zajw--
 					field, err = dc.ReadMapKeyPtr()
 					if err != nil {
 						return
 					}
 					switch msgp.UnsafeString(field) {
 					case "start":
-						z.m[zbai].start, err = dc.ReadUint32()
+						z.m[zxvk].start, err = dc.ReadUint32()
 						if err != nil {
 							return
 						}
 					case "last":
-						z.m[zbai].last, err = dc.ReadUint32()
+						z.m[zxvk].last, err = dc.ReadUint32()
 						if err != nil {
 							return
 						}
@@ -292,9 +90,71 @@ func (z *addHelper32) DecodeMsg(dc *msgp.Reader) (err error) {
 				if z.rc == nil {
 					z.rc = new(runContainer32)
 				}
-				err = z.rc.DecodeMsg(dc)
+				var zwht uint32
+				zwht, err = dc.ReadMapHeader()
 				if err != nil {
 					return
+				}
+				for zwht > 0 {
+					zwht--
+					field, err = dc.ReadMapKeyPtr()
+					if err != nil {
+						return
+					}
+					switch msgp.UnsafeString(field) {
+					case "iv":
+						var zhct uint32
+						zhct, err = dc.ReadArrayHeader()
+						if err != nil {
+							return
+						}
+						if cap(z.rc.iv) >= int(zhct) {
+							z.rc.iv = (z.rc.iv)[:zhct]
+						} else {
+							z.rc.iv = make([]interval32, zhct)
+						}
+						for zbzg := range z.rc.iv {
+							var zcua uint32
+							zcua, err = dc.ReadMapHeader()
+							if err != nil {
+								return
+							}
+							for zcua > 0 {
+								zcua--
+								field, err = dc.ReadMapKeyPtr()
+								if err != nil {
+									return
+								}
+								switch msgp.UnsafeString(field) {
+								case "start":
+									z.rc.iv[zbzg].start, err = dc.ReadUint32()
+									if err != nil {
+										return
+									}
+								case "last":
+									z.rc.iv[zbzg].last, err = dc.ReadUint32()
+									if err != nil {
+										return
+									}
+								default:
+									err = dc.Skip()
+									if err != nil {
+										return
+									}
+								}
+							}
+						}
+					case "card":
+						z.rc.card, err = dc.ReadInt64()
+						if err != nil {
+							return
+						}
+					default:
+						err = dc.Skip()
+						if err != nil {
+							return
+						}
+					}
 				}
 			}
 		default:
@@ -346,14 +206,14 @@ func (z *addHelper32) EncodeMsg(en *msgp.Writer) (err error) {
 	if err != nil {
 		return
 	}
-	for zbai := range z.m {
+	for zxvk := range z.m {
 		// map header, size 2
 		// write "start"
 		err = en.Append(0x82, 0xa5, 0x73, 0x74, 0x61, 0x72, 0x74)
 		if err != nil {
 			return err
 		}
-		err = en.WriteUint32(z.m[zbai].start)
+		err = en.WriteUint32(z.m[zxvk].start)
 		if err != nil {
 			return
 		}
@@ -362,7 +222,7 @@ func (z *addHelper32) EncodeMsg(en *msgp.Writer) (err error) {
 		if err != nil {
 			return err
 		}
-		err = en.WriteUint32(z.m[zbai].last)
+		err = en.WriteUint32(z.m[zxvk].last)
 		if err != nil {
 			return
 		}
@@ -378,7 +238,43 @@ func (z *addHelper32) EncodeMsg(en *msgp.Writer) (err error) {
 			return
 		}
 	} else {
-		err = z.rc.EncodeMsg(en)
+		// map header, size 2
+		// write "iv"
+		err = en.Append(0x82, 0xa2, 0x69, 0x76)
+		if err != nil {
+			return err
+		}
+		err = en.WriteArrayHeader(uint32(len(z.rc.iv)))
+		if err != nil {
+			return
+		}
+		for zbzg := range z.rc.iv {
+			// map header, size 2
+			// write "start"
+			err = en.Append(0x82, 0xa5, 0x73, 0x74, 0x61, 0x72, 0x74)
+			if err != nil {
+				return err
+			}
+			err = en.WriteUint32(z.rc.iv[zbzg].start)
+			if err != nil {
+				return
+			}
+			// write "last"
+			err = en.Append(0xa4, 0x6c, 0x61, 0x73, 0x74)
+			if err != nil {
+				return err
+			}
+			err = en.WriteUint32(z.rc.iv[zbzg].last)
+			if err != nil {
+				return
+			}
+		}
+		// write "card"
+		err = en.Append(0xa4, 0x63, 0x61, 0x72, 0x64)
+		if err != nil {
+			return err
+		}
+		err = en.WriteInt64(z.rc.card)
 		if err != nil {
 			return
 		}
@@ -402,24 +298,36 @@ func (z *addHelper32) MarshalMsg(b []byte) (o []byte, err error) {
 	// string "m"
 	o = append(o, 0xa1, 0x6d)
 	o = msgp.AppendArrayHeader(o, uint32(len(z.m)))
-	for zbai := range z.m {
+	for zxvk := range z.m {
 		// map header, size 2
 		// string "start"
 		o = append(o, 0x82, 0xa5, 0x73, 0x74, 0x61, 0x72, 0x74)
-		o = msgp.AppendUint32(o, z.m[zbai].start)
+		o = msgp.AppendUint32(o, z.m[zxvk].start)
 		// string "last"
 		o = append(o, 0xa4, 0x6c, 0x61, 0x73, 0x74)
-		o = msgp.AppendUint32(o, z.m[zbai].last)
+		o = msgp.AppendUint32(o, z.m[zxvk].last)
 	}
 	// string "rc"
 	o = append(o, 0xa2, 0x72, 0x63)
 	if z.rc == nil {
 		o = msgp.AppendNil(o)
 	} else {
-		o, err = z.rc.MarshalMsg(o)
-		if err != nil {
-			return
+		// map header, size 2
+		// string "iv"
+		o = append(o, 0x82, 0xa2, 0x69, 0x76)
+		o = msgp.AppendArrayHeader(o, uint32(len(z.rc.iv)))
+		for zbzg := range z.rc.iv {
+			// map header, size 2
+			// string "start"
+			o = append(o, 0x82, 0xa5, 0x73, 0x74, 0x61, 0x72, 0x74)
+			o = msgp.AppendUint32(o, z.rc.iv[zbzg].start)
+			// string "last"
+			o = append(o, 0xa4, 0x6c, 0x61, 0x73, 0x74)
+			o = msgp.AppendUint32(o, z.rc.iv[zbzg].last)
 		}
+		// string "card"
+		o = append(o, 0xa4, 0x63, 0x61, 0x72, 0x64)
+		o = msgp.AppendInt64(o, z.rc.card)
 	}
 	return
 }
@@ -428,13 +336,13 @@ func (z *addHelper32) MarshalMsg(b []byte) (o []byte, err error) {
 func (z *addHelper32) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	var field []byte
 	_ = field
-	var zhct uint32
-	zhct, bts, err = msgp.ReadMapHeaderBytes(bts)
+	var zxhx uint32
+	zxhx, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if err != nil {
 		return
 	}
-	for zhct > 0 {
-		zhct--
+	for zxhx > 0 {
+		zxhx--
 		field, bts, err = msgp.ReadMapKeyZC(bts)
 		if err != nil {
 			return
@@ -456,36 +364,36 @@ func (z *addHelper32) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				return
 			}
 		case "m":
-			var zcua uint32
-			zcua, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zlqf uint32
+			zlqf, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				return
 			}
-			if cap(z.m) >= int(zcua) {
-				z.m = (z.m)[:zcua]
+			if cap(z.m) >= int(zlqf) {
+				z.m = (z.m)[:zlqf]
 			} else {
-				z.m = make([]interval32, zcua)
+				z.m = make([]interval32, zlqf)
 			}
-			for zbai := range z.m {
-				var zxhx uint32
-				zxhx, bts, err = msgp.ReadMapHeaderBytes(bts)
+			for zxvk := range z.m {
+				var zdaf uint32
+				zdaf, bts, err = msgp.ReadMapHeaderBytes(bts)
 				if err != nil {
 					return
 				}
-				for zxhx > 0 {
-					zxhx--
+				for zdaf > 0 {
+					zdaf--
 					field, bts, err = msgp.ReadMapKeyZC(bts)
 					if err != nil {
 						return
 					}
 					switch msgp.UnsafeString(field) {
 					case "start":
-						z.m[zbai].start, bts, err = msgp.ReadUint32Bytes(bts)
+						z.m[zxvk].start, bts, err = msgp.ReadUint32Bytes(bts)
 						if err != nil {
 							return
 						}
 					case "last":
-						z.m[zbai].last, bts, err = msgp.ReadUint32Bytes(bts)
+						z.m[zxvk].last, bts, err = msgp.ReadUint32Bytes(bts)
 						if err != nil {
 							return
 						}
@@ -508,9 +416,71 @@ func (z *addHelper32) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				if z.rc == nil {
 					z.rc = new(runContainer32)
 				}
-				bts, err = z.rc.UnmarshalMsg(bts)
+				var zpks uint32
+				zpks, bts, err = msgp.ReadMapHeaderBytes(bts)
 				if err != nil {
 					return
+				}
+				for zpks > 0 {
+					zpks--
+					field, bts, err = msgp.ReadMapKeyZC(bts)
+					if err != nil {
+						return
+					}
+					switch msgp.UnsafeString(field) {
+					case "iv":
+						var zjfb uint32
+						zjfb, bts, err = msgp.ReadArrayHeaderBytes(bts)
+						if err != nil {
+							return
+						}
+						if cap(z.rc.iv) >= int(zjfb) {
+							z.rc.iv = (z.rc.iv)[:zjfb]
+						} else {
+							z.rc.iv = make([]interval32, zjfb)
+						}
+						for zbzg := range z.rc.iv {
+							var zcxo uint32
+							zcxo, bts, err = msgp.ReadMapHeaderBytes(bts)
+							if err != nil {
+								return
+							}
+							for zcxo > 0 {
+								zcxo--
+								field, bts, err = msgp.ReadMapKeyZC(bts)
+								if err != nil {
+									return
+								}
+								switch msgp.UnsafeString(field) {
+								case "start":
+									z.rc.iv[zbzg].start, bts, err = msgp.ReadUint32Bytes(bts)
+									if err != nil {
+										return
+									}
+								case "last":
+									z.rc.iv[zbzg].last, bts, err = msgp.ReadUint32Bytes(bts)
+									if err != nil {
+										return
+									}
+								default:
+									bts, err = msgp.Skip(bts)
+									if err != nil {
+										return
+									}
+								}
+							}
+						}
+					case "card":
+						z.rc.card, bts, err = msgp.ReadInt64Bytes(bts)
+						if err != nil {
+							return
+						}
+					default:
+						bts, err = msgp.Skip(bts)
+						if err != nil {
+							return
+						}
+					}
 				}
 			}
 		default:
@@ -530,7 +500,7 @@ func (z *addHelper32) Msgsize() (s int) {
 	if z.rc == nil {
 		s += msgp.NilSize
 	} else {
-		s += z.rc.Msgsize()
+		s += 1 + 3 + msgp.ArrayHeaderSize + (len(z.rc.iv) * (12 + msgp.Uint32Size + msgp.Uint32Size)) + 5 + msgp.Int64Size
 	}
 	return
 }
@@ -539,13 +509,13 @@ func (z *addHelper32) Msgsize() (s int) {
 func (z *interval32) DecodeMsg(dc *msgp.Reader) (err error) {
 	var field []byte
 	_ = field
-	var zlqf uint32
-	zlqf, err = dc.ReadMapHeader()
+	var zeff uint32
+	zeff, err = dc.ReadMapHeader()
 	if err != nil {
 		return
 	}
-	for zlqf > 0 {
-		zlqf--
+	for zeff > 0 {
+		zeff--
 		field, err = dc.ReadMapKeyPtr()
 		if err != nil {
 			return
@@ -612,13 +582,13 @@ func (z interval32) MarshalMsg(b []byte) (o []byte, err error) {
 func (z *interval32) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	var field []byte
 	_ = field
-	var zdaf uint32
-	zdaf, bts, err = msgp.ReadMapHeaderBytes(bts)
+	var zrsw uint32
+	zrsw, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if err != nil {
 		return
 	}
-	for zdaf > 0 {
-		zdaf--
+	for zrsw > 0 {
+		zrsw--
 		field, bts, err = msgp.ReadMapKeyZC(bts)
 		if err != nil {
 			return
@@ -655,49 +625,49 @@ func (z interval32) Msgsize() (s int) {
 func (z *runContainer32) DecodeMsg(dc *msgp.Reader) (err error) {
 	var field []byte
 	_ = field
-	var zjfb uint32
-	zjfb, err = dc.ReadMapHeader()
+	var zdnj uint32
+	zdnj, err = dc.ReadMapHeader()
 	if err != nil {
 		return
 	}
-	for zjfb > 0 {
-		zjfb--
+	for zdnj > 0 {
+		zdnj--
 		field, err = dc.ReadMapKeyPtr()
 		if err != nil {
 			return
 		}
 		switch msgp.UnsafeString(field) {
 		case "iv":
-			var zcxo uint32
-			zcxo, err = dc.ReadArrayHeader()
+			var zobc uint32
+			zobc, err = dc.ReadArrayHeader()
 			if err != nil {
 				return
 			}
-			if cap(z.iv) >= int(zcxo) {
-				z.iv = (z.iv)[:zcxo]
+			if cap(z.iv) >= int(zobc) {
+				z.iv = (z.iv)[:zobc]
 			} else {
-				z.iv = make([]interval32, zcxo)
+				z.iv = make([]interval32, zobc)
 			}
-			for zpks := range z.iv {
-				var zeff uint32
-				zeff, err = dc.ReadMapHeader()
+			for zxpk := range z.iv {
+				var zsnv uint32
+				zsnv, err = dc.ReadMapHeader()
 				if err != nil {
 					return
 				}
-				for zeff > 0 {
-					zeff--
+				for zsnv > 0 {
+					zsnv--
 					field, err = dc.ReadMapKeyPtr()
 					if err != nil {
 						return
 					}
 					switch msgp.UnsafeString(field) {
 					case "start":
-						z.iv[zpks].start, err = dc.ReadUint32()
+						z.iv[zxpk].start, err = dc.ReadUint32()
 						if err != nil {
 							return
 						}
 					case "last":
-						z.iv[zpks].last, err = dc.ReadUint32()
+						z.iv[zxpk].last, err = dc.ReadUint32()
 						if err != nil {
 							return
 						}
@@ -736,14 +706,14 @@ func (z *runContainer32) EncodeMsg(en *msgp.Writer) (err error) {
 	if err != nil {
 		return
 	}
-	for zpks := range z.iv {
+	for zxpk := range z.iv {
 		// map header, size 2
 		// write "start"
 		err = en.Append(0x82, 0xa5, 0x73, 0x74, 0x61, 0x72, 0x74)
 		if err != nil {
 			return err
 		}
-		err = en.WriteUint32(z.iv[zpks].start)
+		err = en.WriteUint32(z.iv[zxpk].start)
 		if err != nil {
 			return
 		}
@@ -752,7 +722,7 @@ func (z *runContainer32) EncodeMsg(en *msgp.Writer) (err error) {
 		if err != nil {
 			return err
 		}
-		err = en.WriteUint32(z.iv[zpks].last)
+		err = en.WriteUint32(z.iv[zxpk].last)
 		if err != nil {
 			return
 		}
@@ -776,14 +746,14 @@ func (z *runContainer32) MarshalMsg(b []byte) (o []byte, err error) {
 	// string "iv"
 	o = append(o, 0x82, 0xa2, 0x69, 0x76)
 	o = msgp.AppendArrayHeader(o, uint32(len(z.iv)))
-	for zpks := range z.iv {
+	for zxpk := range z.iv {
 		// map header, size 2
 		// string "start"
 		o = append(o, 0x82, 0xa5, 0x73, 0x74, 0x61, 0x72, 0x74)
-		o = msgp.AppendUint32(o, z.iv[zpks].start)
+		o = msgp.AppendUint32(o, z.iv[zxpk].start)
 		// string "last"
 		o = append(o, 0xa4, 0x6c, 0x61, 0x73, 0x74)
-		o = msgp.AppendUint32(o, z.iv[zpks].last)
+		o = msgp.AppendUint32(o, z.iv[zxpk].last)
 	}
 	// string "card"
 	o = append(o, 0xa4, 0x63, 0x61, 0x72, 0x64)
@@ -795,49 +765,49 @@ func (z *runContainer32) MarshalMsg(b []byte) (o []byte, err error) {
 func (z *runContainer32) UnmarshalMsg(bts []byte) (o []byte, err error) {
 	var field []byte
 	_ = field
-	var zrsw uint32
-	zrsw, bts, err = msgp.ReadMapHeaderBytes(bts)
+	var zkgt uint32
+	zkgt, bts, err = msgp.ReadMapHeaderBytes(bts)
 	if err != nil {
 		return
 	}
-	for zrsw > 0 {
-		zrsw--
+	for zkgt > 0 {
+		zkgt--
 		field, bts, err = msgp.ReadMapKeyZC(bts)
 		if err != nil {
 			return
 		}
 		switch msgp.UnsafeString(field) {
 		case "iv":
-			var zxpk uint32
-			zxpk, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zema uint32
+			zema, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				return
 			}
-			if cap(z.iv) >= int(zxpk) {
-				z.iv = (z.iv)[:zxpk]
+			if cap(z.iv) >= int(zema) {
+				z.iv = (z.iv)[:zema]
 			} else {
-				z.iv = make([]interval32, zxpk)
+				z.iv = make([]interval32, zema)
 			}
-			for zpks := range z.iv {
-				var zdnj uint32
-				zdnj, bts, err = msgp.ReadMapHeaderBytes(bts)
+			for zxpk := range z.iv {
+				var zpez uint32
+				zpez, bts, err = msgp.ReadMapHeaderBytes(bts)
 				if err != nil {
 					return
 				}
-				for zdnj > 0 {
-					zdnj--
+				for zpez > 0 {
+					zpez--
 					field, bts, err = msgp.ReadMapKeyZC(bts)
 					if err != nil {
 						return
 					}
 					switch msgp.UnsafeString(field) {
 					case "start":
-						z.iv[zpks].start, bts, err = msgp.ReadUint32Bytes(bts)
+						z.iv[zxpk].start, bts, err = msgp.ReadUint32Bytes(bts)
 						if err != nil {
 							return
 						}
 					case "last":
-						z.iv[zpks].last, bts, err = msgp.ReadUint32Bytes(bts)
+						z.iv[zxpk].last, bts, err = msgp.ReadUint32Bytes(bts)
 						if err != nil {
 							return
 						}
@@ -872,19 +842,221 @@ func (z *runContainer32) Msgsize() (s int) {
 }
 
 // DecodeMsg implements msgp.Decodable
-func (z *uint32Slice) DecodeMsg(dc *msgp.Reader) (err error) {
-	var zkgt uint32
-	zkgt, err = dc.ReadArrayHeader()
+func (z *runIterator32) DecodeMsg(dc *msgp.Reader) (err error) {
+	var field []byte
+	_ = field
+	var zqke uint32
+	zqke, err = dc.ReadMapHeader()
 	if err != nil {
 		return
 	}
-	if cap((*z)) >= int(zkgt) {
-		(*z) = (*z)[:zkgt]
-	} else {
-		(*z) = make(uint32Slice, zkgt)
+	for zqke > 0 {
+		zqke--
+		field, err = dc.ReadMapKeyPtr()
+		if err != nil {
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "rc":
+			if dc.IsNil() {
+				err = dc.ReadNil()
+				if err != nil {
+					return
+				}
+				z.rc = nil
+			} else {
+				if z.rc == nil {
+					z.rc = new(runContainer32)
+				}
+				err = z.rc.DecodeMsg(dc)
+				if err != nil {
+					return
+				}
+			}
+		case "curIndex":
+			z.curIndex, err = dc.ReadInt64()
+			if err != nil {
+				return
+			}
+		case "curPosInIndex":
+			z.curPosInIndex, err = dc.ReadUint32()
+			if err != nil {
+				return
+			}
+		case "curSeq":
+			z.curSeq, err = dc.ReadInt64()
+			if err != nil {
+				return
+			}
+		default:
+			err = dc.Skip()
+			if err != nil {
+				return
+			}
+		}
 	}
-	for zsnv := range *z {
-		(*z)[zsnv], err = dc.ReadUint32()
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z *runIterator32) EncodeMsg(en *msgp.Writer) (err error) {
+	// map header, size 4
+	// write "rc"
+	err = en.Append(0x84, 0xa2, 0x72, 0x63)
+	if err != nil {
+		return err
+	}
+	if z.rc == nil {
+		err = en.WriteNil()
+		if err != nil {
+			return
+		}
+	} else {
+		err = z.rc.EncodeMsg(en)
+		if err != nil {
+			return
+		}
+	}
+	// write "curIndex"
+	err = en.Append(0xa8, 0x63, 0x75, 0x72, 0x49, 0x6e, 0x64, 0x65, 0x78)
+	if err != nil {
+		return err
+	}
+	err = en.WriteInt64(z.curIndex)
+	if err != nil {
+		return
+	}
+	// write "curPosInIndex"
+	err = en.Append(0xad, 0x63, 0x75, 0x72, 0x50, 0x6f, 0x73, 0x49, 0x6e, 0x49, 0x6e, 0x64, 0x65, 0x78)
+	if err != nil {
+		return err
+	}
+	err = en.WriteUint32(z.curPosInIndex)
+	if err != nil {
+		return
+	}
+	// write "curSeq"
+	err = en.Append(0xa6, 0x63, 0x75, 0x72, 0x53, 0x65, 0x71)
+	if err != nil {
+		return err
+	}
+	err = en.WriteInt64(z.curSeq)
+	if err != nil {
+		return
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *runIterator32) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// map header, size 4
+	// string "rc"
+	o = append(o, 0x84, 0xa2, 0x72, 0x63)
+	if z.rc == nil {
+		o = msgp.AppendNil(o)
+	} else {
+		o, err = z.rc.MarshalMsg(o)
+		if err != nil {
+			return
+		}
+	}
+	// string "curIndex"
+	o = append(o, 0xa8, 0x63, 0x75, 0x72, 0x49, 0x6e, 0x64, 0x65, 0x78)
+	o = msgp.AppendInt64(o, z.curIndex)
+	// string "curPosInIndex"
+	o = append(o, 0xad, 0x63, 0x75, 0x72, 0x50, 0x6f, 0x73, 0x49, 0x6e, 0x49, 0x6e, 0x64, 0x65, 0x78)
+	o = msgp.AppendUint32(o, z.curPosInIndex)
+	// string "curSeq"
+	o = append(o, 0xa6, 0x63, 0x75, 0x72, 0x53, 0x65, 0x71)
+	o = msgp.AppendInt64(o, z.curSeq)
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *runIterator32) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zqyh uint32
+	zqyh, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		return
+	}
+	for zqyh > 0 {
+		zqyh--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "rc":
+			if msgp.IsNil(bts) {
+				bts, err = msgp.ReadNilBytes(bts)
+				if err != nil {
+					return
+				}
+				z.rc = nil
+			} else {
+				if z.rc == nil {
+					z.rc = new(runContainer32)
+				}
+				bts, err = z.rc.UnmarshalMsg(bts)
+				if err != nil {
+					return
+				}
+			}
+		case "curIndex":
+			z.curIndex, bts, err = msgp.ReadInt64Bytes(bts)
+			if err != nil {
+				return
+			}
+		case "curPosInIndex":
+			z.curPosInIndex, bts, err = msgp.ReadUint32Bytes(bts)
+			if err != nil {
+				return
+			}
+		case "curSeq":
+			z.curSeq, bts, err = msgp.ReadInt64Bytes(bts)
+			if err != nil {
+				return
+			}
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				return
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *runIterator32) Msgsize() (s int) {
+	s = 1 + 3
+	if z.rc == nil {
+		s += msgp.NilSize
+	} else {
+		s += z.rc.Msgsize()
+	}
+	s += 9 + msgp.Int64Size + 14 + msgp.Uint32Size + 7 + msgp.Int64Size
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
+func (z *uint32Slice) DecodeMsg(dc *msgp.Reader) (err error) {
+	var zjpj uint32
+	zjpj, err = dc.ReadArrayHeader()
+	if err != nil {
+		return
+	}
+	if cap((*z)) >= int(zjpj) {
+		(*z) = (*z)[:zjpj]
+	} else {
+		(*z) = make(uint32Slice, zjpj)
+	}
+	for zywj := range *z {
+		(*z)[zywj], err = dc.ReadUint32()
 		if err != nil {
 			return
 		}
@@ -898,8 +1070,8 @@ func (z uint32Slice) EncodeMsg(en *msgp.Writer) (err error) {
 	if err != nil {
 		return
 	}
-	for zema := range z {
-		err = en.WriteUint32(z[zema])
+	for zzpf := range z {
+		err = en.WriteUint32(z[zzpf])
 		if err != nil {
 			return
 		}
@@ -911,26 +1083,26 @@ func (z uint32Slice) EncodeMsg(en *msgp.Writer) (err error) {
 func (z uint32Slice) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
 	o = msgp.AppendArrayHeader(o, uint32(len(z)))
-	for zema := range z {
-		o = msgp.AppendUint32(o, z[zema])
+	for zzpf := range z {
+		o = msgp.AppendUint32(o, z[zzpf])
 	}
 	return
 }
 
 // UnmarshalMsg implements msgp.Unmarshaler
 func (z *uint32Slice) UnmarshalMsg(bts []byte) (o []byte, err error) {
-	var zqke uint32
-	zqke, bts, err = msgp.ReadArrayHeaderBytes(bts)
+	var zgmo uint32
+	zgmo, bts, err = msgp.ReadArrayHeaderBytes(bts)
 	if err != nil {
 		return
 	}
-	if cap((*z)) >= int(zqke) {
-		(*z) = (*z)[:zqke]
+	if cap((*z)) >= int(zgmo) {
+		(*z) = (*z)[:zgmo]
 	} else {
-		(*z) = make(uint32Slice, zqke)
+		(*z) = make(uint32Slice, zgmo)
 	}
-	for zpez := range *z {
-		(*z)[zpez], bts, err = msgp.ReadUint32Bytes(bts)
+	for zrfe := range *z {
+		(*z)[zrfe], bts, err = msgp.ReadUint32Bytes(bts)
 		if err != nil {
 			return
 		}

--- a/rle_gen_test.go
+++ b/rle_gen_test.go
@@ -11,119 +11,6 @@ import (
 	"github.com/tinylib/msgp/msgp"
 )
 
-func TestMarshalUnmarshalRunIterator32(t *testing.T) {
-	v := RunIterator32{}
-	bts, err := v.MarshalMsg(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	left, err := v.UnmarshalMsg(bts)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(left) > 0 {
-		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
-	}
-
-	left, err = msgp.Skip(bts)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(left) > 0 {
-		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
-	}
-}
-
-func BenchmarkMarshalMsgRunIterator32(b *testing.B) {
-	v := RunIterator32{}
-	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		v.MarshalMsg(nil)
-	}
-}
-
-func BenchmarkAppendMsgRunIterator32(b *testing.B) {
-	v := RunIterator32{}
-	bts := make([]byte, 0, v.Msgsize())
-	bts, _ = v.MarshalMsg(bts[0:0])
-	b.SetBytes(int64(len(bts)))
-	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		bts, _ = v.MarshalMsg(bts[0:0])
-	}
-}
-
-func BenchmarkUnmarshalRunIterator32(b *testing.B) {
-	v := RunIterator32{}
-	bts, _ := v.MarshalMsg(nil)
-	b.ReportAllocs()
-	b.SetBytes(int64(len(bts)))
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		_, err := v.UnmarshalMsg(bts)
-		if err != nil {
-			b.Fatal(err)
-		}
-	}
-}
-
-func TestEncodeDecodeRunIterator32(t *testing.T) {
-	v := RunIterator32{}
-	var buf bytes.Buffer
-	msgp.Encode(&buf, &v)
-
-	m := v.Msgsize()
-	if buf.Len() > m {
-		t.Logf("WARNING: Msgsize() for %v is inaccurate", v)
-	}
-
-	vn := RunIterator32{}
-	err := msgp.Decode(&buf, &vn)
-	if err != nil {
-		t.Error(err)
-	}
-
-	buf.Reset()
-	msgp.Encode(&buf, &v)
-	err = msgp.NewReader(&buf).Skip()
-	if err != nil {
-		t.Error(err)
-	}
-}
-
-func BenchmarkEncodeRunIterator32(b *testing.B) {
-	v := RunIterator32{}
-	var buf bytes.Buffer
-	msgp.Encode(&buf, &v)
-	b.SetBytes(int64(buf.Len()))
-	en := msgp.NewWriter(msgp.Nowhere)
-	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		v.EncodeMsg(en)
-	}
-	en.Flush()
-}
-
-func BenchmarkDecodeRunIterator32(b *testing.B) {
-	v := RunIterator32{}
-	var buf bytes.Buffer
-	msgp.Encode(&buf, &v)
-	b.SetBytes(int64(buf.Len()))
-	rd := msgp.NewEndlessReader(buf.Bytes(), b)
-	dc := msgp.NewReader(rd)
-	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		err := v.DecodeMsg(dc)
-		if err != nil {
-			b.Fatal(err)
-		}
-	}
-}
-
 func TestMarshalUnmarshaladdHelper32(t *testing.T) {
 	v := addHelper32{}
 	bts, err := v.MarshalMsg(nil)
@@ -448,6 +335,119 @@ func BenchmarkEncoderunContainer32(b *testing.B) {
 
 func BenchmarkDecoderunContainer32(b *testing.B) {
 	v := runContainer32{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	rd := msgp.NewEndlessReader(buf.Bytes(), b)
+	dc := msgp.NewReader(rd)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := v.DecodeMsg(dc)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestMarshalUnmarshalrunIterator32(t *testing.T) {
+	v := runIterator32{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgrunIterator32(b *testing.B) {
+	v := runIterator32{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgrunIterator32(b *testing.B) {
+	v := runIterator32{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalrunIterator32(b *testing.B) {
+	v := runIterator32{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestEncodeDecoderunIterator32(t *testing.T) {
+	v := runIterator32{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+
+	m := v.Msgsize()
+	if buf.Len() > m {
+		t.Logf("WARNING: Msgsize() for %v is inaccurate", v)
+	}
+
+	vn := runIterator32{}
+	err := msgp.Decode(&buf, &vn)
+	if err != nil {
+		t.Error(err)
+	}
+
+	buf.Reset()
+	msgp.Encode(&buf, &v)
+	err = msgp.NewReader(&buf).Skip()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkEncoderunIterator32(b *testing.B) {
+	v := runIterator32{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	en := msgp.NewWriter(msgp.Nowhere)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.EncodeMsg(en)
+	}
+	en.Flush()
+}
+
+func BenchmarkDecoderunIterator32(b *testing.B) {
+	v := runIterator32{}
 	var buf bytes.Buffer
 	msgp.Encode(&buf, &v)
 	b.SetBytes(int64(buf.Len()))

--- a/rle_test.go
+++ b/rle_test.go
@@ -77,26 +77,26 @@ func TestRleRunIterator32(t *testing.T) {
 			_ = msg
 			p("an empty container: '%s'\n", msg)
 			So(rc.cardinality(), ShouldEqual, 0)
-			it := rc.NewRunIterator32()
-			So(it.HasNext(), ShouldBeFalse)
+			it := rc.newRunIterator32()
+			So(it.hasNext(), ShouldBeFalse)
 		}
 		{
 			rc := newRunContainer32TakeOwnership([]interval32{{start: 4, last: 4}})
 			So(rc.cardinality(), ShouldEqual, 1)
-			it := rc.NewRunIterator32()
-			So(it.HasNext(), ShouldBeTrue)
-			So(it.Next(), ShouldResemble, uint32(4))
-			So(it.Cur(), ShouldResemble, uint32(4))
+			it := rc.newRunIterator32()
+			So(it.hasNext(), ShouldBeTrue)
+			So(it.next(), ShouldResemble, uint32(4))
+			So(it.cur(), ShouldResemble, uint32(4))
 		}
 		{
 			rc := newRunContainer32CopyIv([]interval32{{start: 4, last: 9}})
 			So(rc.cardinality(), ShouldEqual, 6)
-			it := rc.NewRunIterator32()
-			So(it.HasNext(), ShouldBeTrue)
+			it := rc.newRunIterator32()
+			So(it.hasNext(), ShouldBeTrue)
 			for i := 4; i < 10; i++ {
-				So(it.Next(), ShouldEqual, uint32(i))
+				So(it.next(), ShouldEqual, uint32(i))
 			}
-			So(it.HasNext(), ShouldBeFalse)
+			So(it.hasNext(), ShouldBeFalse)
 		}
 
 		{
@@ -105,25 +105,25 @@ func TestRleRunIterator32(t *testing.T) {
 			So(card, ShouldEqual, 6)
 			//So(rc.serializedSizeInBytes(), ShouldEqual, 2+4*rc.numberOfRuns())
 
-			it := rc.NewRunIterator32()
-			So(it.HasNext(), ShouldBeTrue)
+			it := rc.newRunIterator32()
+			So(it.hasNext(), ShouldBeTrue)
 			for i := 4; i < 6; i++ {
-				So(it.Next(), ShouldEqual, uint32(i))
+				So(it.next(), ShouldEqual, uint32(i))
 			}
-			So(it.Cur(), ShouldEqual, uint32(5))
+			So(it.cur(), ShouldEqual, uint32(5))
 
 			p("before Remove of 5, rc = '%s'", rc)
 
-			So(it.Remove(), ShouldEqual, uint32(5))
+			So(it.remove(), ShouldEqual, uint32(5))
 
 			p("after Remove of 5, rc = '%s'", rc)
 			So(rc.cardinality(), ShouldEqual, 5)
 
-			it2 := rc.NewRunIterator32()
+			it2 := rc.newRunIterator32()
 			So(rc.cardinality(), ShouldEqual, 5)
-			So(it2.Next(), ShouldEqual, uint32(4))
+			So(it2.next(), ShouldEqual, uint32(4))
 			for i := 6; i < 10; i++ {
-				So(it2.Next(), ShouldEqual, uint32(i))
+				So(it2.next(), ShouldEqual, uint32(i))
 			}
 		}
 		{
@@ -141,16 +141,16 @@ func TestRleRunIterator32(t *testing.T) {
 			rc = rc.union(rc1)
 
 			So(rc.cardinality(), ShouldEqual, 8)
-			it := rc.NewRunIterator32()
-			So(it.Next(), ShouldEqual, uint32(0))
-			So(it.Next(), ShouldEqual, uint32(2))
-			So(it.Next(), ShouldEqual, uint32(4))
-			So(it.Next(), ShouldEqual, uint32(6))
-			So(it.Next(), ShouldEqual, uint32(7))
-			So(it.Next(), ShouldEqual, uint32(10))
-			So(it.Next(), ShouldEqual, uint32(11))
-			So(it.Next(), ShouldEqual, uint32(MaxUint32))
-			So(it.HasNext(), ShouldEqual, false)
+			it := rc.newRunIterator32()
+			So(it.next(), ShouldEqual, uint32(0))
+			So(it.next(), ShouldEqual, uint32(2))
+			So(it.next(), ShouldEqual, uint32(4))
+			So(it.next(), ShouldEqual, uint32(6))
+			So(it.next(), ShouldEqual, uint32(7))
+			So(it.next(), ShouldEqual, uint32(10))
+			So(it.next(), ShouldEqual, uint32(11))
+			So(it.next(), ShouldEqual, uint32(MaxUint32))
+			So(it.hasNext(), ShouldEqual, false)
 
 			rc2 := newRunContainer32TakeOwnership([]interval32{
 				{start: 0, last: MaxUint32},
@@ -636,17 +636,17 @@ func TestRleCoverageOddsAndEnds32(t *testing.T) {
 			ra.Add(5)
 			So(ra.cardinality(), ShouldEqual, 2)
 
-			// NewRunIterator32()
+			// newRunIterator32()
 			empty := newRunContainer32()
-			it := empty.NewRunIterator32()
-			So(func() { it.Next() }, ShouldPanic)
-			it2 := ra.NewRunIterator32()
+			it := empty.newRunIterator32()
+			So(func() { it.next() }, ShouldPanic)
+			it2 := ra.newRunIterator32()
 			it2.curIndex = int64(len(it2.rc.iv))
-			So(func() { it2.Next() }, ShouldPanic)
+			So(func() { it2.next() }, ShouldPanic)
 
-			// RunIterator32.Remove()
-			emptyIt := empty.NewRunIterator32()
-			So(func() { emptyIt.Remove() }, ShouldPanic)
+			// runIterator32.remove()
+			emptyIt := empty.newRunIterator32()
+			So(func() { emptyIt.remove() }, ShouldPanic)
 
 			// newRunContainer32FromArray
 			arr := newArrayContainerRange(1, 6)
@@ -672,16 +672,16 @@ func TestRleCoverageOddsAndEnds32(t *testing.T) {
 			rc3.Add(10)
 			rc3.Add(12)
 			So(rc3.cardinality(), ShouldEqual, 5)
-			it3 := rc3.NewRunIterator32()
-			it3.Next()
-			it3.Next()
-			it3.Next()
-			it3.Next()
+			it3 := rc3.newRunIterator32()
+			it3.next()
+			it3.next()
+			it3.next()
+			it3.next()
 			//p("rc3 = %v", rc3) // 5, 6, 9, 10, 12
-			So(it3.Cur(), ShouldEqual, uint32(10))
-			it3.Remove()
+			So(it3.cur(), ShouldEqual, uint32(10))
+			it3.remove()
 			//p("after Remove of 10, rc3 = %v", rc3) // 5, 6, 9, 12
-			So(it3.Next(), ShouldEqual, uint32(12))
+			So(it3.next(), ShouldEqual, uint32(12))
 		}
 	})
 }

--- a/rle_test.go
+++ b/rle_test.go
@@ -683,6 +683,17 @@ func TestRleCoverageOddsAndEnds32(t *testing.T) {
 			//p("after Remove of 10, rc3 = %v", rc3) // 5, 6, 9, 12
 			So(it3.next(), ShouldEqual, uint32(12))
 		}
+
+		// runContainer32.equals
+		{
+			rc32 := newRunContainer32()
+			So(rc32.equals32(rc32), ShouldBeTrue)
+			rc32b := newRunContainer32()
+			So(rc32.equals32(rc32b), ShouldBeTrue)
+			rc32.Add(1)
+			rc32b.Add(2)
+			So(rc32.equals32(rc32b), ShouldBeFalse)
+		}
 	})
 }
 

--- a/rlecommon.go
+++ b/rlecommon.go
@@ -2,7 +2,6 @@ package roaring
 
 import (
 	"fmt"
-	"sort"
 )
 
 // common to rle32.go and rle16.go
@@ -83,20 +82,6 @@ func (rc *runContainer32) Or(b *Bitmap) *Bitmap {
 	return out
 }
 
-func showHash(name string, h map[int]bool) {
-	hv := []int{}
-	for k := range h {
-		hv = append(hv, k)
-	}
-	sort.Sort(sort.IntSlice(hv))
-	stringH := ""
-	for i := range hv {
-		stringH += fmt.Sprintf("%v, ", hv[i])
-	}
-
-	fmt.Printf("%s is (len %v): %s", name, len(h), stringH)
-}
-
 // trial is used in the randomized testing of runContainers
 type trial struct {
 	n           int
@@ -156,9 +141,9 @@ func (rc *runContainer16) Or(b *Bitmap) *Bitmap {
 	return out
 }
 
-func (rc *runContainer32) and(container) container {
-	panic("TODO. not yet implemented")
-}
+//func (rc *runContainer32) and(container) container {
+//	panic("TODO. not yet implemented")
+//}
 
 // serializedSizeInBytes returns the number of bytes of memory
 // required by this runContainer16. This is for the
@@ -173,27 +158,4 @@ func (rc *runContainer16) serializedSizeInBytes() int {
 // required by this runContainer32.
 func (rc *runContainer32) serializedSizeInBytes() int {
 	return 4 + len(rc.iv)*8
-}
-
-func (rc *runContainer32) equals32(srb *runContainer32) bool {
-	//p("both rc32")
-	// Check if the containers are the same object.
-	if rc == srb {
-		//p("same object")
-		return true
-	}
-
-	if len(srb.iv) != len(rc.iv) {
-		//p("iv len differ")
-		return false
-	}
-
-	for i, v := range rc.iv {
-		if v != srb.iv[i] {
-			//p("differ at iv i=%v, srb.iv[i]=%v, rc.iv[i]=%v", i, srb.iv[i], rc.iv[i])
-			return false
-		}
-	}
-	//p("all intervals same, returning true")
-	return true
 }

--- a/rlei.go
+++ b/rlei.go
@@ -267,28 +267,23 @@ func (rc *runContainer16) equals(o container) bool {
 	}
 
 	//p("not both rc16; o is %T / val=%#v", o, o)
-	bc, ok := o.(container)
-	if ok {
-		// use generic comparison
-		if bc.getCardinality() != rc.getCardinality() {
-			//p("card differ bc.card=%v, rc.card=%v", bc.getCardinality(), rc.getCardinality())
+	// use generic comparison
+	if o.getCardinality() != rc.getCardinality() {
+		//p("card differ o.card=%v, rc.card=%v", o.getCardinality(), rc.getCardinality())
+		return false
+	}
+	rit := rc.getShortIterator()
+	bit := o.getShortIterator()
+
+	//k := 0
+	for rit.hasNext() {
+		if bit.next() != rit.next() {
+			//p("differ at pos %k", k)
 			return false
 		}
-		rit := rc.getShortIterator()
-		bit := bc.getShortIterator()
-
-		//k := 0
-		for rit.hasNext() {
-			if bit.next() != rit.next() {
-				//p("differ at pos %k", k)
-				return false
-			}
-			//k++
-		}
-		return true
+		//k++
 	}
-	//p("o was not a container!")
-	return false
+	return true
 }
 
 func (rc *runContainer16) iaddReturnMinimized(x uint16) container {

--- a/rlei.go
+++ b/rlei.go
@@ -143,7 +143,7 @@ func (rc *runContainer16) fillLeastSignificant16bits(x []uint32, i int, mask uin
 }
 
 func (rc *runContainer16) getShortIterator() shortIterable {
-	return rc.NewRunIterator16()
+	return rc.newRunIterator16()
 }
 
 // add the values in the range [firstOfRange, endx). endx

--- a/rlei_test.go
+++ b/rlei_test.go
@@ -870,9 +870,9 @@ func TestRle16SubtractionOfIntervals019(t *testing.T) {
 				p("rc.cardinality = %v", rc.cardinality())
 				p("rcb from b is %v", rcb)
 				p("rcb.cardinality = %v", rcb.cardinality())
-				it := rcb.NewRunIterator16()
-				for it.HasNext() {
-					nx := it.Next()
+				it := rcb.newRunIterator16()
+				for it.hasNext() {
+					nx := it.next()
 					rc.isubtract(interval16{start: nx, last: nx})
 				}
 

--- a/rlei_test.go
+++ b/rlei_test.go
@@ -73,33 +73,33 @@ func TestRle16RandomIntersectAgainstOtherContainers010(t *testing.T) {
 				// vs runContainer
 				rcb := newRunContainer16FromVals(false, b...)
 
-				rc_vs_bc_isect := rc.and(bc)
-				rc_vs_ac_isect := rc.and(ac)
-				rc_vs_rcb_isect := rc.and(rcb)
+				rcVsBcIsect := rc.and(bc)
+				rcVsAcIsect := rc.and(ac)
+				rcVsRcbIsect := rc.and(rcb)
 
-				p("rc_vs_bc_isect is %v", rc_vs_bc_isect)
-				p("rc_vs_ac_isect is %v", rc_vs_ac_isect)
-				p("rc_vs_rcb_isect is %v", rc_vs_rcb_isect)
+				p("rcVsBcIsect is %v", rcVsBcIsect)
+				p("rcVsAcIsect is %v", rcVsAcIsect)
+				p("rcVsRcbIsect is %v", rcVsRcbIsect)
 
 				//showHash("hashi", hashi)
 
 				for k := range hashi {
-					p("hashi has %v, checking in rc_vs_bc_isect", k)
-					So(rc_vs_bc_isect.contains(uint16(k)), ShouldBeTrue)
+					p("hashi has %v, checking in rcVsBcIsect", k)
+					So(rcVsBcIsect.contains(uint16(k)), ShouldBeTrue)
 
-					p("hashi has %v, checking in rc_vs_ac_isect", k)
-					So(rc_vs_ac_isect.contains(uint16(k)), ShouldBeTrue)
+					p("hashi has %v, checking in rcVsAcIsect", k)
+					So(rcVsAcIsect.contains(uint16(k)), ShouldBeTrue)
 
-					p("hashi has %v, checking in rc_vs_rcb_isect", k)
-					So(rc_vs_rcb_isect.contains(uint16(k)), ShouldBeTrue)
+					p("hashi has %v, checking in rcVsRcbIsect", k)
+					So(rcVsRcbIsect.contains(uint16(k)), ShouldBeTrue)
 				}
 
-				p("checking for cardinality agreement: rc_vs_bc_isect is %v, len(hashi) is %v", rc_vs_bc_isect.getCardinality(), len(hashi))
-				p("checking for cardinality agreement: rc_vs_ac_isect is %v, len(hashi) is %v", rc_vs_ac_isect.getCardinality(), len(hashi))
-				p("checking for cardinality agreement: rc_vs_rcb_isect is %v, len(hashi) is %v", rc_vs_rcb_isect.getCardinality(), len(hashi))
-				So(rc_vs_bc_isect.getCardinality(), ShouldEqual, len(hashi))
-				So(rc_vs_ac_isect.getCardinality(), ShouldEqual, len(hashi))
-				So(rc_vs_rcb_isect.getCardinality(), ShouldEqual, len(hashi))
+				p("checking for cardinality agreement: rcVsBcIsect is %v, len(hashi) is %v", rcVsBcIsect.getCardinality(), len(hashi))
+				p("checking for cardinality agreement: rcVsAcIsect is %v, len(hashi) is %v", rcVsAcIsect.getCardinality(), len(hashi))
+				p("checking for cardinality agreement: rcVsRcbIsect is %v, len(hashi) is %v", rcVsRcbIsect.getCardinality(), len(hashi))
+				So(rcVsBcIsect.getCardinality(), ShouldEqual, len(hashi))
+				So(rcVsAcIsect.getCardinality(), ShouldEqual, len(hashi))
+				So(rcVsRcbIsect.getCardinality(), ShouldEqual, len(hashi))
 			}
 			p("done with randomized and() vs bitmapContainer and arrayContainer checks for trial %#v", tr)
 		}
@@ -180,33 +180,33 @@ func TestRle16RandomUnionAgainstOtherContainers011(t *testing.T) {
 				// vs runContainer
 				rcb := newRunContainer16FromVals(false, b...)
 
-				rc_vs_bc_union := rc.or(bc)
-				rc_vs_ac_union := rc.or(ac)
-				rc_vs_rcb_union := rc.or(rcb)
+				rcVsBcUnion := rc.or(bc)
+				rcVsAcUnion := rc.or(ac)
+				rcVsRcbUnion := rc.or(rcb)
 
-				p("rc_vs_bc_union is %v", rc_vs_bc_union)
-				p("rc_vs_ac_union is %v", rc_vs_ac_union)
-				p("rc_vs_rcb_union is %v", rc_vs_rcb_union)
+				p("rcVsBcUnion is %v", rcVsBcUnion)
+				p("rcVsAcUnion is %v", rcVsAcUnion)
+				p("rcVsRcbUnion is %v", rcVsRcbUnion)
 
 				//showHash("hashi", hashi)
 
 				for k := range hashi {
-					p("hashi has %v, checking in rc_vs_bc_union", k)
-					So(rc_vs_bc_union.contains(uint16(k)), ShouldBeTrue)
+					p("hashi has %v, checking in rcVsBcUnion", k)
+					So(rcVsBcUnion.contains(uint16(k)), ShouldBeTrue)
 
-					p("hashi has %v, checking in rc_vs_ac_union", k)
-					So(rc_vs_ac_union.contains(uint16(k)), ShouldBeTrue)
+					p("hashi has %v, checking in rcVsAcUnion", k)
+					So(rcVsAcUnion.contains(uint16(k)), ShouldBeTrue)
 
-					p("hashi has %v, checking in rc_vs_rcb_union", k)
-					So(rc_vs_rcb_union.contains(uint16(k)), ShouldBeTrue)
+					p("hashi has %v, checking in rcVsRcbUnion", k)
+					So(rcVsRcbUnion.contains(uint16(k)), ShouldBeTrue)
 				}
 
-				p("checking for cardinality agreement: rc_vs_bc_union is %v, len(hashi) is %v", rc_vs_bc_union.getCardinality(), len(hashi))
-				p("checking for cardinality agreement: rc_vs_ac_union is %v, len(hashi) is %v", rc_vs_ac_union.getCardinality(), len(hashi))
-				p("checking for cardinality agreement: rc_vs_rcb_union is %v, len(hashi) is %v", rc_vs_rcb_union.getCardinality(), len(hashi))
-				So(rc_vs_bc_union.getCardinality(), ShouldEqual, len(hashi))
-				So(rc_vs_ac_union.getCardinality(), ShouldEqual, len(hashi))
-				So(rc_vs_rcb_union.getCardinality(), ShouldEqual, len(hashi))
+				p("checking for cardinality agreement: rcVsBcUnion is %v, len(hashi) is %v", rcVsBcUnion.getCardinality(), len(hashi))
+				p("checking for cardinality agreement: rcVsAcUnion is %v, len(hashi) is %v", rcVsAcUnion.getCardinality(), len(hashi))
+				p("checking for cardinality agreement: rcVsRcbUnion is %v, len(hashi) is %v", rcVsRcbUnion.getCardinality(), len(hashi))
+				So(rcVsBcUnion.getCardinality(), ShouldEqual, len(hashi))
+				So(rcVsAcUnion.getCardinality(), ShouldEqual, len(hashi))
+				So(rcVsRcbUnion.getCardinality(), ShouldEqual, len(hashi))
 			}
 			p("done with randomized or() vs bitmapContainer and arrayContainer checks for trial %#v", tr)
 		}
@@ -267,9 +267,9 @@ func TestRle16RandomInplaceUnionAgainstOtherContainers012(t *testing.T) {
 
 				p("rc from a is %v", rc)
 
-				rc_vs_bc_union := rc.Clone()
-				rc_vs_ac_union := rc.Clone()
-				rc_vs_rcb_union := rc.Clone()
+				rcVsBcUnion := rc.Clone()
+				rcVsAcUnion := rc.Clone()
+				rcVsRcbUnion := rc.Clone()
 
 				// vs bitmapContainer
 				bc := newBitmapContainer()
@@ -286,33 +286,33 @@ func TestRle16RandomInplaceUnionAgainstOtherContainers012(t *testing.T) {
 				// vs runContainer
 				rcb := newRunContainer16FromVals(false, b...)
 
-				rc_vs_bc_union.ior(bc)
-				rc_vs_ac_union.ior(ac)
-				rc_vs_rcb_union.ior(rcb)
+				rcVsBcUnion.ior(bc)
+				rcVsAcUnion.ior(ac)
+				rcVsRcbUnion.ior(rcb)
 
-				p("rc_vs_bc_union is %v", rc_vs_bc_union)
-				p("rc_vs_ac_union is %v", rc_vs_ac_union)
-				p("rc_vs_rcb_union is %v", rc_vs_rcb_union)
+				p("rcVsBcUnion is %v", rcVsBcUnion)
+				p("rcVsAcUnion is %v", rcVsAcUnion)
+				p("rcVsRcbUnion is %v", rcVsRcbUnion)
 
 				//showHash("hashi", hashi)
 
 				for k := range hashi {
-					p("hashi has %v, checking in rc_vs_bc_union", k)
-					So(rc_vs_bc_union.contains(uint16(k)), ShouldBeTrue)
+					p("hashi has %v, checking in rcVsBcUnion", k)
+					So(rcVsBcUnion.contains(uint16(k)), ShouldBeTrue)
 
-					p("hashi has %v, checking in rc_vs_ac_union", k)
-					So(rc_vs_ac_union.contains(uint16(k)), ShouldBeTrue)
+					p("hashi has %v, checking in rcVsAcUnion", k)
+					So(rcVsAcUnion.contains(uint16(k)), ShouldBeTrue)
 
-					p("hashi has %v, checking in rc_vs_rcb_union", k)
-					So(rc_vs_rcb_union.contains(uint16(k)), ShouldBeTrue)
+					p("hashi has %v, checking in rcVsRcbUnion", k)
+					So(rcVsRcbUnion.contains(uint16(k)), ShouldBeTrue)
 				}
 
-				p("checking for cardinality agreement: rc_vs_bc_union is %v, len(hashi) is %v", rc_vs_bc_union.getCardinality(), len(hashi))
-				p("checking for cardinality agreement: rc_vs_ac_union is %v, len(hashi) is %v", rc_vs_ac_union.getCardinality(), len(hashi))
-				p("checking for cardinality agreement: rc_vs_rcb_union is %v, len(hashi) is %v", rc_vs_rcb_union.getCardinality(), len(hashi))
-				So(rc_vs_bc_union.getCardinality(), ShouldEqual, len(hashi))
-				So(rc_vs_ac_union.getCardinality(), ShouldEqual, len(hashi))
-				So(rc_vs_rcb_union.getCardinality(), ShouldEqual, len(hashi))
+				p("checking for cardinality agreement: rcVsBcUnion is %v, len(hashi) is %v", rcVsBcUnion.getCardinality(), len(hashi))
+				p("checking for cardinality agreement: rcVsAcUnion is %v, len(hashi) is %v", rcVsAcUnion.getCardinality(), len(hashi))
+				p("checking for cardinality agreement: rcVsRcbUnion is %v, len(hashi) is %v", rcVsRcbUnion.getCardinality(), len(hashi))
+				So(rcVsBcUnion.getCardinality(), ShouldEqual, len(hashi))
+				So(rcVsAcUnion.getCardinality(), ShouldEqual, len(hashi))
+				So(rcVsRcbUnion.getCardinality(), ShouldEqual, len(hashi))
 			}
 			p("done with randomized or() vs bitmapContainer and arrayContainer checks for trial %#v", tr)
 		}
@@ -387,37 +387,37 @@ func TestRle16RandomInplaceIntersectAgainstOtherContainers014(t *testing.T) {
 				// vs runContainer
 				rcb := newRunContainer16FromVals(false, b...)
 
-				rc_vs_bc_isect := rc.Clone()
-				rc_vs_ac_isect := rc.Clone()
-				rc_vs_rcb_isect := rc.Clone()
+				rcVsBcIsect := rc.Clone()
+				rcVsAcIsect := rc.Clone()
+				rcVsRcbIsect := rc.Clone()
 
-				rc_vs_bc_isect.iand(bc)
-				rc_vs_ac_isect.iand(ac)
-				rc_vs_rcb_isect.iand(rcb)
+				rcVsBcIsect.iand(bc)
+				rcVsAcIsect.iand(ac)
+				rcVsRcbIsect.iand(rcb)
 
-				p("rc_vs_bc_isect is %v", rc_vs_bc_isect)
-				p("rc_vs_ac_isect is %v", rc_vs_ac_isect)
-				p("rc_vs_rcb_isect is %v", rc_vs_rcb_isect)
+				p("rcVsBcIsect is %v", rcVsBcIsect)
+				p("rcVsAcIsect is %v", rcVsAcIsect)
+				p("rcVsRcbIsect is %v", rcVsRcbIsect)
 
 				//showHash("hashi", hashi)
 
 				for k := range hashi {
-					p("hashi has %v, checking in rc_vs_bc_isect", k)
-					So(rc_vs_bc_isect.contains(uint16(k)), ShouldBeTrue)
+					p("hashi has %v, checking in rcVsBcIsect", k)
+					So(rcVsBcIsect.contains(uint16(k)), ShouldBeTrue)
 
-					p("hashi has %v, checking in rc_vs_ac_isect", k)
-					So(rc_vs_ac_isect.contains(uint16(k)), ShouldBeTrue)
+					p("hashi has %v, checking in rcVsAcIsect", k)
+					So(rcVsAcIsect.contains(uint16(k)), ShouldBeTrue)
 
-					p("hashi has %v, checking in rc_vs_rcb_isect", k)
-					So(rc_vs_rcb_isect.contains(uint16(k)), ShouldBeTrue)
+					p("hashi has %v, checking in rcVsRcbIsect", k)
+					So(rcVsRcbIsect.contains(uint16(k)), ShouldBeTrue)
 				}
 
-				p("checking for cardinality agreement: rc_vs_bc_isect is %v, len(hashi) is %v", rc_vs_bc_isect.getCardinality(), len(hashi))
-				p("checking for cardinality agreement: rc_vs_ac_isect is %v, len(hashi) is %v", rc_vs_ac_isect.getCardinality(), len(hashi))
-				p("checking for cardinality agreement: rc_vs_rcb_isect is %v, len(hashi) is %v", rc_vs_rcb_isect.getCardinality(), len(hashi))
-				So(rc_vs_bc_isect.getCardinality(), ShouldEqual, len(hashi))
-				So(rc_vs_ac_isect.getCardinality(), ShouldEqual, len(hashi))
-				So(rc_vs_rcb_isect.getCardinality(), ShouldEqual, len(hashi))
+				p("checking for cardinality agreement: rcVsBcIsect is %v, len(hashi) is %v", rcVsBcIsect.getCardinality(), len(hashi))
+				p("checking for cardinality agreement: rcVsAcIsect is %v, len(hashi) is %v", rcVsAcIsect.getCardinality(), len(hashi))
+				p("checking for cardinality agreement: rcVsRcbIsect is %v, len(hashi) is %v", rcVsRcbIsect.getCardinality(), len(hashi))
+				So(rcVsBcIsect.getCardinality(), ShouldEqual, len(hashi))
+				So(rcVsAcIsect.getCardinality(), ShouldEqual, len(hashi))
+				So(rcVsRcbIsect.getCardinality(), ShouldEqual, len(hashi))
 			}
 			p("done with randomized and() vs bitmapContainer and arrayContainer checks for trial %#v", tr)
 		}
@@ -577,33 +577,33 @@ func TestRle16RandomAndNot016(t *testing.T) {
 				// vs runContainer
 				rcb := newRunContainer16FromVals(false, b...)
 
-				rc_vs_bc_andnot := rc.andNot(bc)
-				rc_vs_ac_andnot := rc.andNot(ac)
-				rc_vs_rcb_andnot := rc.andNot(rcb)
+				rcVsBcAndnot := rc.andNot(bc)
+				rcVsAcAndnot := rc.andNot(ac)
+				rcVsRcbAndnot := rc.andNot(rcb)
 
-				p("rc_vs_bc_andnot is %v", rc_vs_bc_andnot)
-				p("rc_vs_ac_andnot is %v", rc_vs_ac_andnot)
-				p("rc_vs_rcb_andnot is %v", rc_vs_rcb_andnot)
+				p("rcVsBcAndnot is %v", rcVsBcAndnot)
+				p("rcVsAcAndnot is %v", rcVsAcAndnot)
+				p("rcVsRcbAndnot is %v", rcVsRcbAndnot)
 
 				//showHash("hashi", hashi)
 
 				for k := range hashi {
-					p("hashi has %v, checking in rc_vs_bc_andnot", k)
-					So(rc_vs_bc_andnot.contains(uint16(k)), ShouldBeTrue)
+					p("hashi has %v, checking in rcVsBcAndnot", k)
+					So(rcVsBcAndnot.contains(uint16(k)), ShouldBeTrue)
 
-					p("hashi has %v, checking in rc_vs_ac_andnot", k)
-					So(rc_vs_ac_andnot.contains(uint16(k)), ShouldBeTrue)
+					p("hashi has %v, checking in rcVsAcAndnot", k)
+					So(rcVsAcAndnot.contains(uint16(k)), ShouldBeTrue)
 
-					p("hashi has %v, checking in rc_vs_rcb_andnot", k)
-					So(rc_vs_rcb_andnot.contains(uint16(k)), ShouldBeTrue)
+					p("hashi has %v, checking in rcVsRcbAndnot", k)
+					So(rcVsRcbAndnot.contains(uint16(k)), ShouldBeTrue)
 				}
 
-				p("checking for cardinality agreement: rc_vs_bc_andnot is %v, len(hashi) is %v", rc_vs_bc_andnot.getCardinality(), len(hashi))
-				p("checking for cardinality agreement: rc_vs_ac_andnot is %v, len(hashi) is %v", rc_vs_ac_andnot.getCardinality(), len(hashi))
-				p("checking for cardinality agreement: rc_vs_rcb_andnot is %v, len(hashi) is %v", rc_vs_rcb_andnot.getCardinality(), len(hashi))
-				So(rc_vs_bc_andnot.getCardinality(), ShouldEqual, len(hashi))
-				So(rc_vs_ac_andnot.getCardinality(), ShouldEqual, len(hashi))
-				So(rc_vs_rcb_andnot.getCardinality(), ShouldEqual, len(hashi))
+				p("checking for cardinality agreement: rcVsBcAndnot is %v, len(hashi) is %v", rcVsBcAndnot.getCardinality(), len(hashi))
+				p("checking for cardinality agreement: rcVsAcAndnot is %v, len(hashi) is %v", rcVsAcAndnot.getCardinality(), len(hashi))
+				p("checking for cardinality agreement: rcVsRcbAndnot is %v, len(hashi) is %v", rcVsRcbAndnot.getCardinality(), len(hashi))
+				So(rcVsBcAndnot.getCardinality(), ShouldEqual, len(hashi))
+				So(rcVsAcAndnot.getCardinality(), ShouldEqual, len(hashi))
+				So(rcVsRcbAndnot.getCardinality(), ShouldEqual, len(hashi))
 			}
 			p("done with randomized andNot() vs bitmapContainer and arrayContainer checks for trial %#v", tr)
 		}
@@ -679,37 +679,37 @@ func TestRle16RandomInplaceAndNot017(t *testing.T) {
 				// vs runContainer
 				rcb := newRunContainer16FromVals(false, b...)
 
-				rc_vs_bc_iandnot := rc.Clone()
-				rc_vs_ac_iandnot := rc.Clone()
-				rc_vs_rcb_iandnot := rc.Clone()
+				rcVsBcIandnot := rc.Clone()
+				rcVsAcIandnot := rc.Clone()
+				rcVsRcbIandnot := rc.Clone()
 
-				rc_vs_bc_iandnot.iandNot(bc)
-				rc_vs_ac_iandnot.iandNot(ac)
-				rc_vs_rcb_iandnot.iandNot(rcb)
+				rcVsBcIandnot.iandNot(bc)
+				rcVsAcIandnot.iandNot(ac)
+				rcVsRcbIandnot.iandNot(rcb)
 
-				p("rc_vs_bc_iandnot is %v", rc_vs_bc_iandnot)
-				p("rc_vs_ac_iandnot is %v", rc_vs_ac_iandnot)
-				p("rc_vs_rcb_iandnot is %v", rc_vs_rcb_iandnot)
+				p("rcVsBcIandnot is %v", rcVsBcIandnot)
+				p("rcVsAcIandnot is %v", rcVsAcIandnot)
+				p("rcVsRcbIandnot is %v", rcVsRcbIandnot)
 
 				//showHash("hashi", hashi)
 
 				for k := range hashi {
-					p("hashi has %v, checking in rc_vs_bc_iandnot", k)
-					So(rc_vs_bc_iandnot.contains(uint16(k)), ShouldBeTrue)
+					p("hashi has %v, checking in rcVsBcIandnot", k)
+					So(rcVsBcIandnot.contains(uint16(k)), ShouldBeTrue)
 
-					p("hashi has %v, checking in rc_vs_ac_iandnot", k)
-					So(rc_vs_ac_iandnot.contains(uint16(k)), ShouldBeTrue)
+					p("hashi has %v, checking in rcVsAcIandnot", k)
+					So(rcVsAcIandnot.contains(uint16(k)), ShouldBeTrue)
 
-					p("hashi has %v, checking in rc_vs_rcb_iandnot", k)
-					So(rc_vs_rcb_iandnot.contains(uint16(k)), ShouldBeTrue)
+					p("hashi has %v, checking in rcVsRcbIandnot", k)
+					So(rcVsRcbIandnot.contains(uint16(k)), ShouldBeTrue)
 				}
 
-				p("checking for cardinality agreement: rc_vs_bc_iandnot is %v, len(hashi) is %v", rc_vs_bc_iandnot.getCardinality(), len(hashi))
-				p("checking for cardinality agreement: rc_vs_ac_iandnot is %v, len(hashi) is %v", rc_vs_ac_iandnot.getCardinality(), len(hashi))
-				p("checking for cardinality agreement: rc_vs_rcb_iandnot is %v, len(hashi) is %v", rc_vs_rcb_iandnot.getCardinality(), len(hashi))
-				So(rc_vs_bc_iandnot.getCardinality(), ShouldEqual, len(hashi))
-				So(rc_vs_ac_iandnot.getCardinality(), ShouldEqual, len(hashi))
-				So(rc_vs_rcb_iandnot.getCardinality(), ShouldEqual, len(hashi))
+				p("checking for cardinality agreement: rcVsBcIandnot is %v, len(hashi) is %v", rcVsBcIandnot.getCardinality(), len(hashi))
+				p("checking for cardinality agreement: rcVsAcIandnot is %v, len(hashi) is %v", rcVsAcIandnot.getCardinality(), len(hashi))
+				p("checking for cardinality agreement: rcVsRcbIandnot is %v, len(hashi) is %v", rcVsRcbIandnot.getCardinality(), len(hashi))
+				So(rcVsBcIandnot.getCardinality(), ShouldEqual, len(hashi))
+				So(rcVsAcIandnot.getCardinality(), ShouldEqual, len(hashi))
+				So(rcVsRcbIandnot.getCardinality(), ShouldEqual, len(hashi))
 			}
 			p("done with randomized andNot() vs bitmapContainer and arrayContainer checks for trial %#v", tr)
 		}

--- a/rlei_test.go
+++ b/rlei_test.go
@@ -10,6 +10,21 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
+// showHash utility really only used in testing
+func showHash(name string, h map[int]bool) {
+	hv := []int{}
+	for k := range h {
+		hv = append(hv, k)
+	}
+	sort.Sort(sort.IntSlice(hv))
+	stringH := ""
+	for i := range hv {
+		stringH += fmt.Sprintf("%v, ", hv[i])
+	}
+
+	fmt.Printf("%s is (len %v): %s", name, len(h), stringH)
+}
+
 func TestRle16RandomIntersectAgainstOtherContainers010(t *testing.T) {
 
 	Convey("runContainer16 `and` operation against other container types should correctly do the intersection", t, func() {

--- a/roaring.go
+++ b/roaring.go
@@ -46,7 +46,7 @@ func (rb *Bitmap) WriteTo(stream io.Writer) (int64, error) {
 	return rb.highlowcontainer.writeTo(stream)
 }
 
-// WriteTo writes a msgpack2/snappy-streaming compressed serialized
+// WriteToMsgpack writes a msgpack2/snappy-streaming compressed serialized
 // version of this bitmap to stream. The format is not
 // compatible with the WriteTo() format, and is
 // experimental: it may produce smaller on disk
@@ -1161,6 +1161,7 @@ func FlipInt(bm *Bitmap, rangeStart, rangeEnd int) *Bitmap {
 	return Flip(bm, uint64(rangeStart), uint64(rangeEnd))
 }
 
+// Statistics provides details on the container types in use.
 type Statistics struct {
 	Cardinality uint64
 	Containers  uint64
@@ -1178,23 +1179,24 @@ type Statistics struct {
 	RunContainerValues uint64
 }
 
-func (bm *Bitmap) Stats() Statistics {
+// Stats returns details on container type usage in a Statistics struct.
+func (rb *Bitmap) Stats() Statistics {
 	stats := Statistics{}
-	stats.Containers = uint64(len(bm.highlowcontainer.containers))
-	for _, c := range bm.highlowcontainer.containers {
+	stats.Containers = uint64(len(rb.highlowcontainer.containers))
+	for _, c := range rb.highlowcontainer.containers {
 		stats.Cardinality += uint64(c.getCardinality())
 
 		switch c.(type) {
 		case *arrayContainer:
-			stats.ArrayContainers += 1
+			stats.ArrayContainers++
 			stats.ArrayContainerBytes += uint64(c.getSizeInBytes())
 			stats.ArrayContainerValues += uint64(c.getCardinality())
 		case *bitmapContainer:
-			stats.BitmapContainers += 1
+			stats.BitmapContainers++
 			stats.BitmapContainerBytes += uint64(c.getSizeInBytes())
 			stats.BitmapContainerValues += uint64(c.getCardinality())
 		case *runContainer16:
-			stats.RunContainers += 1
+			stats.RunContainers++
 			stats.RunContainerBytes += uint64(c.getSizeInBytes())
 			stats.RunContainerValues += uint64(c.getCardinality())
 		}

--- a/roaring.go
+++ b/roaring.go
@@ -38,18 +38,29 @@ func (rb *Bitmap) FromBase64(str string) (int64, error) {
 	return rb.ReadFrom(buf)
 }
 
-// WriteTo writes a serialized version of this bitmap to stream
+// WriteTo writes a serialized version of this bitmap to stream.
+// The format is compatible with other RoaringBitmap
+// implementations (Java, C) and is documented here:
+// https://github.com/RoaringBitmap/RoaringFormatSpec
 func (rb *Bitmap) WriteTo(stream io.Writer) (int64, error) {
 	return rb.highlowcontainer.writeTo(stream)
 }
 
 // WriteTo writes a msgpack2/snappy-streaming compressed serialized
-// version of this bitmap to stream
+// version of this bitmap to stream. The format is not
+// compatible with the WriteTo() format, and is
+// experimental: it may produce smaller on disk
+// footprint and/or be faster to read, depending
+// on your content. Currently only the Go roaring
+// implementation supports this format.
 func (rb *Bitmap) WriteToMsgpack(stream io.Writer) (int64, error) {
 	return 0, rb.highlowcontainer.writeToMsgpack(stream)
 }
 
-// ReadFrom reads a serialized version of this bitmap from stream
+// ReadFrom reads a serialized version of this bitmap from stream.
+// The format is compatible with other RoaringBitmap
+// implementations (Java, C) and is documented here:
+// https://github.com/RoaringBitmap/RoaringFormatSpec
 func (rb *Bitmap) ReadFrom(stream io.Reader) (int64, error) {
 	return rb.highlowcontainer.readFrom(stream)
 }
@@ -60,7 +71,9 @@ func (rb *Bitmap) RunOptimize() {
 }
 
 // ReadFromMsgpack reads a msgpack2/snappy-streaming serialized
-// version of this bitmap from stream
+// version of this bitmap from stream. The format is
+// expected is that written by the WriteToMsgpack()
+// call; see additional notes there.
 func (rb *Bitmap) ReadFromMsgpack(stream io.Reader) (int64, error) {
 	return 0, rb.highlowcontainer.readFromMsgpack(stream)
 }

--- a/roaringarray.go
+++ b/roaringarray.go
@@ -32,8 +32,8 @@ type container interface {
 	iremove(x uint16) bool                   // inplace, returns true if x was present.
 	iremoveReturnMinimized(uint16) container // may change return type to minimize storage.
 
-	not(start, final int) container               // range is [firstOfRange,lastOfRange)
-	inot(firstOfRange, lastOfRange int) container // i stands for inplace, range is [firstOfRange,lastOfRange)
+	not(start, final int) container        // range is [firstOfRange,lastOfRange)
+	inot(firstOfRange, endx int) container // i stands for inplace, range is [firstOfRange,endx)
 	xor(r container) container
 	getShortIterator() shortIterable
 	contains(i uint16) bool

--- a/roaringarray.go
+++ b/roaringarray.go
@@ -646,7 +646,7 @@ func (ra *roaringArray) writeToMsgpack(stream io.Writer) error {
 			ra.conserz[i].t = run16Contype
 			ra.conserz[i].r = bts
 		default:
-			fmt.Errorf("Unrecognized container implementation: %T", cn)
+			panic(fmt.Errorf("Unrecognized container implementation: %T", cn))
 		}
 	}
 	w := snappy.NewWriter(stream)

--- a/roaringarray.go
+++ b/roaringarray.go
@@ -27,7 +27,7 @@ type container interface {
 	iaddReturnMinimized(uint16) container // may change return type to minimize storage.
 
 	//addRange(start, final int) container  // range is [firstOfRange,lastOfRange) (unused)
-	iaddRange(start, final int) container // i stands for inplace, range is [firstOfRange,lastOfRange)
+	iaddRange(start, endx int) container // i stands for inplace, range is [firstOfRange,endx)
 
 	iremove(x uint16) bool                   // inplace, returns true if x was present.
 	iremoveReturnMinimized(uint16) container // may change return type to minimize storage.

--- a/serialization_test.go
+++ b/serialization_test.go
@@ -256,7 +256,7 @@ func TestSerializationBasic3_042(t *testing.T) {
 			case *runContainer16:
 				rc = true
 			default:
-				fmt.Errorf("Unrecognized container implementation: %T", cn)
+				panic(fmt.Errorf("Unrecognized container implementation: %T", cn))
 			}
 		}
 		if !bc {
@@ -561,7 +561,7 @@ func TestSerializationBasicMsgpack035(t *testing.T) {
 				rc = true
 				So(cn.containerType(), ShouldEqual, run16Contype)
 			default:
-				fmt.Errorf("Unrecognized container implementation: %T", cn)
+				panic(fmt.Errorf("Unrecognized container implementation: %T", cn))
 			}
 		}
 		if !bc {

--- a/util.go
+++ b/util.go
@@ -139,6 +139,7 @@ func flipBitmapRange(bitmap []uint64, start int, end int) {
 	endword := (end - 1) / 64
 	bitmap[firstword] ^= ^(^uint64(0) << uint(start%64))
 	for i := firstword; i < endword; i++ {
+		//p("flipBitmapRange on i=%v", i)
 		bitmap[i] = ^bitmap[i]
 	}
 	bitmap[endword] ^= ^uint64(0) >> (uint(-end) % 64)


### PR DESCRIPTION
Looking through the godoc (https://godoc.org/github.com/RoaringBitmap/roaring), I see that internal details like the RunIterator16 and RunIterator32 were left public, but should probably be private to not confuse those reading the docs. This PR makes them private, as runIterator32 and runIterator16.

In addition I added some detail to the godoc around the WriteToMsgpack/ReadFromMsgpack methods, and provided a pointer to the spec format for the WriteTo/ReadFrom docs.