### PR TITLE
Benchmark ORs using _real roaring datasets_

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,14 @@ https://coveralls.io/github/RoaringBitmap/roaring?branch=master
 Type
 
          go test -bench Benchmark -run -
+         
+To run benchmarks on [Real Roaring Datasets](https://github.com/RoaringBitmap/real-roaring-datasets)
+run the following:
+
+```sh
+go get github.com/RoaringBitmap/real-roaring-datasets
+BENCH_REAL_DATA=1 go test -bench BenchmarkRealData -run -
+```
 
 ### Iterative use
 

--- a/real_data_benchmark_test.go
+++ b/real_data_benchmark_test.go
@@ -1,0 +1,125 @@
+package roaring
+
+import (
+	"archive/zip"
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+var benchRealData = false
+
+var realDatasets = []string{
+	"census-income_srt", "census-income", "census1881_srt", "census1881",
+	"dimension_003", "dimension_008", "dimension_033", "uscensus2000", "weather_sept_85_srt", "weather_sept_85",
+	"wikileaks-noquotes_srt", "wikileaks-noquotes",
+}
+
+func init() {
+	if envStr, ok := os.LookupEnv("BENCH_REAL_DATA"); ok {
+		v, err := strconv.ParseBool(envStr)
+		if err != nil {
+			v = false
+		}
+		benchRealData = v
+	}
+}
+
+func retrieveRealDataBitmaps(datasetName string, optimize bool) ([]*Bitmap, error) {
+	gopath, ok := os.LookupEnv("GOPATH")
+	if !ok {
+		return nil, fmt.Errorf("GOPATH not set. It's required to locate real-roaring-datasets. Set GOPATH or disable BENCH_REAL_DATA")
+	}
+
+	basePath := path.Join(gopath, "src", "github.com", "RoaringBitmap", "real-roaring-datasets")
+
+	if _, err := os.Stat(basePath); os.IsNotExist(err) {
+		return nil, fmt.Errorf("real-roaring-datasets does not exist. Run `go get github.com/RoaringBitmap/real-roaring-datasets`")
+	}
+
+	datasetPath := path.Join(basePath, datasetName+".zip")
+
+	if _, err := os.Stat(datasetPath); os.IsNotExist(err) {
+		return nil, fmt.Errorf("dataset %s does not exist, tried path: %s", datasetName, datasetPath)
+	}
+
+	zipFile, err := zip.OpenReader(datasetPath)
+	if err != nil {
+		return nil, fmt.Errorf("error opening dataset %s zipfile, cause: %v", datasetPath, err)
+	}
+	defer zipFile.Close()
+
+	bitmaps := make([]*Bitmap, len(zipFile.File))
+	for i, f := range zipFile.File {
+		r, err := f.Open()
+		if err != nil {
+			return nil, fmt.Errorf("failed to read bitmap file %s from dataset %s, cause: %v", f.Name, datasetName, err)
+		}
+
+		content, err := ioutil.ReadAll(r)
+		if err != nil {
+			r.Close()
+			return nil, fmt.Errorf("could not read content of file %s from dataset %s, cause: %v", f.Name, datasetName, err)
+		}
+
+		elemsAsBytes := bytes.Split(content, []byte{44}) // 44 is a comma
+
+		b := NewBitmap()
+		for _, elemBytes := range elemsAsBytes {
+			elemStr := strings.TrimSpace(string(elemBytes))
+			e, err := strconv.ParseUint(elemStr, 10, 32)
+			if err != nil {
+				r.Close()
+				return nil, fmt.Errorf("could not parse %s as uint32. Reading %s from %s. Cause: %v", elemStr, f.Name, datasetName, err)
+			}
+
+			b.Add(uint32(e))
+		}
+		if optimize {
+			b.RunOptimize()
+		}
+
+		bitmaps[i] = b
+
+		r.Close()
+	}
+
+	return bitmaps, nil
+}
+
+func benchmarkRealDataAggregate(b *testing.B, aggregator func(b []*Bitmap) uint64) {
+	if !benchRealData {
+		b.SkipNow()
+	}
+
+	for _, dataset := range realDatasets {
+		b.Run(dataset, func(b *testing.B) {
+			bitmaps, err := retrieveRealDataBitmaps(dataset, true)
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				aggregator(bitmaps)
+			}
+		})
+	}
+}
+
+func BenchmarkRealDataParOr(b *testing.B) {
+	benchmarkRealDataAggregate(b, func(bitmaps []*Bitmap) uint64 {
+		return ParOr(0, bitmaps...).GetCardinality()
+	})
+}
+
+func BenchmarkRealDataFastOr(b *testing.B) {
+	benchmarkRealDataAggregate(b, func(bitmaps []*Bitmap) uint64 {
+		return FastOr(bitmaps...).GetCardinality()
+	})
+}

--- a/real_data_benchmark_test.go
+++ b/real_data_benchmark_test.go
@@ -4,7 +4,7 @@ import (
 	"archive/zip"
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path"
 	"strconv"
@@ -54,24 +54,50 @@ func retrieveRealDataBitmaps(datasetName string, optimize bool) ([]*Bitmap, erro
 	}
 	defer zipFile.Close()
 
+	var largestFileSize uint64
+	for _, f := range zipFile.File {
+		if f.UncompressedSize64 > largestFileSize {
+			largestFileSize = f.UncompressedSize64
+		}
+	}
+
 	bitmaps := make([]*Bitmap, len(zipFile.File))
+	buf := make([]byte, largestFileSize)
+	var bufStep uint64 = 32768 // apparently the largest buffer zip can read
 	for i, f := range zipFile.File {
 		r, err := f.Open()
 		if err != nil {
 			return nil, fmt.Errorf("failed to read bitmap file %s from dataset %s, cause: %v", f.Name, datasetName, err)
 		}
 
-		content, err := ioutil.ReadAll(r)
-		if err != nil {
-			r.Close()
-			return nil, fmt.Errorf("could not read content of file %s from dataset %s, cause: %v", f.Name, datasetName, err)
+		var totalReadBytes uint64
+
+		for {
+			var endOffset uint64
+			if f.UncompressedSize64 < totalReadBytes+bufStep {
+				endOffset = f.UncompressedSize64
+			} else {
+				endOffset = totalReadBytes + bufStep
+			}
+
+			readBytes, err := r.Read(buf[totalReadBytes:endOffset])
+			totalReadBytes += uint64(readBytes)
+
+			if err == io.EOF {
+				r.Close()
+				break
+			} else if err != nil {
+				r.Close()
+				return nil, fmt.Errorf("could not read content of file %s from dataset %s, cause: %v", f.Name, datasetName, err)
+			}
 		}
 
-		elemsAsBytes := bytes.Split(content, []byte{44}) // 44 is a comma
+		elemsAsBytes := bytes.Split(buf[:totalReadBytes], []byte{44}) // 44 is a comma
 
 		b := NewBitmap()
 		for _, elemBytes := range elemsAsBytes {
 			elemStr := strings.TrimSpace(string(elemBytes))
+
 			e, err := strconv.ParseUint(elemStr, 10, 32)
 			if err != nil {
 				r.Close()
@@ -80,13 +106,12 @@ func retrieveRealDataBitmaps(datasetName string, optimize bool) ([]*Bitmap, erro
 
 			b.Add(uint32(e))
 		}
+
 		if optimize {
 			b.RunOptimize()
 		}
 
 		bitmaps[i] = b
-
-		r.Close()
 	}
 
 	return bitmaps, nil


### PR DESCRIPTION
This commit introduces benchmarks that use _real roaring datasets_[1].

I think it gets us covered pretty well in terms of benchmarking
`fast` and `par` aggregations.

Below are results from running on my Mac
(Late 2013 15' MBP with Intel(R) Core(TM) i7-4960HQ CPU @ 2.60GHz):

```
⨯ env BENCH_REAL_DATA=1 go1.10rc1 test -bench 'BenchmarkRealData' -run -                                                14:31:58
goos: darwin
goarch: amd64
pkg: github.com/RoaringBitmap/roaring
BenchmarkRealDataParOr/census-income_srt-8         	    5000	    350298 ns/op
BenchmarkRealDataParOr/census-income-8             	    3000	    420514 ns/op
BenchmarkRealDataParOr/census1881_srt-8            	    2000	    687655 ns/op
BenchmarkRealDataParOr/census1881-8                	    2000	    680842 ns/op
BenchmarkRealDataParOr/dimension_003-8             	     200	   7257651 ns/op
BenchmarkRealDataParOr/dimension_008-8             	     500	   3174280 ns/op
BenchmarkRealDataParOr/dimension_033-8             	    3000	    468538 ns/op
BenchmarkRealDataParOr/uscensus2000-8              	    1000	   1975417 ns/op
BenchmarkRealDataParOr/weather_sept_85_srt-8       	    5000	    370837 ns/op
BenchmarkRealDataParOr/weather_sept_85-8           	    1000	   1284231 ns/op
BenchmarkRealDataParOr/wikileaks-noquotes_srt-8    	    5000	    286445 ns/op
BenchmarkRealDataParOr/wikileaks-noquotes-8        	    5000	    366164 ns/op
BenchmarkRealDataFastOr/census-income_srt-8        	    2000	    760627 ns/op
BenchmarkRealDataFastOr/census-income-8            	    2000	   1053403 ns/op
BenchmarkRealDataFastOr/census1881_srt-8           	    1000	   1648185 ns/op
BenchmarkRealDataFastOr/census1881-8               	    1000	   2284316 ns/op
BenchmarkRealDataFastOr/dimension_003-8            	      50	  32693733 ns/op
BenchmarkRealDataFastOr/dimension_008-8            	     100	  12077923 ns/op
BenchmarkRealDataFastOr/dimension_033-8            	    2000	    994401 ns/op
BenchmarkRealDataFastOr/uscensus2000-8             	     300	   4090877 ns/op
BenchmarkRealDataFastOr/weather_sept_85_srt-8      	    3000	    579828 ns/op
BenchmarkRealDataFastOr/weather_sept_85-8          	     300	   4556971 ns/op
BenchmarkRealDataFastOr/wikileaks-noquotes_srt-8   	    3000	    459795 ns/op
BenchmarkRealDataFastOr/wikileaks-noquotes-8       	    2000	    752005 ns/op
PASS
ok  	github.com/RoaringBitmap/roaring	94.864s

```

[1] https://github.com/RoaringBitmap/real-roaring-datasets