### PR TITLE
Fix deserialization of empty bitmaps

### DIFF
--- a/roaringarray.go
+++ b/roaringarray.go
@@ -505,7 +505,7 @@ func (ra *roaringArray) readFrom(stream io.Reader) (int64, error) {
 	var isRun container = newRunContainer16()
 	if cookie&0x0000FFFF == serialCookie {
 		haveRunContainers = true
-		size = (cookie >> 16) + 1
+		size = uint32(uint16((cookie >> 16)) + 1)
 		//p("stream contains run containers. total number of containers == size = %v", size)
 		bytesToRead := (int(size) + 7) / 8
 		//p("bytesToRead = %v", bytesToRead)

--- a/serialization_test.go
+++ b/serialization_test.go
@@ -14,6 +14,27 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
+func TestSerializationOfEmptyBitmap(t *testing.T) {
+	rb := NewBitmap()
+
+	buf := &bytes.Buffer{}
+	_, err := rb.WriteTo(buf)
+	if err != nil {
+		t.Errorf("Failed writing")
+	}
+
+	newrb := NewBitmap()
+	_, err = newrb.ReadFrom(buf)
+	if err != nil {
+		t.Errorf("Failed reading: %v", err)
+	}
+	if !rb.Equals(newrb) {
+		p("rb = '%s'", rb)
+		p("but newrb = '%s'", newrb)
+		t.Errorf("Cannot retrieve serialized version; rb != newrb")
+	}
+}
+
 func TestBase64_036(t *testing.T) {
 	rb := BitmapOf(1, 2, 3, 4, 5, 100, 1000)
 


### PR DESCRIPTION
Cast size to an uint16 so it overflows correctly in the case where there
are 0 containers.

Without this change trying to deserialize an empty bitmap returns an error: `error in readFrom: could not read the runContainer bit flags of length 8192 bytes: EOF`

I'm not sure if this is the best fix, it seems like an empty bitmap is a bit of a grey area -- based on reading the format spec it sounds like there should always at least be 1 container. 