### PR TITLE
Make maxWord computed from uint64

### DIFF
--- a/util.go
+++ b/util.go
@@ -15,17 +15,13 @@ const (
 	noOffsetThreshold          = 4
 
 	// Compute wordSizeInBytes, the size of a word in bytes.
-	_m              = ^word(0)
+	_m              = ^uint64(0)
 	_logS           = _m>>8&1 + _m>>16&1 + _m>>32&1
 	wordSizeInBytes = 1 << _logS
 
 	// other constants used in ctz_generic.go
 	wordSizeInBits = wordSizeInBytes << 3 // word size in bits
-	digitBase      = 1 << wordSizeInBits  // digit base
-	digitMask      = digitBase - 1        // digit mask
 )
-
-type word uintptr
 
 const maxWord = 1<<wordSizeInBits - 1
 


### PR DESCRIPTION
Running on armv7l (Raspberry Pi 3 CPU) resulted in slice overruns.
To fix this I made the `maxWord` be computed of the same type - `uint64`
on both 32 and 64 bit architectures. `uintptr` is architecture dependent

```
* /home/pi/go/src/github.com/RoaringBitmap/roaring/rlei_test.go
  Line 703: - runtime error: index out of range
  goroutine 18 [running]:
  panic(0x26d138, 0x3e2530)
  	/usr/local/go/src/runtime/panic.go:491 +0x204
  github.com/RoaringBitmap/roaring.newRunContainer16FromBitmapContainer(0x10e748e0, 0x10e38c4c)
  	/home/pi/go/src/github.com/RoaringBitmap/roaring/rle16.go:257 +0x448
  github.com/RoaringBitmap/roaring.(*runContainer16).iandNotBitmap(0x10e705d0, 0x10e38c4c, 0x2041d8, 0x10f27800)
  	/home/pi/go/src/github.com/RoaringBitmap/roaring/rlei.go:632 +0x40
```

To be honest, I'm not sure if it's a perfect fix, however it made the tests green :-)