### PR TITLE
FastAggregation: ensure COW is respected

### DIFF
--- a/fastaggregation.go
+++ b/fastaggregation.go
@@ -97,6 +97,8 @@ main:
 					if !t.isFull() {
 						c1 = t.toBitmapContainer()
 					}
+				case *bitmapContainer:
+					c1 = x1.highlowcontainer.getWritableContainerAtIndex(pos1)
 				}
 
 				answer.highlowcontainer.appendContainer(s1, c1.lazyIOR(x2.highlowcontainer.getContainerAtIndex(pos2)), false)

--- a/roaringarray.go
+++ b/roaringarray.go
@@ -137,7 +137,8 @@ func (ra *roaringArray) appendContainer(key uint16, value container, mustCopyOnW
 }
 
 func (ra *roaringArray) appendWithoutCopy(sa roaringArray, startingindex int) {
-	ra.appendContainer(sa.keys[startingindex], sa.containers[startingindex], false)
+	mustCopyOnWrite := sa.needCopyOnWrite[startingindex]
+	ra.appendContainer(sa.keys[startingindex], sa.containers[startingindex], mustCopyOnWrite)
 }
 
 func (ra *roaringArray) appendCopy(sa roaringArray, startingindex int) {


### PR DESCRIPTION
This PR fixes two issues with `FastOr` method. Both of them are related to `func (*Bitmap) lazyOR(*Bitmap) *Bitmap)`:
* in the case when containers where appended to the resulting bitmap copy-on-write marker was not carried over, which in some cases resulted in writing to a container that requires copy on write
* if a bitmap container was encountered in the receiver `Bitmap` copy-on-write marker was not respected
