### PR TITLE
BitmapContainer invalidate cardinality on lazyIOR with RunContainer

### DIFF
--- a/bitmapcontainer.go
+++ b/bitmapcontainer.go
@@ -352,6 +352,7 @@ func (bc *bitmapContainer) lazyIOR(a container) container {
 			setBitmapRange(bc.bitmap, int(x.iv[i].start), int(x.iv[i].last)+1)
 			//bc.iaddRange(int(x.iv[i].start), int(x.iv[i].last)+1)
 		}
+		bc.cardinality = invalidCardinality
 		//bc.computeCardinality()
 		return bc
 	}


### PR DESCRIPTION
Fixes a bug where BitmapContainer.lazyIOR(RunContainer) resulted in invalid cardinality of the returned container.