### PR TITLE
Fast `byteSliceAsInterval16Slice`

### DIFF
--- a/arraycontainer_test.go
+++ b/arraycontainer_test.go
@@ -261,7 +261,9 @@ func TestArrayContainerIaddRangeNearMax068(t *testing.T) {
 
 	Convey("arrayContainer iaddRange should work near MaxUint16", t, func() {
 
-		iv := []interval16{{65525, 65527}, {65530, 65530}, {65534, 65535}}
+		iv := []interval16{newInterval16Range(65525, 65527),
+			newInterval16Range(65530, 65530),
+			newInterval16Range(65534, 65535)}
 		rc := newRunContainer16TakeOwnership(iv)
 
 		ac2 := rc.toArrayContainer()
@@ -283,7 +285,9 @@ func TestArrayContainerEtc070(t *testing.T) {
 
 	Convey("arrayContainer rarely exercised code paths should get some coverage", t, func() {
 
-		iv := []interval16{{65525, 65527}, {65530, 65530}, {65534, 65535}}
+		iv := []interval16{newInterval16Range(65525, 65527),
+			newInterval16Range(65530, 65530),
+			newInterval16Range(65534, 65535)}
 		rc := newRunContainer16TakeOwnership(iv)
 		ac := rc.toArrayContainer()
 

--- a/bitmapcontainer.go
+++ b/bitmapcontainer.go
@@ -326,7 +326,7 @@ func (bc *bitmapContainer) ior(a container) container {
 			return x.clone()
 		}
 		for i := range x.iv {
-			bc.iaddRange(int(x.iv[i].start), int(x.iv[i].last)+1)
+			bc.iaddRange(int(x.iv[i].start), int(x.iv[i].last())+1)
 		}
 		if bc.isFull() {
 			return newRunContainer16Range(0, MaxUint16)
@@ -349,7 +349,7 @@ func (bc *bitmapContainer) lazyIOR(a container) container {
 		}
 		// TODO : implement efficient in-place lazy OR to bitmap
 		for i := range x.iv {
-			setBitmapRange(bc.bitmap, int(x.iv[i].start), int(x.iv[i].last)+1)
+			setBitmapRange(bc.bitmap, int(x.iv[i].start), int(x.iv[i].last())+1)
 			//bc.iaddRange(int(x.iv[i].start), int(x.iv[i].last)+1)
 		}
 		bc.cardinality = invalidCardinality
@@ -907,14 +907,13 @@ func (bc *bitmapContainer) toEfficientContainer() container {
 func newBitmapContainerFromRun(rc *runContainer16) *bitmapContainer {
 
 	if len(rc.iv) == 1 {
-		return newBitmapContainerwithRange(int(rc.iv[0].start), int(rc.iv[0].last))
+		return newBitmapContainerwithRange(int(rc.iv[0].start), int(rc.iv[0].last()))
 	}
 
 	bc := newBitmapContainer()
 	for i := range rc.iv {
-		setBitmapRange(bc.bitmap, int(rc.iv[i].start), int(rc.iv[i].last)+1)
-		bc.cardinality += int(rc.iv[i].last) + 1 - int(rc.iv[i].start)
-		//bc.iaddRange(int(rc.iv[i].start), int(rc.iv[i].last)+1)
+		setBitmapRange(bc.bitmap, int(rc.iv[i].start), int(rc.iv[i].last())+1)
+		bc.cardinality += int(rc.iv[i].last()) + 1 - int(rc.iv[i].start)
 	}
 	//bc.computeCardinality()
 	return bc

--- a/rle16_gen.go
+++ b/rle16_gen.go
@@ -67,7 +67,8 @@ func (z *addHelper16) DecodeMsg(dc *msgp.Reader) (err error) {
 							return
 						}
 					case "last":
-						z.m[zxvk].last, err = dc.ReadUint16()
+						z.m[zxvk].length, err = dc.ReadUint16()
+						z.m[zxvk].length -= z.m[zxvk].start
 						if err != nil {
 							return
 						}
@@ -132,7 +133,8 @@ func (z *addHelper16) DecodeMsg(dc *msgp.Reader) (err error) {
 										return
 									}
 								case "last":
-									z.rc.iv[zbzg].last, err = dc.ReadUint16()
+									z.rc.iv[zbzg].length, err = dc.ReadUint16()
+									z.rc.iv[zbzg].length -= z.rc.iv[zbzg].start
 									if err != nil {
 										return
 									}
@@ -222,7 +224,7 @@ func (z *addHelper16) EncodeMsg(en *msgp.Writer) (err error) {
 		if err != nil {
 			return err
 		}
-		err = en.WriteUint16(z.m[zxvk].last)
+		err = en.WriteUint16(z.m[zxvk].last())
 		if err != nil {
 			return
 		}
@@ -264,7 +266,7 @@ func (z *addHelper16) EncodeMsg(en *msgp.Writer) (err error) {
 			if err != nil {
 				return err
 			}
-			err = en.WriteUint16(z.rc.iv[zbzg].last)
+			err = en.WriteUint16(z.rc.iv[zbzg].last())
 			if err != nil {
 				return
 			}
@@ -305,7 +307,7 @@ func (z *addHelper16) MarshalMsg(b []byte) (o []byte, err error) {
 		o = msgp.AppendUint16(o, z.m[zxvk].start)
 		// string "last"
 		o = append(o, 0xa4, 0x6c, 0x61, 0x73, 0x74)
-		o = msgp.AppendUint16(o, z.m[zxvk].last)
+		o = msgp.AppendUint16(o, z.m[zxvk].last())
 	}
 	// string "rc"
 	o = append(o, 0xa2, 0x72, 0x63)
@@ -323,7 +325,7 @@ func (z *addHelper16) MarshalMsg(b []byte) (o []byte, err error) {
 			o = msgp.AppendUint16(o, z.rc.iv[zbzg].start)
 			// string "last"
 			o = append(o, 0xa4, 0x6c, 0x61, 0x73, 0x74)
-			o = msgp.AppendUint16(o, z.rc.iv[zbzg].last)
+			o = msgp.AppendUint16(o, z.rc.iv[zbzg].last())
 		}
 		// string "card"
 		o = append(o, 0xa4, 0x63, 0x61, 0x72, 0x64)
@@ -393,7 +395,8 @@ func (z *addHelper16) UnmarshalMsg(bts []byte) (o []byte, err error) {
 							return
 						}
 					case "last":
-						z.m[zxvk].last, bts, err = msgp.ReadUint16Bytes(bts)
+						z.m[zxvk].length, bts, err = msgp.ReadUint16Bytes(bts)
+						z.m[zxvk].length -= z.m[zxvk].start
 						if err != nil {
 							return
 						}
@@ -458,7 +461,8 @@ func (z *addHelper16) UnmarshalMsg(bts []byte) (o []byte, err error) {
 										return
 									}
 								case "last":
-									z.rc.iv[zbzg].last, bts, err = msgp.ReadUint16Bytes(bts)
+									z.rc.iv[zbzg].length, bts, err = msgp.ReadUint16Bytes(bts)
+									z.rc.iv[zbzg].length -= z.rc.iv[zbzg].start
 									if err != nil {
 										return
 									}
@@ -527,7 +531,8 @@ func (z *interval16) DecodeMsg(dc *msgp.Reader) (err error) {
 				return
 			}
 		case "last":
-			z.last, err = dc.ReadUint16()
+			z.length, err = dc.ReadUint16()
+			z.length = -z.start
 			if err != nil {
 				return
 			}
@@ -558,7 +563,7 @@ func (z interval16) EncodeMsg(en *msgp.Writer) (err error) {
 	if err != nil {
 		return err
 	}
-	err = en.WriteUint16(z.last)
+	err = en.WriteUint16(z.last())
 	if err != nil {
 		return
 	}
@@ -574,7 +579,7 @@ func (z interval16) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.AppendUint16(o, z.start)
 	// string "last"
 	o = append(o, 0xa4, 0x6c, 0x61, 0x73, 0x74)
-	o = msgp.AppendUint16(o, z.last)
+	o = msgp.AppendUint16(o, z.last())
 	return
 }
 
@@ -600,7 +605,8 @@ func (z *interval16) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				return
 			}
 		case "last":
-			z.last, bts, err = msgp.ReadUint16Bytes(bts)
+			z.length, bts, err = msgp.ReadUint16Bytes(bts)
+			z.length -= z.start
 			if err != nil {
 				return
 			}
@@ -667,7 +673,8 @@ func (z *runContainer16) DecodeMsg(dc *msgp.Reader) (err error) {
 							return
 						}
 					case "last":
-						z.iv[zxpk].last, err = dc.ReadUint16()
+						z.iv[zxpk].length, err = dc.ReadUint16()
+						z.iv[zxpk].length -= z.iv[zxpk].start
 						if err != nil {
 							return
 						}
@@ -722,7 +729,7 @@ func (z *runContainer16) EncodeMsg(en *msgp.Writer) (err error) {
 		if err != nil {
 			return err
 		}
-		err = en.WriteUint16(z.iv[zxpk].last)
+		err = en.WriteUint16(z.iv[zxpk].last())
 		if err != nil {
 			return
 		}
@@ -753,7 +760,7 @@ func (z *runContainer16) MarshalMsg(b []byte) (o []byte, err error) {
 		o = msgp.AppendUint16(o, z.iv[zxpk].start)
 		// string "last"
 		o = append(o, 0xa4, 0x6c, 0x61, 0x73, 0x74)
-		o = msgp.AppendUint16(o, z.iv[zxpk].last)
+		o = msgp.AppendUint16(o, z.iv[zxpk].last())
 	}
 	// string "card"
 	o = append(o, 0xa4, 0x63, 0x61, 0x72, 0x64)
@@ -807,7 +814,8 @@ func (z *runContainer16) UnmarshalMsg(bts []byte) (o []byte, err error) {
 							return
 						}
 					case "last":
-						z.iv[zxpk].last, bts, err = msgp.ReadUint16Bytes(bts)
+						z.iv[zxpk].length, bts, err = msgp.ReadUint16Bytes(bts)
+						z.iv[zxpk].length -= z.iv[zxpk].start
 						if err != nil {
 							return
 						}

--- a/rle16_test.go
+++ b/rle16_test.go
@@ -81,7 +81,7 @@ func TestRleRunIterator16(t *testing.T) {
 			So(it.hasNext(), ShouldBeFalse)
 		}
 		{
-			rc := newRunContainer16TakeOwnership([]interval16{{start: 4, last: 4}})
+			rc := newRunContainer16TakeOwnership([]interval16{newInterval16Range(4, 4)})
 			So(rc.cardinality(), ShouldEqual, 1)
 			it := rc.newRunIterator16()
 			So(it.hasNext(), ShouldBeTrue)
@@ -151,9 +151,8 @@ func TestRleRunIterator16(t *testing.T) {
 			So(it.next(), ShouldEqual, uint16(MaxUint16))
 			So(it.hasNext(), ShouldEqual, false)
 
-			rc2 := newRunContainer16TakeOwnership([]interval16{
-				{start: 0, last: MaxUint16},
-			})
+			newInterval16Range(0, MaxUint16)
+			rc2 := newRunContainer16TakeOwnership([]interval16{newInterval16Range(0, MaxUint16)})
 
 			p("union with a full [0,2^16-1] container should yield that same single interval run container")
 			rc2 = rc2.union(rc)
@@ -264,7 +263,8 @@ func TestRleIntersection16(t *testing.T) {
 			So(isect.contains(6), ShouldBeTrue)
 			So(isect.contains(8), ShouldBeTrue)
 
-			d := newRunContainer16TakeOwnership([]interval16{{start: 0, last: MaxUint16}})
+			newInterval16Range(0, MaxUint16)
+			d := newRunContainer16TakeOwnership([]interval16{newInterval16Range(0, MaxUint16)})
 
 			isect = isect.intersect(d)
 			p("isect is %v", isect)
@@ -529,9 +529,9 @@ func TestRleAndOrXor16(t *testing.T) {
 	Convey("RunContainer And, Or, Xor tests", t, func() {
 		{
 			rc := newRunContainer16TakeOwnership([]interval16{
-				{start: 0, last: 0},
-				{start: 2, last: 2},
-				{start: 4, last: 4},
+				newInterval16Range(0, 0),
+				newInterval16Range(2, 2),
+				newInterval16Range(4, 4),
 			})
 			b0 := NewBitmap()
 			b0.Add(2)

--- a/rle16_test.go
+++ b/rle16_test.go
@@ -17,20 +17,20 @@ func init() {
 func TestRleInterval16s(t *testing.T) {
 
 	Convey("canMerge, and mergeInterval16s should do what they say", t, func() {
-		a := interval16{start: 0, last: 9}
+		a := newInterval16Range(0, 9)
 		msg := a.String()
 		p("a is %v", msg)
-		b := interval16{start: 0, last: 1}
+		b := newInterval16Range(0, 1)
 		report := sliceToString16([]interval16{a, b})
 		_ = report
 		p("a and b together are: %s", report)
-		c := interval16{start: 2, last: 4}
-		d := interval16{start: 2, last: 5}
-		e := interval16{start: 0, last: 4}
-		f := interval16{start: 9, last: 9}
-		g := interval16{start: 8, last: 9}
-		h := interval16{start: 5, last: 6}
-		i := interval16{start: 6, last: 6}
+		c := newInterval16Range(2, 4)
+		d := newInterval16Range(2, 5)
+		e := newInterval16Range(0, 4)
+		f := newInterval16Range(9, 9)
+		g := newInterval16Range(8, 9)
+		h := newInterval16Range(5, 6)
+		i := newInterval16Range(6, 6)
 
 		aIb, empty := intersectInterval16s(a, b)
 		So(empty, ShouldBeFalse)
@@ -55,15 +55,15 @@ func TestRleInterval16s(t *testing.T) {
 		So(mergeInterval16s(i, h), ShouldResemble, h)
 
 		////// start
-		So(mergeInterval16s(interval16{start: 0, last: 0}, interval16{start: 1, last: 1}), ShouldResemble, interval16{start: 0, last: 1})
-		So(mergeInterval16s(interval16{start: 1, last: 1}, interval16{start: 0, last: 0}), ShouldResemble, interval16{start: 0, last: 1})
-		So(mergeInterval16s(interval16{start: 0, last: 4}, interval16{start: 3, last: 5}), ShouldResemble, interval16{start: 0, last: 5})
-		So(mergeInterval16s(interval16{start: 0, last: 4}, interval16{start: 3, last: 4}), ShouldResemble, interval16{start: 0, last: 4})
+		So(mergeInterval16s(newInterval16Range(0, 0), newInterval16Range(1, 1)), ShouldResemble, newInterval16Range(0, 1))
+		So(mergeInterval16s(newInterval16Range(1, 1), newInterval16Range(0, 0)), ShouldResemble, newInterval16Range(0, 1))
+		So(mergeInterval16s(newInterval16Range(0, 4), newInterval16Range(3, 5)), ShouldResemble, newInterval16Range(0, 5))
+		So(mergeInterval16s(newInterval16Range(0, 4), newInterval16Range(3, 4)), ShouldResemble, newInterval16Range(0, 4))
 
-		So(mergeInterval16s(interval16{start: 0, last: 8}, interval16{start: 1, last: 7}), ShouldResemble, interval16{start: 0, last: 8})
-		So(mergeInterval16s(interval16{start: 1, last: 7}, interval16{start: 0, last: 8}), ShouldResemble, interval16{start: 0, last: 8})
+		So(mergeInterval16s(newInterval16Range(0, 8), newInterval16Range(1, 7)), ShouldResemble, newInterval16Range(0, 8))
+		So(mergeInterval16s(newInterval16Range(1, 7), newInterval16Range(0, 8)), ShouldResemble, newInterval16Range(0, 8))
 
-		So(func() { _ = mergeInterval16s(interval16{start: 0, last: 0}, interval16{start: 2, last: 3}) }, ShouldPanic)
+		So(func() { _ = mergeInterval16s(newInterval16Range(0, 0), newInterval16Range(2, 3)) }, ShouldPanic)
 
 	})
 }
@@ -89,7 +89,7 @@ func TestRleRunIterator16(t *testing.T) {
 			So(it.cur(), ShouldResemble, uint16(4))
 		}
 		{
-			rc := newRunContainer16CopyIv([]interval16{{start: 4, last: 9}})
+			rc := newRunContainer16CopyIv([]interval16{newInterval16Range(4, 9)})
 			So(rc.cardinality(), ShouldEqual, 6)
 			it := rc.newRunIterator16()
 			So(it.hasNext(), ShouldBeTrue)
@@ -100,10 +100,9 @@ func TestRleRunIterator16(t *testing.T) {
 		}
 
 		{
-			rc := newRunContainer16TakeOwnership([]interval16{{start: 4, last: 9}})
+			rc := newRunContainer16TakeOwnership([]interval16{newInterval16Range(4, 9)})
 			card := rc.cardinality()
 			So(card, ShouldEqual, 6)
-			//So(rc.serializedSizeInBytes(), ShouldEqual, 2+4*rc.numberOfRuns())
 
 			it := rc.newRunIterator16()
 			So(it.hasNext(), ShouldBeTrue)
@@ -128,14 +127,14 @@ func TestRleRunIterator16(t *testing.T) {
 		}
 		{
 			rc := newRunContainer16TakeOwnership([]interval16{
-				{start: 0, last: 0},
-				{start: 2, last: 2},
-				{start: 4, last: 4},
+				newInterval16Range(0, 0),
+				newInterval16Range(2, 2),
+				newInterval16Range(4, 4),
 			})
 			rc1 := newRunContainer16TakeOwnership([]interval16{
-				{start: 6, last: 7},
-				{start: 10, last: 11},
-				{start: MaxUint16, last: MaxUint16},
+				newInterval16Range(6, 7),
+				newInterval16Range(10, 11),
+				newInterval16Range(MaxUint16, MaxUint16),
 			})
 
 			rc = rc.union(rc1)
@@ -253,8 +252,8 @@ func TestRleIntersection16(t *testing.T) {
 			p("a is %v", a)
 			p("b is %v", b)
 
-			So(haveOverlap16(interval16{0, 2}, interval16{2, 2}), ShouldBeTrue)
-			So(haveOverlap16(interval16{0, 2}, interval16{3, 3}), ShouldBeFalse)
+			So(haveOverlap16(newInterval16Range(0, 2), newInterval16Range(2, 2)), ShouldBeTrue)
+			So(haveOverlap16(newInterval16Range(0, 2), newInterval16Range(3, 3)), ShouldBeFalse)
 
 			isect := a.intersect(b)
 
@@ -275,8 +274,18 @@ func TestRleIntersection16(t *testing.T) {
 			So(isect.contains(8), ShouldBeTrue)
 
 			p("test breaking apart intervals")
-			e := newRunContainer16TakeOwnership([]interval16{{2, 4}, {8, 9}, {14, 16}, {20, 22}})
-			f := newRunContainer16TakeOwnership([]interval16{{3, 18}, {22, 23}})
+			e := newRunContainer16TakeOwnership(
+				[]interval16{
+					newInterval16Range(2, 4),
+					newInterval16Range(8, 9),
+					newInterval16Range(14, 16),
+					newInterval16Range(20, 22)},
+			)
+			f := newRunContainer16TakeOwnership(
+				[]interval16{
+					newInterval16Range(3, 18),
+					newInterval16Range(22, 23)},
+			)
 
 			p("e = %v", e)
 			p("f = %v", f)
@@ -584,12 +593,12 @@ func TestRleCoverageOddsAndEnds16(t *testing.T) {
 		rc := &runContainer16{}
 		So(rc.String(), ShouldEqual, "runContainer16{}")
 		rc.iv = make([]interval16, 1)
-		rc.iv[0] = interval16{start: 3, last: 4}
+		rc.iv[0] = newInterval16Range(3, 4)
 		So(rc.String(), ShouldEqual, "runContainer16{0:[3, 4], }")
 
-		a := interval16{start: 5, last: 9}
-		b := interval16{start: 0, last: 1}
-		c := interval16{start: 1, last: 2}
+		a := newInterval16Range(5, 9)
+		b := newInterval16Range(0, 1)
+		c := newInterval16Range(1, 2)
 
 		// intersectInterval16s(a, b interval16)
 		isect, isEmpty := intersectInterval16s(a, b)

--- a/rlecommon.go
+++ b/rlecommon.go
@@ -31,7 +31,6 @@ const MaxUint16 = 65535
 // prior knowledge of (mostly lower) bounds. This is used by Union
 // and Intersect.
 type searchOptions struct {
-
 	// start here instead of at 0
 	startIndex int64
 
@@ -105,7 +104,8 @@ type trial struct {
 func (rc *runContainer16) And(b *Bitmap) *Bitmap {
 	out := NewBitmap()
 	for _, p := range rc.iv {
-		for i := p.start; i <= p.last; i++ {
+		plast := p.last()
+		for i := p.start; i <= plast; i++ {
 			if b.Contains(uint32(i)) {
 				out.Add(uint32(i))
 			}
@@ -118,7 +118,8 @@ func (rc *runContainer16) And(b *Bitmap) *Bitmap {
 func (rc *runContainer16) Xor(b *Bitmap) *Bitmap {
 	out := b.Clone()
 	for _, p := range rc.iv {
-		for v := p.start; v <= p.last; v++ {
+		plast := p.last()
+		for v := p.start; v <= plast; v++ {
 			w := uint32(v)
 			if out.Contains(w) {
 				out.RemoveRange(uint64(w), uint64(w+1))
@@ -134,7 +135,8 @@ func (rc *runContainer16) Xor(b *Bitmap) *Bitmap {
 func (rc *runContainer16) Or(b *Bitmap) *Bitmap {
 	out := b.Clone()
 	for _, p := range rc.iv {
-		for v := p.start; v <= p.last; v++ {
+		plast := p.last()
+		for v := p.start; v <= plast; v++ {
 			out.Add(uint32(v))
 		}
 	}

--- a/rlei.go
+++ b/rlei.go
@@ -201,6 +201,7 @@ func (rc *runContainer16) iaddRange(firstOfRange, endx int) container {
 		{
 			start: uint16(firstOfRange),
 			last:  uint16(endx - 1),
+			length: uint16(endx - 1 - firstOfRange),
 		},
 	})
 	*rc = *rc.union(addme)
@@ -214,7 +215,7 @@ func (rc *runContainer16) iremoveRange(firstOfRange, endx int) container {
 			" nothing to do.", firstOfRange, endx))
 		//return rc
 	}
-	x := interval16{start: uint16(firstOfRange), last: uint16(endx - 1)}
+	x := interval16{start: uint16(firstOfRange), last: uint16(endx - 1), length: uint16(endx - 1 - firstOfRange)}
 	rc.isubtract(x)
 	return rc
 }
@@ -256,7 +257,7 @@ func (rc *runContainer16) Not(firstOfRange, endx int) *runContainer16 {
 
 	nota := a.invert()
 
-	bs := []interval16{{start: uint16(firstOfRange), last: uint16(endx - 1)}}
+	bs := []interval16{{start: uint16(firstOfRange), last: uint16(endx - 1), length: uint16(endx - 1 - firstOfRange)}}
 	b := newRunContainer16TakeOwnership(bs)
 
 	notAintersectB := nota.intersect(b)

--- a/rlei.go
+++ b/rlei.go
@@ -22,11 +22,11 @@ func (rc *runContainer16) minimum() uint16 {
 }
 
 func (rc *runContainer16) maximum() uint16 {
-	return rc.iv[len(rc.iv)-1].last // assume not empty
+	return rc.iv[len(rc.iv)-1].last() // assume not empty
 }
 
 func (rc *runContainer16) isFull() bool {
-	return (len(rc.iv) == 1) && ((rc.iv[0].start == 0) && (rc.iv[0].last == MaxUint16))
+	return (len(rc.iv) == 1) && ((rc.iv[0].start == 0) && (rc.iv[0].last() == MaxUint16))
 }
 
 func (rc *runContainer16) and(a container) container {
@@ -85,7 +85,7 @@ mainloop:
 			}
 			v = ac.content[pos]
 		}
-		for v <= p.last {
+		for v <= p.last() {
 			answer++
 			pos++
 			if pos == maxpos {
@@ -199,8 +199,7 @@ func (rc *runContainer16) iaddRange(firstOfRange, endx int) container {
 	}
 	addme := newRunContainer16TakeOwnership([]interval16{
 		{
-			start: uint16(firstOfRange),
-			last:  uint16(endx - 1),
+			start:  uint16(firstOfRange),
 			length: uint16(endx - 1 - firstOfRange),
 		},
 	})
@@ -215,7 +214,7 @@ func (rc *runContainer16) iremoveRange(firstOfRange, endx int) container {
 			" nothing to do.", firstOfRange, endx))
 		//return rc
 	}
-	x := interval16{start: uint16(firstOfRange), last: uint16(endx - 1), length: uint16(endx - 1 - firstOfRange)}
+	x := newInterval16Range(uint16(firstOfRange), uint16(endx-1))
 	rc.isubtract(x)
 	return rc
 }
@@ -257,7 +256,7 @@ func (rc *runContainer16) Not(firstOfRange, endx int) *runContainer16 {
 
 	nota := a.invert()
 
-	bs := []interval16{{start: uint16(firstOfRange), last: uint16(endx - 1), length: uint16(endx - 1 - firstOfRange)}}
+	bs := []interval16{newInterval16Range(uint16(firstOfRange), uint16(endx-1))}
 	b := newRunContainer16TakeOwnership(bs)
 
 	notAintersectB := nota.intersect(b)
@@ -370,7 +369,7 @@ func (rc *runContainer16) orBitmapContainer(bc *bitmapContainer) container {
 func (rc *runContainer16) andBitmapContainerCardinality(bc *bitmapContainer) int {
 	answer := 0
 	for i := range rc.iv {
-		answer += bc.getCardinalityInRange(uint(rc.iv[i].start), uint(rc.iv[i].last)+1)
+		answer += bc.getCardinalityInRange(uint(rc.iv[i].start), uint(rc.iv[i].last())+1)
 	}
 	//bc.computeCardinality()
 	return answer
@@ -410,7 +409,7 @@ func (rc *runContainer16) ior(a container) container {
 func (rc *runContainer16) inplaceUnion(rc2 *runContainer16) container {
 	p("rc.inplaceUnion with len(rc2.iv)=%v", len(rc2.iv))
 	for _, p := range rc2.iv {
-		last := int64(p.last)
+		last := int64(p.last())
 		for i := int64(p.start); i <= last; i++ {
 			rc.Add(uint16(i))
 		}
@@ -607,7 +606,7 @@ func (rc *runContainer16) toBitmapContainer() *bitmapContainer {
 	p("run16 toBitmap starting; rc has %v ranges", len(rc.iv))
 	bc := newBitmapContainer()
 	for i := range rc.iv {
-		bc.iaddRange(int(rc.iv[i].start), int(rc.iv[i].last)+1)
+		bc.iaddRange(int(rc.iv[i].start), int(rc.iv[i].last())+1)
 	}
 	bc.computeCardinality()
 	return bc
@@ -683,7 +682,7 @@ func (rc *runContainer16) toEfficientContainer() container {
 func (rc *runContainer16) toArrayContainer() *arrayContainer {
 	ac := newArrayContainer()
 	for i := range rc.iv {
-		ac.iaddRange(int(rc.iv[i].start), int(rc.iv[i].last)+1)
+		ac.iaddRange(int(rc.iv[i].start), int(rc.iv[i].last())+1)
 	}
 	return ac
 }

--- a/rlei_test.go
+++ b/rlei_test.go
@@ -817,21 +817,21 @@ func TestRle16SubtractionOfIntervals019(t *testing.T) {
 		left, _ = v.subtractInterval(newInterval16Range(3, 4))
 		So(len(left), ShouldResemble, 2)
 		So(left[0].start, ShouldEqual, 1)
-		So(left[0].last, ShouldEqual, 2)
+		So(left[0].last(), ShouldEqual, 2)
 		So(left[1].start, ShouldEqual, 5)
-		So(left[1].last, ShouldEqual, 6)
+		So(left[1].last(), ShouldEqual, 6)
 
 		v = newInterval16Range(1, 6)
 		left, _ = v.subtractInterval(newInterval16Range(4, 10))
 		So(len(left), ShouldResemble, 1)
 		So(left[0].start, ShouldEqual, 1)
-		So(left[0].last, ShouldEqual, 3)
+		So(left[0].last(), ShouldEqual, 3)
 
 		v = newInterval16Range(5, 10)
 		left, _ = v.subtractInterval(newInterval16Range(0, 7))
 		So(len(left), ShouldResemble, 1)
 		So(left[0].start, ShouldEqual, 8)
-		So(left[0].last, ShouldEqual, 10)
+		So(left[0].last(), ShouldEqual, 10)
 
 		seed := int64(42)
 		p("seed is %v", seed)
@@ -887,7 +887,7 @@ func TestRle16SubtractionOfIntervals019(t *testing.T) {
 				it := rcb.newRunIterator16()
 				for it.hasNext() {
 					nx := it.next()
-					rc.isubtract(interval16{start: nx, last: nx})
+					rc.isubtract(newInterval16Range(nx, nx))
 				}
 
 				// also check full interval subtraction
@@ -1767,11 +1767,11 @@ func getRandomSameThreeContainers(tr trial) (*arrayContainer, *runContainer16, *
 	if tr.srang != nil {
 		samp = *tr.srang
 	} else {
-		samp.start = 0
 		if n-1 > MaxUint16 {
 			panic(fmt.Errorf("n out of range: %v", n))
 		}
-		samp.last = uint16(n - 1)
+		samp.start = 0
+		samp.length = uint16(n - 2)
 	}
 
 	draw := int(float64(n) * tr.percentFill)

--- a/rlei_test.go
+++ b/rlei_test.go
@@ -809,26 +809,26 @@ func TestRle16SubtractionOfIntervals019(t *testing.T) {
 	Convey("runContainer `subtract` operation removes an interval in-place", t, func() {
 		// basics
 
-		i22 := interval16{start: 2, last: 2}
+		i22 := newInterval16Range(2, 2)
 		left, _ := i22.subtractInterval(i22)
 		So(len(left), ShouldResemble, 0)
 
-		v := interval16{start: 1, last: 6}
-		left, _ = v.subtractInterval(interval16{start: 3, last: 4})
+		v := newInterval16Range(1, 6)
+		left, _ = v.subtractInterval(newInterval16Range(3, 4))
 		So(len(left), ShouldResemble, 2)
 		So(left[0].start, ShouldEqual, 1)
 		So(left[0].last, ShouldEqual, 2)
 		So(left[1].start, ShouldEqual, 5)
 		So(left[1].last, ShouldEqual, 6)
 
-		v = interval16{start: 1, last: 6}
-		left, _ = v.subtractInterval(interval16{start: 4, last: 10})
+		v = newInterval16Range(1, 6)
+		left, _ = v.subtractInterval(newInterval16Range(4, 10))
 		So(len(left), ShouldResemble, 1)
 		So(left[0].start, ShouldEqual, 1)
 		So(left[0].last, ShouldEqual, 3)
 
-		v = interval16{start: 5, last: 10}
-		left, _ = v.subtractInterval(interval16{start: 0, last: 7})
+		v = newInterval16Range(5, 10)
+		left, _ = v.subtractInterval(newInterval16Range(0, 7))
 		So(len(left), ShouldResemble, 1)
 		So(left[0].start, ShouldEqual, 8)
 		So(left[0].last, ShouldEqual, 10)
@@ -1612,9 +1612,10 @@ func TestAllContainerMethodsAllContainerTypesWithData067(t *testing.T) {
 		p("seed is %v", seed)
 		rand.Seed(seed)
 
+		srang := newInterval16Range(MaxUint16-100, MaxUint16)
 		trials := []trial{
 			{n: 100, percentFill: .7, ntrial: 1, numRandomOpsPass: 100},
-			{n: 100, percentFill: .7, ntrial: 1, numRandomOpsPass: 100, srang: &interval16{MaxUint16 - 100, MaxUint16}}}
+			{n: 100, percentFill: .7, ntrial: 1, numRandomOpsPass: 100, srang: &srang}}
 
 		tester := func(tr trial) {
 			for j := 0; j < tr.ntrial; j++ {

--- a/roaring_test.go
+++ b/roaring_test.go
@@ -22,6 +22,7 @@ func TestFirstLast(t *testing.T) {
 		t.Errorf("bad maximum")
 		t.FailNow()
 	}
+
 	i := 1 << 5
 	for ; i < (1 << 17); i++ {
 		bm.AddInt(i)
@@ -34,7 +35,9 @@ func TestFirstLast(t *testing.T) {
 			t.FailNow()
 		}
 	}
+
 	bm.RunOptimize()
+
 	if 2 != bm.Minimum() {
 		t.Errorf("bad minimum")
 		t.FailNow()

--- a/serialization.go
+++ b/serialization.go
@@ -78,29 +78,3 @@ func (b *runContainer16) readFrom(stream io.Reader) (int, error) {
 	}
 	return 0, err
 }
-
-// Converts a byte slice to a interval16 slice.
-// The function assumes that the slice byte buffer is run container data
-// encoded according to Roaring Format Spec
-func byteSliceAsInterval16Slice(byteSlice []byte) []interval16 {
-	// Since interval16 is currently implemented as a start-last pair
-	// whereas the Roaring Spec Format says the data is serialized as start-length
-	// To compensate for this mismatch we have to copy the slice and re-calculate the values
-
-	if len(byteSlice)%4 != 0 {
-		panic("Slice size should be divisible by 4")
-	}
-
-	encSlice := byteSliceAsUint16Slice(byteSlice)
-
-	intervalSlice := make([]interval16, len(byteSlice)/4)
-
-	for i := range intervalSlice {
-		intervalSlice[i] = interval16{
-			start:  encSlice[2*i],
-			length: encSlice[i*2+1],
-		}
-	}
-
-	return intervalSlice
-}

--- a/serialization_generic.go
+++ b/serialization_generic.go
@@ -63,7 +63,7 @@ func byteSliceAsUint16Slice(slice []byte) []uint16 {
 		panic("Slice size should be divisible by 2")
 	}
 
-	b := make([]uint16, len(slice), len(slice))
+	b := make([]uint16, len(slice)/2)
 
 	for i := range b {
 		b[i] = binary.LittleEndian.Uint16(slice[2*i:])
@@ -77,11 +77,31 @@ func byteSliceAsUint64Slice(slice []byte) []uint64 {
 		panic("Slice size should be divisible by 8")
 	}
 
-	b := make([]uint64, len(slice), len(slice))
+	b := make([]uint64, len(slice)/8)
 
 	for i := range b {
 		b[i] = binary.LittleEndian.Uint64(slice[8*i:])
 	}
 
 	return b
+}
+
+// Converts a byte slice to a interval16 slice.
+// The function assumes that the slice byte buffer is run container data
+// encoded according to Roaring Format Spec
+func byteSliceAsInterval16Slice(byteSlice []byte) []interval16 {
+	if len(byteSlice)%4 != 0 {
+		panic("Slice size should be divisible by 4")
+	}
+
+	intervalSlice := make([]interval16, len(byteSlice)/4)
+
+	for i := range intervalSlice {
+		intervalSlice[i] = interval16{
+			start:  binary.LittleEndian.Uint16(byteSlice[i*4:]),
+			length: binary.LittleEndian.Uint16(byteSlice[i*4+2:]),
+		}
+	}
+
+	return intervalSlice
 }

--- a/serialization_littleendian.go
+++ b/serialization_littleendian.go
@@ -95,3 +95,19 @@ func byteSliceAsUint64Slice(slice []byte) []uint64 {
 	// return it
 	return *(*[]uint64)(unsafe.Pointer(&header))
 }
+
+func byteSliceAsInterval16Slice(slice []byte) []interval16 {
+	if len(slice)%4 != 0 {
+		panic("Slice size should be divisible by 4")
+	}
+
+	// make a new slice header
+	header := *(*reflect.SliceHeader)(unsafe.Pointer(&slice))
+
+	// update its capacity and length
+	header.Len /= 4
+	header.Cap /= 4
+
+	// return it
+	return *(*[]interval16)(unsafe.Pointer(&header))
+}

--- a/serialization_test.go
+++ b/serialization_test.go
@@ -793,8 +793,8 @@ func TestByteSliceAsInterval16Slice(t *testing.T) {
 			t.Errorf("Expected output slice cap %d, got %d", expectedSize, len(intervalSlice))
 		}
 
-		i1 := interval16{10, 12}
-		i2 := interval16{20, 22}
+		i1 := newInterval16Range(10, 12)
+		i2 := newInterval16Range(20, 22)
 		if intervalSlice[0] != i1 || intervalSlice[1] != i2 {
 			t.Errorf("Unexpected items in result slice")
 		}


### PR DESCRIPTION
With introduction of a RLE memory layout matching RoaringFormatSpec
`byteSliceAsInterval16Slice` can be now be implemented using an
unsafe slice cast from `[]byte` to `[]interval16`

This pull request is based of #126.