### PR TITLE
roaringArray.fromBuffer() changes

### DIFF
--- a/roaringarray.go
+++ b/roaringarray.go
@@ -580,13 +580,16 @@ func (ra *roaringArray) fromBuffer(buf []byte) (int64, error) {
 	}
 
 	// Allocate slices upfront as number of containers is known
-	ra.containers = make([]container, 0, size)
-	ra.keys = make([]uint16, 0, size)
-	ra.needCopyOnWrite = make([]bool, 0, size)
+	ra.containers = make([]container, size)
+	ra.keys = make([]uint16, size)
+	ra.needCopyOnWrite = make([]bool, size)
 
 	for i := uint32(0); i < size; i++ {
 		key := uint16(keycard[2*i])
 		card := int(keycard[2*i+1]) + 1
+		ra.keys[i] = key
+		ra.needCopyOnWrite[i] = true
+
 		if haveRunContainers && isRun.contains(uint16(i)) {
 			// run container
 			nr := binary.LittleEndian.Uint16(buf[pos:])
@@ -596,7 +599,7 @@ func (ra *roaringArray) fromBuffer(buf []byte) (int64, error) {
 				card: int64(card),
 			}
 			pos += int(nr) * 4
-			ra.appendContainer(key, &nb, true)
+			ra.containers[i] = &nb
 		} else if card > arrayDefaultMaxSize {
 			// bitmap container
 			nb := bitmapContainer{
@@ -604,14 +607,14 @@ func (ra *roaringArray) fromBuffer(buf []byte) (int64, error) {
 				bitmap:      byteSliceAsUint64Slice(buf[pos : pos+arrayDefaultMaxSize*2]),
 			}
 			pos += arrayDefaultMaxSize * 2
-			ra.appendContainer(key, &nb, true)
+			ra.containers[i] = &nb
 		} else {
 			// array container
 			nb := arrayContainer{
 				byteSliceAsUint16Slice(buf[pos : pos+card*2]),
 			}
 			pos += card * 2
-			ra.appendContainer(key, &nb, true)
+			ra.containers[i] = &nb
 		}
 	}
 

--- a/serialization_generic.go
+++ b/serialization_generic.go
@@ -59,6 +59,16 @@ func (bc *bitmapContainer) asLittleEndianByteSlice() []byte {
 	return by
 }
 
+func uint64SliceAsByteSlice(slice []uint64) []byte {
+	by := make([]byte, len(slice)*8)
+
+	for i, v := range slice {
+		binary.LittleEndian.PutUint64(by[i*8:], v)
+	}
+
+	return by
+}
+
 func byteSliceAsUint16Slice(slice []byte) []uint16 {
 	if len(slice)%2 != 0 {
 		panic("Slice size should be divisible by 2")


### PR DESCRIPTION
This PR introduces two changes to `roaringArray.fromBuffer` function:

* when creating the `isRun` bitmap instead looping over `unit64`s (and the remainder of bytes)  I "cast" the `isRun` bitmap to a `[]byte` slice using the `uint64SliceAsByteSlice` function and use the built-in `copy` fun to copy into the bitmap. I can observe a slight performance improvement on production systems due to that change

* a less significant change removes usage of `appendContainer` method and instead populates the `roaringArray` slices directly. I don't know if this has any impact on performance. Taking it on face value we eliminate the slice length change and the assignment. I have no measured if it has any impact on performance TBH, it'd likely be very insignificant if anything. Frankly, I simply prefer that way of expressing the operation in code. :-)