### PR TITLE
Parallel operation changes

### DIFF
--- a/parallel.go
+++ b/parallel.go
@@ -9,10 +9,9 @@ import (
 var defaultWorkerCount = runtime.NumCPU()
 
 type bitmapContainerKey struct {
-	bitmap    *Bitmap
-	container container
-	key       uint16
-	idx       int
+	key    uint16
+	idx    int
+	bitmap *Bitmap
 }
 
 type multipleContainers struct {
@@ -43,7 +42,7 @@ func (h *bitmapContainerHeap) Pop() interface{} {
 	old := *h
 	n := len(old)
 	x := old[n-1]
-	*h = old[0: n-1]
+	*h = old[0 : n-1]
 	return x
 }
 
@@ -54,15 +53,14 @@ func (h bitmapContainerHeap) Peek() bitmapContainerKey {
 func (h *bitmapContainerHeap) popIncrementing() (key uint16, container container) {
 	k := h.Peek()
 	key = k.key
-	container = k.container
+	container = k.bitmap.highlowcontainer.containers[k.idx]
 
 	newIdx := k.idx + 1
 	if newIdx < k.bitmap.highlowcontainer.size() {
 		k = bitmapContainerKey{
-			k.bitmap,
-			k.bitmap.highlowcontainer.containers[newIdx],
 			k.bitmap.highlowcontainer.keys[newIdx],
 			newIdx,
+			k.bitmap,
 		}
 		(*h)[0] = k
 		heap.Fix(h, 0)
@@ -99,10 +97,9 @@ func newBitmapContainerHeap(bitmaps ...*Bitmap) bitmapContainerHeap {
 	for _, bitmap := range bitmaps {
 		if !bitmap.IsEmpty() {
 			key := bitmapContainerKey{
-				bitmap,
-				bitmap.highlowcontainer.containers[0],
 				bitmap.highlowcontainer.keys[0],
 				0,
+				bitmap,
 			}
 			h = append(h, key)
 		}


### PR DESCRIPTION
This PR introduces two changes to parallel operations:
* it removes the unnecessary container pointer from `bitmapContainerKey` struct. This has a surprisingly significant impact on performance in the private benchmark[1] I'm using.
* it pools `[]container` slice passed to `orFunc` in `ParOr`. The measured perf. impact is not as significant as in the first change, but it's also positive

[1] I hope, hope to make some progress on #113 soon! :-)