### PR TITLE
Remove unnecessary type conversions

### DIFF
--- a/arraycontainer.go
+++ b/arraycontainer.go
@@ -923,7 +923,7 @@ func (ac *arrayContainer) toEfficientContainer() container {
 
 	sizeAsRunContainer := runContainer16SerializedSizeInBytes(numRuns)
 	sizeAsBitmapContainer := bitmapContainerSizeInBytes()
-	card := int(ac.getCardinality())
+	card := ac.getCardinality()
 	sizeAsArrayContainer := arrayContainerSizeInBytes(card)
 
 	if sizeAsRunContainer <= min(sizeAsBitmapContainer, sizeAsArrayContainer) {

--- a/bitmapcontainer.go
+++ b/bitmapcontainer.go
@@ -203,7 +203,7 @@ func (bc *bitmapContainer) iadd(i uint16) bool {
 	mask := uint64(1) << (uint(x) % 64)
 	newb := previous | mask
 	bc.bitmap[x/64] = newb
-	bc.cardinality += int(uint64(previous^newb) >> (uint(x) % 64))
+	bc.cardinality += int((previous ^ newb) >> (uint(x) % 64))
 	return newb != previous
 }
 
@@ -530,7 +530,7 @@ func (bc *bitmapContainer) selectInt(x uint16) int {
 	for k := 0; k < len(bc.bitmap); k++ {
 		w := popcount(bc.bitmap[k])
 		if uint16(w) > remaining {
-			return int(k*64 + selectBitPosition(bc.bitmap[k], int(remaining)))
+			return k*64 + selectBitPosition(bc.bitmap[k], int(remaining))
 		}
 		remaining -= uint16(w)
 	}
@@ -763,7 +763,7 @@ func (bc *bitmapContainer) andNotArray(value2 *arrayContainer) container {
 		oldv := answer.bitmap[i]
 		newv := oldv &^ (uint64(1) << (vc % 64))
 		answer.bitmap[i] = newv
-		answer.cardinality -= int(uint64(oldv^newv) >> (vc % 64))
+		answer.cardinality -= int((oldv ^ newv) >> (vc % 64))
 	}
 	if answer.cardinality <= arrayDefaultMaxSize {
 		return answer.toArrayContainer()
@@ -798,7 +798,7 @@ func (bc *bitmapContainer) iandNotBitmapSurely(value2 *bitmapContainer) *bitmapC
 func (bc *bitmapContainer) contains(i uint16) bool { //testbit
 	x := uint(i)
 	w := bc.bitmap[x>>6]
-	mask := uint64(1) << uint(x&63)
+	mask := uint64(1) << (x & 63)
 	return (w & mask) != 0
 }
 
@@ -892,7 +892,7 @@ func (bc *bitmapContainer) toEfficientContainer() container {
 
 	sizeAsRunContainer := runContainer16SerializedSizeInBytes(numRuns)
 	sizeAsBitmapContainer := bitmapContainerSizeInBytes()
-	card := int(bc.getCardinality())
+	card := bc.getCardinality()
 	sizeAsArrayContainer := arrayContainerSizeInBytes(card)
 
 	if sizeAsRunContainer <= min(sizeAsBitmapContainer, sizeAsArrayContainer) {

--- a/rle.go
+++ b/rle.go
@@ -598,9 +598,9 @@ func (rc *runContainer32) indexOfIntervalAtOrAfter(key int64, startIndex int64) 
 
 	w, already, _ := rc.search(key, &rc.myOpts)
 	if already {
-		return int64(w)
+		return w
 	}
-	return int64(w) + 1
+	return w + 1
 }
 
 // intersect returns a new runContainer32 holding the
@@ -863,7 +863,7 @@ func (rc *runContainer32) search(key int64, opts *searchOptions) (whichInterval3
 	}
 
 	startIndex := int64(0)
-	endxIndex := int64(n)
+	endxIndex := n
 	if opts != nil {
 		startIndex = opts.startIndex
 
@@ -903,7 +903,7 @@ func (rc *runContainer32) search(key int64, opts *searchOptions) (whichInterval3
 			return key < rc.iv[i].start
 		})
 	*/
-	whichInterval32 = int64(below) - 1
+	whichInterval32 = below - 1
 
 	if below == n {
 		// all falses => key is >= start of all interval32s
@@ -953,7 +953,7 @@ func (rc *runContainer32) cardinality() int64 {
 	// have to compute it
 	var n int64
 	for _, p := range rc.iv {
-		n += int64(p.runlen())
+		n += p.runlen()
 	}
 	rc.card = n // cache it
 	return n
@@ -965,7 +965,7 @@ func (rc *runContainer32) AsSlice() []uint32 {
 	j := 0
 	for _, p := range rc.iv {
 		for i := p.start; i <= p.last; i++ {
-			s[j] = uint32(i)
+			s[j] = i
 			j++
 		}
 	}
@@ -1242,10 +1242,10 @@ func (rc *runContainer32) deleteAt(curIndex *int64, curPosInIndex *uint32, curSe
 }
 
 func have4Overlap32(astart, alast, bstart, blast int64) bool {
-	if int64(alast)+1 <= bstart {
+	if alast+1 <= bstart {
 		return false
 	}
-	return int64(blast)+1 > astart
+	return blast+1 > astart
 }
 
 func intersectWithLeftover32(astart, alast, bstart, blast int64) (isOverlap, isLeftoverA, isLeftoverB bool, leftoverstart int64, intersection interval32) {
@@ -1263,11 +1263,11 @@ func intersectWithLeftover32(astart, alast, bstart, blast int64) (isOverlap, isL
 	switch {
 	case blast < alast:
 		isLeftoverA = true
-		leftoverstart = int64(blast) + 1
+		leftoverstart = blast + 1
 		intersection.last = uint32(blast)
 	case alast < blast:
 		isLeftoverB = true
-		leftoverstart = int64(alast) + 1
+		leftoverstart = alast + 1
 		intersection.last = uint32(alast)
 	default:
 		// alast == blast
@@ -1592,7 +1592,7 @@ func (rc *runContainer32) AndNotRunContainer32(b *runContainer32) *runContainer3
 		switch {
 		case alast < bstart:
 			// output the first run
-			dst.iv = append(dst.iv, interval32{start: uint32(astart), last: uint32(alast)})
+			dst.iv = append(dst.iv, interval32{start: astart, last: alast})
 			apos++
 			if apos < alen {
 				astart = a.iv[apos].start
@@ -1611,7 +1611,7 @@ func (rc *runContainer32) AndNotRunContainer32(b *runContainer32) *runContainer3
 			// alast >= bstart
 			// blast >= astart
 			if astart < bstart {
-				dst.iv = append(dst.iv, interval32{start: uint32(astart), last: uint32(bstart - 1)})
+				dst.iv = append(dst.iv, interval32{start: astart, last: bstart - 1})
 			}
 			if alast > blast {
 				astart = blast + 1
@@ -1625,7 +1625,7 @@ func (rc *runContainer32) AndNotRunContainer32(b *runContainer32) *runContainer3
 		}
 	}
 	if apos < alen {
-		dst.iv = append(dst.iv, interval32{start: uint32(astart), last: uint32(alast)})
+		dst.iv = append(dst.iv, interval32{start: astart, last: alast})
 		apos++
 		if apos < alen {
 			dst.iv = append(dst.iv, a.iv[apos:]...)

--- a/rle16.go
+++ b/rle16.go
@@ -263,14 +263,14 @@ func newRunContainer16FromArray(arr *arrayContainer) *runContainer16 {
 	case n == 0:
 		// nothing more
 	case n == 1:
-		ah.m = append(ah.m, interval16{start: uint16(arr.content[0]), last: uint16(arr.content[0])})
+		ah.m = append(ah.m, interval16{start: arr.content[0], last: arr.content[0]})
 		ah.actuallyAdded++
 	default:
-		ah.runstart = uint16(arr.content[0])
+		ah.runstart = arr.content[0]
 		ah.actuallyAdded++
 		for i := 1; i < n; i++ {
-			prev = uint16(arr.content[i-1])
-			cur = uint16(arr.content[i])
+			prev = arr.content[i-1]
+			cur = arr.content[i]
 			ah.add(cur, prev, i)
 		}
 		ah.storeIval(ah.runstart, ah.runlen)
@@ -598,9 +598,9 @@ func (rc *runContainer16) indexOfIntervalAtOrAfter(key int64, startIndex int64) 
 
 	w, already, _ := rc.search(key, &rc.myOpts)
 	if already {
-		return int64(w)
+		return w
 	}
-	return int64(w) + 1
+	return w + 1
 }
 
 // intersect returns a new runContainer16 holding the
@@ -863,7 +863,7 @@ func (rc *runContainer16) search(key int64, opts *searchOptions) (whichInterval1
 	}
 
 	startIndex := int64(0)
-	endxIndex := int64(n)
+	endxIndex := n
 	if opts != nil {
 		startIndex = opts.startIndex
 
@@ -903,7 +903,7 @@ func (rc *runContainer16) search(key int64, opts *searchOptions) (whichInterval1
 			return key < rc.iv[i].start
 		})
 	*/
-	whichInterval16 = int64(below) - 1
+	whichInterval16 = below - 1
 
 	if below == n {
 		// all falses => key is >= start of all interval16s
@@ -953,7 +953,7 @@ func (rc *runContainer16) cardinality() int64 {
 	// have to compute it
 	var n int64
 	for _, p := range rc.iv {
-		n += int64(p.runlen())
+		n += p.runlen()
 	}
 	rc.card = n // cache it
 	return n
@@ -965,7 +965,7 @@ func (rc *runContainer16) AsSlice() []uint16 {
 	j := 0
 	for _, p := range rc.iv {
 		for i := p.start; i <= p.last; i++ {
-			s[j] = uint16(i)
+			s[j] = i
 			j++
 		}
 	}
@@ -1242,10 +1242,10 @@ func (rc *runContainer16) deleteAt(curIndex *int64, curPosInIndex *uint16, curSe
 }
 
 func have4Overlap16(astart, alast, bstart, blast int64) bool {
-	if int64(alast)+1 <= bstart {
+	if alast+1 <= bstart {
 		return false
 	}
-	return int64(blast)+1 > astart
+	return blast+1 > astart
 }
 
 func intersectWithLeftover16(astart, alast, bstart, blast int64) (isOverlap, isLeftoverA, isLeftoverB bool, leftoverstart int64, intersection interval16) {
@@ -1263,11 +1263,11 @@ func intersectWithLeftover16(astart, alast, bstart, blast int64) (isOverlap, isL
 	switch {
 	case blast < alast:
 		isLeftoverA = true
-		leftoverstart = int64(blast) + 1
+		leftoverstart = blast + 1
 		intersection.last = uint16(blast)
 	case alast < blast:
 		isLeftoverB = true
-		leftoverstart = int64(alast) + 1
+		leftoverstart = alast + 1
 		intersection.last = uint16(alast)
 	default:
 		// alast == blast
@@ -1592,7 +1592,7 @@ func (rc *runContainer16) AndNotRunContainer16(b *runContainer16) *runContainer1
 		switch {
 		case alast < bstart:
 			// output the first run
-			dst.iv = append(dst.iv, interval16{start: uint16(astart), last: uint16(alast)})
+			dst.iv = append(dst.iv, interval16{start: astart, last: alast})
 			apos++
 			if apos < alen {
 				astart = a.iv[apos].start
@@ -1611,7 +1611,7 @@ func (rc *runContainer16) AndNotRunContainer16(b *runContainer16) *runContainer1
 			// alast >= bstart
 			// blast >= astart
 			if astart < bstart {
-				dst.iv = append(dst.iv, interval16{start: uint16(astart), last: uint16(bstart - 1)})
+				dst.iv = append(dst.iv, interval16{start: astart, last: bstart - 1})
 			}
 			if alast > blast {
 				astart = blast + 1
@@ -1625,7 +1625,7 @@ func (rc *runContainer16) AndNotRunContainer16(b *runContainer16) *runContainer1
 		}
 	}
 	if apos < alen {
-		dst.iv = append(dst.iv, interval16{start: uint16(astart), last: uint16(alast)})
+		dst.iv = append(dst.iv, interval16{start: astart, last: alast})
 		apos++
 		if apos < alen {
 			dst.iv = append(dst.iv, a.iv[apos:]...)

--- a/roaringarray.go
+++ b/roaringarray.go
@@ -307,7 +307,7 @@ func (ra *roaringArray) getIndex(x uint16) int {
 	if (size == 0) || (ra.keys[size-1] == x) {
 		return size - 1
 	}
-	return int(ra.binarySearch(0, int64(size), x))
+	return ra.binarySearch(0, int64(size), x)
 }
 
 func (ra *roaringArray) getKeyAtIndex(i int) uint16 {
@@ -479,7 +479,7 @@ func (ra *roaringArray) toBytes() ([]byte, error) {
 
 	// descriptive header
 	for i, key := range ra.keys {
-		binary.LittleEndian.PutUint16(buf[nw:], uint16(key))
+		binary.LittleEndian.PutUint16(buf[nw:], key)
 		nw += 2
 		c := ra.containers[i]
 		binary.LittleEndian.PutUint16(buf[nw:], uint16(c.getCardinality()-1))
@@ -597,11 +597,11 @@ func (ra *roaringArray) readFrom(stream io.Reader) (int64, error) {
 			if err != nil {
 				return 0, err
 			}
-			nb.cardinality = int(card)
+			nb.cardinality = card
 			pos += nr
 			ra.appendContainer(keycard[2*i], nb, false)
 		} else {
-			nb := newArrayContainerSize(int(card))
+			nb := newArrayContainerSize(card)
 			nr, err := nb.readFrom(stream)
 			if err != nil {
 				return 0, err


### PR DESCRIPTION
This removes all unnecessary type conversions making the code somehow cleaner. OTOH I'm not sure if it'd be better to leave come of the type conversions in for code readability purposes.

Closes #114 