### PR TITLE
bitmapContainer.toArrayContainer: remove double slice allocation

### DIFF
--- a/bitmapcontainer.go
+++ b/bitmapcontainer.go
@@ -819,7 +819,7 @@ func (bc *bitmapContainer) loadData(arrayContainer *arrayContainer) {
 }
 
 func (bc *bitmapContainer) toArrayContainer() *arrayContainer {
-	ac := newArrayContainerCapacity(bc.cardinality)
+	ac := &arrayContainer{}
 	ac.loadData(bc)
 	return ac
 }


### PR DESCRIPTION
Calling `newArrayContainerCapacity(bc.cardinality)` in unnecessary as `ac.loadData(bc)` re-creates the `ac.content`.