### PR TITLE
FastOr: force using bitmap containers

### DIFF
--- a/fastaggregation.go
+++ b/fastaggregation.go
@@ -32,8 +32,17 @@ main:
 				}
 				s2 = x2.highlowcontainer.getKeyAtIndex(pos2)
 			} else {
+				c1 := x1.highlowcontainer.getContainerAtIndex(pos1)
+				switch t := c1.(type) {
+				case *arrayContainer:
+					c1 = t.toBitmapContainer()
+				case *runContainer16:
+					if !t.isFull() {
+						c1 = t.toBitmapContainer()
+					}
+				}
 
-				answer.highlowcontainer.appendContainer(s1, x1.highlowcontainer.getContainerAtIndex(pos1).lazyOR(x2.highlowcontainer.getContainerAtIndex(pos2)), false)
+				answer.highlowcontainer.appendContainer(s1, c1.lazyOR(x2.highlowcontainer.getContainerAtIndex(pos2)), false)
 				pos1++
 				pos2++
 				if (pos1 == length1) || (pos2 == length2) {
@@ -80,8 +89,17 @@ main:
 				}
 				s2 = x2.highlowcontainer.getKeyAtIndex(pos2)
 			} else {
+				c1 := x1.highlowcontainer.getContainerAtIndex(pos1)
+				switch t := c1.(type) {
+				case *arrayContainer:
+					c1 = t.toBitmapContainer()
+				case *runContainer16:
+					if !t.isFull() {
+						c1 = t.toBitmapContainer()
+					}
+				}
 
-				answer.highlowcontainer.appendContainer(s1, x1.highlowcontainer.getWritableContainerAtIndex(pos1).lazyIOR(x2.highlowcontainer.getContainerAtIndex(pos2)), false)
+				answer.highlowcontainer.appendContainer(s1, c1.lazyIOR(x2.highlowcontainer.getContainerAtIndex(pos2)), false)
 				pos1++
 				pos2++
 				if (pos1 == length1) || (pos2 == length2) {


### PR DESCRIPTION
This change converts containers in `lazyOR` methods to bitmap containers when computing an intersection.

It follows a similar pattern found in Java's RoaringBitmap [RoaringBitmap.naivelazyor](https://github.com/RoaringBitmap/RoaringBitmap/blob/master/roaringbitmap/src/main/java/org/roaringbitmap/RoaringBitmap.java#L1628) method.

In our production case when using very wide unions this change improves performance significantly.

When evaluating an expression which consists of two wide unions (one of 161 bitmaps and another one of 144) the speed improvements was of a factor of x50.

Before:
```
and:497.120619ms, or:38.185436472s, andNot:12.385317ms
```

After:
```
and:30.566886ms, or:623.676526ms, andNot:10.220867ms
```

Sadly I cannot share the input bitmaps.