### PR TITLE
Eliminate unnecessary Bitmap allocation in (*Bitmap).lazyOR

### DIFF
--- a/fastaggregation.go
+++ b/fastaggregation.go
@@ -63,7 +63,6 @@ main:
 
 // In-place Or function that requires repairAfterLazy
 func (x1 *Bitmap) lazyOR(x2 *Bitmap) *Bitmap {
-	answer := NewBitmap() // TODO: we return a new bitmap... could be optimized
 	pos1 := 0
 	pos2 := 0
 	length1 := x1.highlowcontainer.size()
@@ -75,15 +74,16 @@ main:
 
 		for {
 			if s1 < s2 {
-				answer.highlowcontainer.appendWithoutCopy(x1.highlowcontainer, pos1)
 				pos1++
 				if pos1 == length1 {
 					break main
 				}
 				s1 = x1.highlowcontainer.getKeyAtIndex(pos1)
 			} else if s1 > s2 {
-				answer.highlowcontainer.appendCopy(x2.highlowcontainer, pos2)
+				x1.highlowcontainer.insertNewKeyValueAt(pos1, s2, x2.highlowcontainer.getContainerAtIndex(pos2).clone())
 				pos2++
+				pos1++
+				length1++
 				if pos2 == length2 {
 					break main
 				}
@@ -101,7 +101,8 @@ main:
 					c1 = x1.highlowcontainer.getWritableContainerAtIndex(pos1)
 				}
 
-				answer.highlowcontainer.appendContainer(s1, c1.lazyIOR(x2.highlowcontainer.getContainerAtIndex(pos2)), false)
+				x1.highlowcontainer.containers[pos1] = c1.lazyIOR(x2.highlowcontainer.getContainerAtIndex(pos2))
+				x1.highlowcontainer.needCopyOnWrite[pos1] = false
 				pos1++
 				pos2++
 				if (pos1 == length1) || (pos2 == length2) {
@@ -113,11 +114,9 @@ main:
 		}
 	}
 	if pos1 == length1 {
-		answer.highlowcontainer.appendCopyMany(x2.highlowcontainer, pos2, length2)
-	} else if pos2 == length2 {
-		answer.highlowcontainer.appendWithoutCopyMany(x1.highlowcontainer, pos1, length1)
+		x1.highlowcontainer.appendCopyMany(x2.highlowcontainer, pos2, length2)
 	}
-	return answer
+	return x1
 }
 
 // to be called after lazy aggregates


### PR DESCRIPTION
Fixes #138

Benchmark on the "real" dataset show a significant improvement:

```
benchmark                                            old ns/op     new ns/op     delta
BenchmarkRealDataFastOr/census-income_srt-4          841099        736937        -12.38%
BenchmarkRealDataFastOr/census-income-4              1248805       1157445       -7.32%
BenchmarkRealDataFastOr/census1881_srt-4             1992651       1295663       -34.98%
BenchmarkRealDataFastOr/census1881-4                 2797780       2096418       -25.07%
BenchmarkRealDataFastOr/dimension_003-4              50486750      2174251       -95.69%
BenchmarkRealDataFastOr/dimension_008-4              17056898      904640        -94.70%
BenchmarkRealDataFastOr/dimension_033-4              1246254       794440        -36.25%
BenchmarkRealDataFastOr/uscensus2000-4               5387897       2702060       -49.85%
BenchmarkRealDataFastOr/weather_sept_85_srt-4        713331        505671        -29.11%
BenchmarkRealDataFastOr/weather_sept_85-4            5248820       4952945       -5.64%
BenchmarkRealDataFastOr/wikileaks-noquotes_srt-4     567737        276666        -51.27%
BenchmarkRealDataFastOr/wikileaks-noquotes-4         906403        613208        -32.35%
```