### PR TITLE
Parallel roaring bitmaps

### DIFF
--- a/parallel.go
+++ b/parallel.go
@@ -177,6 +177,13 @@ func appenderRoutine(bitmapChan chan<- *Bitmap, resultChan <-chan keyedContainer
 }
 
 func ParOr(bitmaps ...*Bitmap) *Bitmap {
+	bitmapCount := len(bitmaps)
+	if bitmapCount == 0 {
+		return NewBitmap()
+	} else if bitmapCount == 1 {
+		return bitmaps[0].Clone()
+	}
+
 	h := newBitmapContainerHeap(bitmaps...)
 
 	bitmapChan := make(chan *Bitmap)
@@ -235,6 +242,11 @@ func ParOr(bitmaps ...*Bitmap) *Bitmap {
 
 func ParAnd(bitmaps ...*Bitmap) *Bitmap {
 	bitmapCount := len(bitmaps)
+	if bitmapCount == 0 {
+		return NewBitmap()
+	} else if bitmapCount == 1 {
+		return bitmaps[0].Clone()
+	}
 
 	h := newBitmapContainerHeap(bitmaps...)
 

--- a/parallel.go
+++ b/parallel.go
@@ -1,0 +1,284 @@
+package roaring
+
+import (
+	"container/heap"
+	"runtime"
+)
+
+var defaultWorkerCount = runtime.NumCPU()
+
+type bitmapContainerKey struct {
+	bitmap    *Bitmap
+	container container
+	key       uint16
+	idx       int
+}
+
+type multipleContainers struct {
+	key        uint16
+	containers []container
+	idx        int
+}
+
+type keyedContainer struct {
+	key       uint16
+	container container
+	idx       int
+}
+
+type bitmapContainerHeap []bitmapContainerKey
+
+func (h bitmapContainerHeap) Len() int           { return len(h) }
+func (h bitmapContainerHeap) Less(i, j int) bool { return h[i].key < h[j].key }
+func (h bitmapContainerHeap) Swap(i, j int)      { h[i], h[j] = h[j], h[i] }
+
+func (h *bitmapContainerHeap) Push(x interface{}) {
+	// Push and Pop use pointer receivers because they modify the slice's length,
+	// not just its contents.
+	*h = append(*h, x.(bitmapContainerKey))
+}
+
+func (h *bitmapContainerHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[0 : n-1]
+	return x
+}
+
+func (h bitmapContainerHeap) Peek() bitmapContainerKey {
+	return h[0]
+}
+
+func (h *bitmapContainerHeap) PopIncrementing() bitmapContainerKey {
+	k := h.Peek()
+
+	newIdx := k.idx + 1
+	if newIdx < k.bitmap.highlowcontainer.size() {
+		newKey := bitmapContainerKey{
+			k.bitmap,
+			k.bitmap.highlowcontainer.getWritableContainerAtIndex(newIdx),
+			k.bitmap.highlowcontainer.keys[newIdx],
+			newIdx,
+		}
+		(*h)[0] = newKey
+		heap.Fix(h, 0)
+	} else {
+		heap.Pop(h)
+	}
+	return k
+}
+
+func (h *bitmapContainerHeap) PopNextContainers() multipleContainers {
+	if h.Len() == 0 {
+		return multipleContainers{}
+	}
+
+	containers := make([]container, 0, 4)
+	bk := h.PopIncrementing()
+	containers = append(containers, bk.container)
+	key := bk.key
+
+	for h.Len() > 0 && key == h.Peek().key {
+		bk = h.PopIncrementing()
+		containers = append(containers, bk.container)
+	}
+
+	return multipleContainers{
+		key,
+		containers,
+		-1,
+	}
+}
+
+func newBitmapContainerHeap(bitmaps ...*Bitmap) bitmapContainerHeap {
+	// Initialize heap
+	var h bitmapContainerHeap = make([]bitmapContainerKey, 0, len(bitmaps))
+	for _, bitmap := range bitmaps {
+		if !bitmap.IsEmpty() {
+			key := bitmapContainerKey{
+				bitmap,
+				bitmap.highlowcontainer.getWritableContainerAtIndex(0),
+				bitmap.highlowcontainer.keys[0],
+				0,
+			}
+			h = append(h, key)
+		}
+	}
+
+	heap.Init(&h)
+
+	return h
+}
+
+func repairAfterLazy(c container) container {
+	switch t := c.(type) {
+	case *bitmapContainer:
+		if t.cardinality == invalidCardinality {
+			t.computeCardinality()
+		}
+
+		if t.getCardinality() <= arrayDefaultMaxSize {
+			return t.toArrayContainer()
+		} else if c.(*bitmapContainer).isFull() {
+			return newRunContainer16Range(0, MaxUint16)
+		}
+	}
+
+	return c
+}
+
+func toBitmapContainer(c container) container {
+	switch t := c.(type) {
+	case *arrayContainer:
+		return t.toBitmapContainer()
+	case *runContainer16:
+		if !t.isFull() {
+			return t.toBitmapContainer()
+		}
+	}
+	return c
+}
+
+func appenderRoutine(bitmapChan chan<- *Bitmap, resultChan <-chan keyedContainer, expectedKeysChan <-chan int) {
+	expectedKeys := -1
+	appendedKeys := 0
+	keys := make([]uint16, 0)
+	containers := make([]container, 0)
+	for appendedKeys != expectedKeys {
+		select {
+		case item := <-resultChan:
+			if len(keys) <= item.idx {
+				keys = append(keys, make([]uint16, item.idx-len(keys)+1)...)
+				containers = append(containers, make([]container, item.idx-len(containers)+1)...)
+			}
+			keys[item.idx] = item.key
+			containers[item.idx] = item.container
+
+			appendedKeys += 1
+		case msg := <-expectedKeysChan:
+			expectedKeys = msg
+		}
+	}
+	answer := &Bitmap{
+		roaringArray{
+			make([]uint16, 0, expectedKeys),
+			make([]container, 0, expectedKeys),
+			make([]bool, 0, expectedKeys),
+			false,
+			nil,
+		},
+	}
+	for i := range keys {
+		answer.highlowcontainer.appendContainer(keys[i], containers[i], false)
+	}
+
+	bitmapChan <- answer
+}
+
+func ParOr(bitmaps ...*Bitmap) *Bitmap {
+	h := newBitmapContainerHeap(bitmaps...)
+
+	bitmapChan := make(chan *Bitmap)
+	inputChan := make(chan multipleContainers, 128)
+	resultChan := make(chan keyedContainer, 32)
+	expectedKeysChan := make(chan int)
+
+	orFunc := func() {
+		for input := range inputChan {
+			c := toBitmapContainer(input.containers[0]).lazyOR(input.containers[1])
+			for _, next := range input.containers[2:] {
+				c = c.lazyIOR(next)
+			}
+			c = repairAfterLazy(c)
+			kx := keyedContainer{
+				input.key,
+				c,
+				input.idx,
+			}
+			resultChan <- kx
+		}
+	}
+
+	go appenderRoutine(bitmapChan, resultChan, expectedKeysChan)
+
+	for i := 0; i < defaultWorkerCount; i++ {
+		go orFunc()
+	}
+
+	idx := 0
+	for h.Len() > 0 {
+		ck := h.PopNextContainers()
+		if len(ck.containers) == 1 {
+			resultChan <- keyedContainer{
+				ck.key,
+				ck.containers[0],
+				idx,
+			}
+		} else {
+			ck.idx = idx
+			inputChan <- ck
+		}
+		idx++
+	}
+	expectedKeysChan <- idx
+
+	bitmap := <-bitmapChan
+
+	close(inputChan)
+	close(resultChan)
+	close(expectedKeysChan)
+
+	return bitmap
+}
+
+func ParAnd(bitmaps ...*Bitmap) *Bitmap {
+	bitmapCount := len(bitmaps)
+
+	h := newBitmapContainerHeap(bitmaps...)
+
+	bitmapChan := make(chan *Bitmap)
+	inputChan := make(chan multipleContainers, 128)
+	resultChan := make(chan keyedContainer, 32)
+	expectedKeysChan := make(chan int)
+
+	andFunc := func() {
+		for input := range inputChan {
+			c := input.containers[0].and(input.containers[1])
+			for _, next := range input.containers[2:] {
+				c = c.iand(next)
+			}
+			kx := keyedContainer{
+				input.key,
+				c,
+				input.idx,
+			}
+			resultChan <- kx
+		}
+	}
+
+	go appenderRoutine(bitmapChan, resultChan, expectedKeysChan)
+
+	for i := 0; i < defaultWorkerCount; i++ {
+		go andFunc()
+	}
+
+	idx := 0
+	for h.Len() > 0 {
+		ck := h.PopNextContainers()
+		if len(ck.containers) == bitmapCount {
+			ck.idx = idx
+			inputChan <- ck
+			idx++
+		}
+	}
+	expectedKeysChan <- idx
+
+	bitmap := <-bitmapChan
+
+	close(inputChan)
+	close(resultChan)
+	close(expectedKeysChan)
+
+	return bitmap
+}

--- a/parallel.go
+++ b/parallel.go
@@ -185,6 +185,7 @@ func ParOr(bitmaps ...*Bitmap) *Bitmap {
 	expectedKeysChan := make(chan int)
 
 	orFunc := func() {
+		// Assumes only structs with >=2 containers are passed
 		for input := range inputChan {
 			c := toBitmapContainer(input.containers[0]).lazyOR(input.containers[1])
 			for _, next := range input.containers[2:] {
@@ -243,6 +244,7 @@ func ParAnd(bitmaps ...*Bitmap) *Bitmap {
 	expectedKeysChan := make(chan int)
 
 	andFunc := func() {
+		// Assumes only structs with >=2 containers are passed
 		for input := range inputChan {
 			c := input.containers[0].and(input.containers[1])
 			for _, next := range input.containers[2:] {

--- a/parallel.go
+++ b/parallel.go
@@ -176,12 +176,16 @@ func appenderRoutine(bitmapChan chan<- *Bitmap, resultChan <-chan keyedContainer
 	bitmapChan <- answer
 }
 
-func ParOr(bitmaps ...*Bitmap) *Bitmap {
+func ParOr(parallelism int, bitmaps ...*Bitmap) *Bitmap {
 	bitmapCount := len(bitmaps)
 	if bitmapCount == 0 {
 		return NewBitmap()
 	} else if bitmapCount == 1 {
 		return bitmaps[0].Clone()
+	}
+
+	if parallelism == 0 {
+		parallelism = defaultWorkerCount
 	}
 
 	h := newBitmapContainerHeap(bitmaps...)
@@ -210,7 +214,7 @@ func ParOr(bitmaps ...*Bitmap) *Bitmap {
 
 	go appenderRoutine(bitmapChan, resultChan, expectedKeysChan)
 
-	for i := 0; i < defaultWorkerCount; i++ {
+	for i := 0; i < parallelism; i++ {
 		go orFunc()
 	}
 
@@ -240,12 +244,16 @@ func ParOr(bitmaps ...*Bitmap) *Bitmap {
 	return bitmap
 }
 
-func ParAnd(bitmaps ...*Bitmap) *Bitmap {
+func ParAnd(parallelism int, bitmaps ...*Bitmap) *Bitmap {
 	bitmapCount := len(bitmaps)
 	if bitmapCount == 0 {
 		return NewBitmap()
 	} else if bitmapCount == 1 {
 		return bitmaps[0].Clone()
+	}
+
+	if parallelism == 0 {
+		parallelism = defaultWorkerCount
 	}
 
 	h := newBitmapContainerHeap(bitmaps...)
@@ -273,7 +281,7 @@ func ParAnd(bitmaps ...*Bitmap) *Bitmap {
 
 	go appenderRoutine(bitmapChan, resultChan, expectedKeysChan)
 
-	for i := 0; i < defaultWorkerCount; i++ {
+	for i := 0; i < parallelism; i++ {
 		go andFunc()
 	}
 

--- a/parallel_benchmark_test.go
+++ b/parallel_benchmark_test.go
@@ -1,0 +1,57 @@
+package roaring
+
+import (
+	"math/rand"
+	"testing"
+)
+
+func BenchmarkIntersectionLargeParallel(b *testing.B) {
+	b.StopTimer()
+
+	initsize := 650000
+	r := rand.New(rand.NewSource(0))
+
+	s1 := NewBitmap()
+	sz := 150 * 1000 * 1000
+	for i := 0; i < initsize; i++ {
+		s1.Add(uint32(r.Int31n(int32(sz))))
+	}
+
+	s2 := NewBitmap()
+	sz = 100 * 1000 * 1000
+	for i := 0; i < initsize; i++ {
+		s2.Add(uint32(r.Int31n(int32(sz))))
+	}
+
+	b.StartTimer()
+	card := uint64(0)
+	for j := 0; j < b.N; j++ {
+		s3 := ParAnd(s1, s2)
+		card = card + s3.GetCardinality()
+	}
+}
+
+func BenchmarkIntersectionLargeRoaring(b *testing.B) {
+	b.StopTimer()
+	initsize := 650000
+	r := rand.New(rand.NewSource(0))
+
+	s1 := NewBitmap()
+	sz := 150 * 1000 * 1000
+	for i := 0; i < initsize; i++ {
+		s1.Add(uint32(r.Int31n(int32(sz))))
+	}
+
+	s2 := NewBitmap()
+	sz = 100 * 1000 * 1000
+	for i := 0; i < initsize; i++ {
+		s2.Add(uint32(r.Int31n(int32(sz))))
+	}
+
+	b.StartTimer()
+	card := uint64(0)
+	for j := 0; j < b.N; j++ {
+		s3 := And(s1, s2)
+		card = card + s3.GetCardinality()
+	}
+}

--- a/parallel_benchmark_test.go
+++ b/parallel_benchmark_test.go
@@ -26,7 +26,7 @@ func BenchmarkIntersectionLargeParallel(b *testing.B) {
 	b.StartTimer()
 	card := uint64(0)
 	for j := 0; j < b.N; j++ {
-		s3 := ParAnd(s1, s2)
+		s3 := ParAnd(0, s1, s2)
 		card = card + s3.GetCardinality()
 	}
 }

--- a/parallel_test.go
+++ b/parallel_test.go
@@ -26,6 +26,15 @@ func TestParAggregationsNothing(t *testing.T) {
 	})
 }
 
+func TestParAggregationsOneBitmap(t *testing.T) {
+	Convey("Par", t, func() {
+		rb := BitmapOf(1, 2, 3)
+
+		So(ParAnd(rb).GetCardinality(), ShouldEqual, 3)
+		So(ParOr(rb).GetCardinality(), ShouldEqual, 3)
+	})
+}
+
 func TestParAggregationsOneEmpty(t *testing.T) {
 	Convey("Par", t, func() {
 		rb1 := NewBitmap()

--- a/parallel_test.go
+++ b/parallel_test.go
@@ -14,15 +14,15 @@ func TestParAggregations(t *testing.T) {
 		rb1.Add(1)
 		rb2.Add(2)
 
-		So(ParAnd(rb1, rb2).GetCardinality(), ShouldEqual, 0)
-		So(ParOr(rb1, rb2).GetCardinality(), ShouldEqual, 2)
+		So(ParAnd(0, rb1, rb2).GetCardinality(), ShouldEqual, 0)
+		So(ParOr(0, rb1, rb2).GetCardinality(), ShouldEqual, 2)
 	})
 }
 
 func TestParAggregationsNothing(t *testing.T) {
 	Convey("Par", t, func() {
-		So(ParAnd().GetCardinality(), ShouldEqual, 0)
-		So(ParOr().GetCardinality(), ShouldEqual, 0)
+		So(ParAnd(0).GetCardinality(), ShouldEqual, 0)
+		So(ParOr(0).GetCardinality(), ShouldEqual, 0)
 	})
 }
 
@@ -30,8 +30,8 @@ func TestParAggregationsOneBitmap(t *testing.T) {
 	Convey("Par", t, func() {
 		rb := BitmapOf(1, 2, 3)
 
-		So(ParAnd(rb).GetCardinality(), ShouldEqual, 3)
-		So(ParOr(rb).GetCardinality(), ShouldEqual, 3)
+		So(ParAnd(0, rb).GetCardinality(), ShouldEqual, 3)
+		So(ParOr(0, rb).GetCardinality(), ShouldEqual, 3)
 	})
 }
 
@@ -41,8 +41,8 @@ func TestParAggregationsOneEmpty(t *testing.T) {
 		rb2 := NewBitmap()
 		rb1.Add(1)
 
-		So(ParAnd(rb1, rb2).GetCardinality(), ShouldEqual, 0)
-		So(ParOr(rb1, rb2).GetCardinality(), ShouldEqual, 1)
+		So(ParAnd(0, rb1, rb2).GetCardinality(), ShouldEqual, 0)
+		So(ParOr(0, rb1, rb2).GetCardinality(), ShouldEqual, 1)
 	})
 }
 
@@ -60,8 +60,8 @@ func TestParAggregationsReversed3COW(t *testing.T) {
 		rb3.Add(1)
 		rb3.Add(300000)
 
-		So(ParAnd(rb2, rb1, rb3).GetCardinality(), ShouldEqual, 0)
-		So(ParOr(rb2, rb1, rb3).GetCardinality(), ShouldEqual, 4)
+		So(ParAnd(0, rb2, rb1, rb3).GetCardinality(), ShouldEqual, 0)
+		So(ParOr(0, rb2, rb1, rb3).GetCardinality(), ShouldEqual, 4)
 	})
 }
 
@@ -76,8 +76,8 @@ func TestParAggregationsReversed3(t *testing.T) {
 		rb3.Add(1)
 		rb3.Add(300000)
 
-		So(ParAnd(rb2, rb1, rb3).GetCardinality(), ShouldEqual, 0)
-		So(ParOr(rb2, rb1, rb3).GetCardinality(), ShouldEqual, 4)
+		So(ParAnd(0, rb2, rb1, rb3).GetCardinality(), ShouldEqual, 0)
+		So(ParOr(0, rb2, rb1, rb3).GetCardinality(), ShouldEqual, 4)
 	})
 }
 
@@ -92,8 +92,8 @@ func TestParAggregations3(t *testing.T) {
 		rb3.Add(1)
 		rb3.Add(300000)
 
-		So(ParAnd(rb1, rb2, rb3).GetCardinality(), ShouldEqual, 0)
-		So(ParOr(rb1, rb2, rb3).GetCardinality(), ShouldEqual, 4)
+		So(ParAnd(0, rb1, rb2, rb3).GetCardinality(), ShouldEqual, 0)
+		So(ParOr(0, rb1, rb2, rb3).GetCardinality(), ShouldEqual, 4)
 	})
 }
 
@@ -111,8 +111,8 @@ func TestParAggregations3COW(t *testing.T) {
 		rb3.Add(1)
 		rb3.Add(300000)
 
-		So(ParAnd(rb1, rb2, rb3).GetCardinality(), ShouldEqual, 0)
-		So(ParOr(rb1, rb2, rb3).GetCardinality(), ShouldEqual, 4)
+		So(ParAnd(0, rb1, rb2, rb3).GetCardinality(), ShouldEqual, 0)
+		So(ParOr(0, rb1, rb2, rb3).GetCardinality(), ShouldEqual, 4)
 	})
 }
 
@@ -142,8 +142,8 @@ func TestParAggregationsAdvanced(t *testing.T) {
 		rb1.Or(rb2)
 		rb1.Or(rb3)
 		bigand := And(And(rb1, rb2), rb3)
-		So(ParOr(rb1, rb2, rb3).Equals(rb1), ShouldEqual, true)
-		So(ParAnd(rb1, rb2, rb3).Equals(bigand), ShouldEqual, true)
+		So(ParOr(0, rb1, rb2, rb3).Equals(rb1), ShouldEqual, true)
+		So(ParAnd(0, rb1, rb2, rb3).Equals(bigand), ShouldEqual, true)
 	})
 }
 
@@ -174,7 +174,7 @@ func TestParAggregationsAdvanced_run(t *testing.T) {
 		rb1.Or(rb2)
 		rb1.Or(rb3)
 		bigand := And(And(rb1, rb2), rb3)
-		So(ParOr(rb1, rb2, rb3).Equals(rb1), ShouldEqual, true)
-		So(ParAnd(rb1, rb2, rb3).Equals(bigand), ShouldEqual, true)
+		So(ParOr(0, rb1, rb2, rb3).Equals(rb1), ShouldEqual, true)
+		So(ParAnd(0, rb1, rb2, rb3).Equals(bigand), ShouldEqual, true)
 	})
 }

--- a/parallel_test.go
+++ b/parallel_test.go
@@ -1,0 +1,171 @@
+package roaring
+
+// to run just these tests: go test -run TestParAggregations*
+
+import (
+	. "github.com/smartystreets/goconvey/convey"
+	"testing"
+)
+
+func TestParAggregations(t *testing.T) {
+	Convey("Par", t, func() {
+		rb1 := NewBitmap()
+		rb2 := NewBitmap()
+		rb1.Add(1)
+		rb2.Add(2)
+
+		So(ParAnd(rb1, rb2).GetCardinality(), ShouldEqual, 0)
+		So(ParOr(rb1, rb2).GetCardinality(), ShouldEqual, 2)
+	})
+}
+
+func TestParAggregationsNothing(t *testing.T) {
+	Convey("Par", t, func() {
+		So(ParAnd().GetCardinality(), ShouldEqual, 0)
+		So(ParOr().GetCardinality(), ShouldEqual, 0)
+	})
+}
+
+func TestParAggregationsOneEmpty(t *testing.T) {
+	Convey("Par", t, func() {
+		rb1 := NewBitmap()
+		rb2 := NewBitmap()
+		rb1.Add(1)
+
+		So(ParAnd(rb1, rb2).GetCardinality(), ShouldEqual, 0)
+		So(ParOr(rb1, rb2).GetCardinality(), ShouldEqual, 1)
+	})
+}
+
+func TestParAggregationsReversed3COW(t *testing.T) {
+	Convey("Par", t, func() {
+		rb1 := NewBitmap()
+		rb2 := NewBitmap()
+		rb3 := NewBitmap()
+		rb1.SetCopyOnWrite(true)
+		rb2.SetCopyOnWrite(true)
+		rb3.SetCopyOnWrite(true)
+		rb1.Add(1)
+		rb1.Add(100000)
+		rb2.Add(200000)
+		rb3.Add(1)
+		rb3.Add(300000)
+
+		So(ParAnd(rb2, rb1, rb3).GetCardinality(), ShouldEqual, 0)
+		So(ParOr(rb2, rb1, rb3).GetCardinality(), ShouldEqual, 4)
+	})
+}
+
+func TestParAggregationsReversed3(t *testing.T) {
+	Convey("Par", t, func() {
+		rb1 := NewBitmap()
+		rb2 := NewBitmap()
+		rb3 := NewBitmap()
+		rb1.Add(1)
+		rb1.Add(100000)
+		rb2.Add(200000)
+		rb3.Add(1)
+		rb3.Add(300000)
+
+		So(ParAnd(rb2, rb1, rb3).GetCardinality(), ShouldEqual, 0)
+		So(ParOr(rb2, rb1, rb3).GetCardinality(), ShouldEqual, 4)
+	})
+}
+
+func TestParAggregations3(t *testing.T) {
+	Convey("Par", t, func() {
+		rb1 := NewBitmap()
+		rb2 := NewBitmap()
+		rb3 := NewBitmap()
+		rb1.Add(1)
+		rb1.Add(100000)
+		rb2.Add(200000)
+		rb3.Add(1)
+		rb3.Add(300000)
+
+		So(ParAnd(rb1, rb2, rb3).GetCardinality(), ShouldEqual, 0)
+		So(ParOr(rb1, rb2, rb3).GetCardinality(), ShouldEqual, 4)
+	})
+}
+
+func TestParAggregations3COW(t *testing.T) {
+	Convey("Par", t, func() {
+		rb1 := NewBitmap()
+		rb2 := NewBitmap()
+		rb3 := NewBitmap()
+		rb1.SetCopyOnWrite(true)
+		rb2.SetCopyOnWrite(true)
+		rb3.SetCopyOnWrite(true)
+		rb1.Add(1)
+		rb1.Add(100000)
+		rb2.Add(200000)
+		rb3.Add(1)
+		rb3.Add(300000)
+
+		So(ParAnd(rb1, rb2, rb3).GetCardinality(), ShouldEqual, 0)
+		So(ParOr(rb1, rb2, rb3).GetCardinality(), ShouldEqual, 4)
+	})
+}
+
+func TestParAggregationsAdvanced(t *testing.T) {
+	Convey("Par", t, func() {
+		rb1 := NewBitmap()
+		rb2 := NewBitmap()
+		rb3 := NewBitmap()
+		for i := uint32(0); i < 1000000; i += 3 {
+			rb1.Add(i)
+		}
+		for i := uint32(0); i < 1000000; i += 7 {
+			rb2.Add(i)
+		}
+		for i := uint32(0); i < 1000000; i += 1001 {
+			rb3.Add(i)
+		}
+		for i := uint32(1000000); i < 2000000; i += 1001 {
+			rb1.Add(i)
+		}
+		for i := uint32(1000000); i < 2000000; i += 3 {
+			rb2.Add(i)
+		}
+		for i := uint32(1000000); i < 2000000; i += 7 {
+			rb3.Add(i)
+		}
+		rb1.Or(rb2)
+		rb1.Or(rb3)
+		bigand := And(And(rb1, rb2), rb3)
+		So(ParOr(rb1, rb2, rb3).Equals(rb1), ShouldEqual, true)
+		So(ParAnd(rb1, rb2, rb3).Equals(bigand), ShouldEqual, true)
+	})
+}
+
+func TestParAggregationsAdvanced_run(t *testing.T) {
+	Convey("Par", t, func() {
+		rb1 := NewBitmap()
+		rb2 := NewBitmap()
+		rb3 := NewBitmap()
+		for i := uint32(500); i < 75000; i++ {
+			rb1.Add(i)
+		}
+		for i := uint32(0); i < 1000000; i += 7 {
+			rb2.Add(i)
+		}
+		for i := uint32(0); i < 1000000; i += 1001 {
+			rb3.Add(i)
+		}
+		for i := uint32(1000000); i < 2000000; i += 1001 {
+			rb1.Add(i)
+		}
+		for i := uint32(1000000); i < 2000000; i += 3 {
+			rb2.Add(i)
+		}
+		for i := uint32(1000000); i < 2000000; i += 7 {
+			rb3.Add(i)
+		}
+		rb1.RunOptimize()
+		rb1.Or(rb2)
+		rb1.Or(rb3)
+		bigand := And(And(rb1, rb2), rb3)
+		So(ParOr(rb1, rb2, rb3).Equals(rb1), ShouldEqual, true)
+		So(ParAnd(rb1, rb2, rb3).Equals(bigand), ShouldEqual, true)
+	})
+}


### PR DESCRIPTION
In this PR I parallelise roaring `And` and `Or` operations.

I depart from adding any shared aggregators, like in #104. The interface is kept simple – only two methods are added. `ParAnd` and `ParOr` take after `FastAnd` and `FastOr`. Resources (goroutines and channels) are not shared between invocations.

I use a heap as means of iterating through the passed bitmaps. Since t's slightly different from the one in `priorityqueue.go` it's implemented from scratch and not reused.

Tests are copied from `fast aggregation_test.go` and adapted.

I consider adding versions of `ParAnd` and `ParOr` in the future that would use shared resources (similar to ParAggregator from #104).

Fixes #38.