### PR TITLE
Fixes an issue with ParAnd producing bitmaps with empty containers

### DIFF
--- a/parallel_test.go
+++ b/parallel_test.go
@@ -46,6 +46,15 @@ func TestParAggregationsOneEmpty(t *testing.T) {
 	})
 }
 
+func TestParAggregationsDisjointSetIntersection(t *testing.T) {
+	Convey("Par", t, func() {
+		rb1 := BitmapOf(1)
+		rb2 := BitmapOf(2)
+
+		So(ParAnd(0, rb1, rb2).Stats().Containers, ShouldEqual, 0)
+	})
+}
+
 func TestParAggregationsReversed3COW(t *testing.T) {
 	Convey("Par", t, func() {
 		rb1 := NewBitmap()


### PR DESCRIPTION
This commit fixes an issue with `ParAnd` producing bitmaps that
contain empty containers, which AFAIK are invalid.

@lemire sorry for bothering you with a fixup to the recent PR. It's a case I haven't thought of before we had a discussion on intersections.