### PR TITLE
Bitmap.FromBuffer

### DIFF
--- a/roaring.go
+++ b/roaring.go
@@ -71,6 +71,20 @@ func (rb *Bitmap) ReadFrom(stream io.Reader) (int64, error) {
 	return rb.highlowcontainer.readFrom(stream)
 }
 
+// FromBuffer creates a bitmap from its serialized version stored in buffer
+//
+// The format specification is available here:
+// https://github.com/RoaringBitmap/RoaringFormatSpec
+//
+// The function makes the best effort attempt not to copy data
+// You should take care not to modify the buffer as it will
+// likely result in unexpected program behavior.
+//
+// Resulting bitmaps are effectively immutable (a copy-on-write marker is used)
+func (rb *Bitmap) FromBuffer(buf []byte) (int64, error) {
+	return rb.highlowcontainer.fromBuffer(buf)
+}
+
 // RunOptimize attempts to further compress the runs of consecutive values found in the bitmap
 func (rb *Bitmap) RunOptimize() {
 	rb.highlowcontainer.runOptimize()

--- a/serialization_generic.go
+++ b/serialization_generic.go
@@ -57,3 +57,31 @@ func (bc *bitmapContainer) asLittleEndianByteSlice() []byte {
 	}
 	return by
 }
+
+func byteSliceAsUint16Slice(slice []byte) []uint16 {
+	if len(slice)%2 != 0 {
+		panic("Slice size should be divisible by 2")
+	}
+
+	b := make([]uint16, len(slice), len(slice))
+
+	for i := range b {
+		b[i] = binary.LittleEndian.Uint16(slice[2*i:])
+	}
+
+	return b
+}
+
+func byteSliceAsUint64Slice(slice []byte) []uint64 {
+	if len(slice)%8 != 0 {
+		panic("Slice size should be divisible by 8")
+	}
+
+	b := make([]uint64, len(slice), len(slice))
+
+	for i := range b {
+		b[i] = binary.LittleEndian.Uint64(slice[8*i:])
+	}
+
+	return b
+}

--- a/serialization_littleendian.go
+++ b/serialization_littleendian.go
@@ -61,3 +61,37 @@ func uint16SliceAsByteSlice(slice []uint16) []byte {
 func (bc *bitmapContainer) asLittleEndianByteSlice() []byte {
 	return uint64SliceAsByteSlice(bc.bitmap)
 }
+
+// Deserialization code follows
+
+func byteSliceAsUint16Slice(slice []byte) []uint16 {
+	if len(slice)%2 != 0 {
+		panic("Slice size should be divisible by 2")
+	}
+
+	// make a new slice header
+	header := *(*reflect.SliceHeader)(unsafe.Pointer(&slice))
+
+	// update its capacity and length
+	header.Len /= 2
+	header.Cap /= 2
+
+	// return it
+	return *(*[]uint16)(unsafe.Pointer(&header))
+}
+
+func byteSliceAsUint64Slice(slice []byte) []uint64 {
+	if len(slice)%8 != 0 {
+		panic("Slice size should be divisible by 8")
+	}
+
+	// make a new slice header
+	header := *(*reflect.SliceHeader)(unsafe.Pointer(&slice))
+
+	// update its capacity and length
+	header.Len /= 8
+	header.Cap /= 8
+
+	// return it
+	return *(*[]uint64)(unsafe.Pointer(&header))
+}

--- a/serialization_test.go
+++ b/serialization_test.go
@@ -4,6 +4,7 @@ package roaring
 
 import (
 	"bytes"
+	"encoding/binary"
 	"encoding/gob"
 	"fmt"
 	"io/ioutil"
@@ -677,4 +678,152 @@ func TestSerializationRunContainer32Msgpack050(t *testing.T) {
 		}
 
 	})
+}
+
+func TestByteSliceAsUint16Slice(t *testing.T) {
+	t.Run("valid slice", func(t *testing.T) {
+		expectedSize := 2
+		slice := make([]byte, 4)
+		binary.LittleEndian.PutUint16(slice, 42)
+		binary.LittleEndian.PutUint16(slice[2:], 43)
+
+		uint16Slice := byteSliceAsUint16Slice(slice)
+
+		if len(uint16Slice) != expectedSize {
+			t.Errorf("Expected output slice length %d, got %d", expectedSize, len(uint16Slice))
+		}
+		if cap(uint16Slice) != expectedSize {
+			t.Errorf("Expected output slice cap %d, got %d", expectedSize, cap(uint16Slice))
+		}
+
+		if uint16Slice[0] != 42 || uint16Slice[1] != 43 {
+			t.Errorf("Unexpected value found in result slice")
+		}
+	})
+
+	t.Run("empty slice", func(t *testing.T) {
+		slice := make([]byte, 0, 0)
+
+		uint16Slice := byteSliceAsUint16Slice(slice)
+		if len(uint16Slice) != 0 {
+			t.Errorf("Expected output slice length 0, got %d", len(uint16Slice))
+		}
+		if cap(uint16Slice) != 0 {
+			t.Errorf("Expected output slice cap 0, got %d", len(uint16Slice))
+		}
+	})
+
+	t.Run("invalid slice size", func(t *testing.T) {
+		defer func() {
+			// All fine
+			_ = recover()
+		}()
+
+		slice := make([]byte, 1, 1)
+
+		byteSliceAsUint16Slice(slice)
+
+		t.Errorf("byteSliceAsUint16Slice should panic on invalid slice size")
+	})
+}
+
+func TestByteSliceAsUint64Slice(t *testing.T) {
+	t.Run("valid slice", func(t *testing.T) {
+		expectedSize := 2
+		slice := make([]byte, 16)
+		binary.LittleEndian.PutUint64(slice, 42)
+		binary.LittleEndian.PutUint64(slice[8:], 43)
+
+		uint64Slice := byteSliceAsUint64Slice(slice)
+
+		if len(uint64Slice) != expectedSize {
+			t.Errorf("Expected output slice length %d, got %d", expectedSize, len(uint64Slice))
+		}
+		if cap(uint64Slice) != expectedSize {
+			t.Errorf("Expected output slice cap %d, got %d", expectedSize, cap(uint64Slice))
+		}
+
+		if uint64Slice[0] != 42 || uint64Slice[1] != 43 {
+			t.Errorf("Unexpected value found in result slice")
+		}
+	})
+
+	t.Run("empty slice", func(t *testing.T) {
+		slice := make([]byte, 0, 0)
+
+		uint64Slice := byteSliceAsUint64Slice(slice)
+		if len(uint64Slice) != 0 {
+			t.Errorf("Expected output slice length 0, got %d", len(uint64Slice))
+		}
+		if len(uint64Slice) != 0 {
+			t.Errorf("Expected output slice length 0, got %d", len(uint64Slice))
+		}
+	})
+
+	t.Run("invalid slice size", func(t *testing.T) {
+		defer func() {
+			// All fine
+			_ = recover()
+		}()
+
+		slice := make([]byte, 1, 1)
+
+		byteSliceAsUint64Slice(slice)
+
+		t.Errorf("byteSliceAsUint64Slice should panic on invalid slice size")
+	})
+}
+
+func TestByteSliceAsInterval16Slice(t *testing.T) {
+	t.Run("valid slice", func(t *testing.T) {
+		expectedSize := 2
+		slice := make([]byte, 8)
+		binary.LittleEndian.PutUint16(slice, 10)
+		binary.LittleEndian.PutUint16(slice[2:], 2)
+		binary.LittleEndian.PutUint16(slice[4:], 20)
+		binary.LittleEndian.PutUint16(slice[6:], 2)
+
+		intervalSlice := byteSliceAsInterval16Slice(slice)
+
+		if len(intervalSlice) != expectedSize {
+			t.Errorf("Expected output slice length %d, got %d", expectedSize, len(intervalSlice))
+		}
+
+		if cap(intervalSlice) != expectedSize {
+			t.Errorf("Expected output slice cap %d, got %d", expectedSize, len(intervalSlice))
+		}
+
+		i1 := interval16{10, 12}
+		i2 := interval16{20, 22}
+		if intervalSlice[0] != i1 || intervalSlice[1] != i2 {
+			t.Errorf("Unexpected items in result slice")
+		}
+	})
+
+	t.Run("empty slice", func(t *testing.T) {
+		slice := make([]byte, 0, 0)
+
+		intervalSlice := byteSliceAsInterval16Slice(slice)
+		if len(intervalSlice) != 0 {
+			t.Errorf("Expected output slice length 0, got %d", len(intervalSlice))
+		}
+		if len(intervalSlice) != 0 {
+			t.Errorf("Expected output slice length 0, got %d", len(intervalSlice))
+		}
+	})
+
+	t.Run("invalid slice length", func(t *testing.T) {
+		defer func() {
+			// All fine
+			_ = recover()
+		}()
+
+		slice := make([]byte, 1, 1)
+
+		byteSliceAsInterval16Slice(slice)
+
+		t.Errorf("byteSliceAsInterval16Slice should panic on invalid slice size")
+
+	})
+
 }


### PR DESCRIPTION
This PR introduces a method that allows to create a Bitmap from a byte buffer (`[]byte`) containing a serialized Roaring Bitmap with minimal memory copying.

Closes #116.