### PR TITLE
Generic bitmapContainer.readFrom() function should compute cardinality

### DIFF
--- a/serialization_generic.go
+++ b/serialization_generic.go
@@ -47,6 +47,7 @@ func (b *bitmapContainer) readFrom(stream io.Reader) (int, error) {
 	if err != nil {
 		return 0, err
 	}
+	b.computeCardinality()
 	return 8 * len(b.bitmap), nil
 }
 


### PR DESCRIPTION
Fix `bitmapContainer.readFrom()` to compute cardinality just like
its _littleendian_ counterpart.