### PR TITLE
Zero value bitmaps

### DIFF
--- a/aggregation_test.go
+++ b/aggregation_test.go
@@ -6,11 +6,12 @@ import (
 	"testing"
 )
 
-func testAggregations(t *testing.T,
-	and func(bitmaps ... *Bitmap) *Bitmap,
-	or func(bitmaps ... *Bitmap) *Bitmap,
-	xor func(bitmaps ... *Bitmap) *Bitmap) {
-
+func testAggregations(
+	t *testing.T,
+	and func(bitmaps ...Bitmap) Bitmap,
+	or func(bitmaps ...Bitmap) Bitmap,
+	xor func(bitmaps ...Bitmap) Bitmap,
+) {
 	t.Run("simple case", func(t *testing.T) {
 		rb1 := NewBitmap()
 		rb2 := NewBitmap()
@@ -271,10 +272,10 @@ func testAggregations(t *testing.T,
 }
 
 func TestParAggregations(t *testing.T) {
-	andFunc := func(bitmaps ... *Bitmap) *Bitmap {
+	andFunc := func(bitmaps ...Bitmap) Bitmap {
 		return ParAnd(0, bitmaps...)
 	}
-	orFunc := func(bitmaps ... *Bitmap) *Bitmap {
+	orFunc := func(bitmaps ...Bitmap) Bitmap {
 		return ParOr(0, bitmaps...)
 	}
 

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -12,7 +12,7 @@ import (
 
 // BENCHMARKS, to run them type "go test -bench Benchmark -run -"
 
-var Rb *Bitmap
+var Rb Bitmap
 
 func BenchmarkNewBitmap(b *testing.B) {
 	b.ReportAllocs()
@@ -34,7 +34,7 @@ var c9 uint
 // go test -bench BenchmarkMemoryUsage -run -
 func BenchmarkMemoryUsage(b *testing.B) {
 	b.StopTimer()
-	bitmaps := make([]*Bitmap, 0, 10)
+	bitmaps := make([]Bitmap, 0, 10)
 
 	incr := uint32(1 << 16)
 	max := uint32(1<<32 - 1)
@@ -524,7 +524,8 @@ func BenchmarkXor(b *testing.B) {
 	b.StartTimer()
 
 	for j := 0; j < b.N; j++ {
-		s.Clone().Xor(x2)
+		bm := s.Clone()
+		bm.Xor(x2)
 	}
 }
 
@@ -546,6 +547,7 @@ func BenchmarkXorLopsided(b *testing.B) {
 	b.StartTimer()
 
 	for j := 0; j < b.N; j++ {
-		s.Clone().Xor(x2)
+		bm := s.Clone()
+		bm.Xor(x2)
 	}
 }

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -15,6 +15,7 @@ import (
 var Rb *Bitmap
 
 func BenchmarkNewBitmap(b *testing.B) {
+	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		Rb = New()
 	}

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -50,8 +50,7 @@ func BenchmarkMemoryUsage(b *testing.B) {
 
 	var stats runtime.MemStats
 	runtime.ReadMemStats(&stats)
-	fmt.Printf("\nHeapInUse %d\n", stats.HeapInuse)
-	fmt.Printf("HeapObjects %d\n", stats.HeapObjects)
+	b.Logf("HeapInUse: %d, HeapObjects: %d", stats.HeapInuse, stats.HeapObjects)
 	b.StartTimer()
 }
 

--- a/fastaggregation.go
+++ b/fastaggregation.go
@@ -5,7 +5,7 @@ import (
 )
 
 // Or function that requires repairAfterLazy
-func lazyOR(x1, x2 *Bitmap) *Bitmap {
+func lazyOR(x1, x2 Bitmap) Bitmap {
 	answer := NewBitmap()
 	pos1 := 0
 	pos2 := 0
@@ -62,7 +62,7 @@ main:
 }
 
 // In-place Or function that requires repairAfterLazy
-func (x1 *Bitmap) lazyOR(x2 *Bitmap) *Bitmap {
+func (x1 Bitmap) lazyOR(x2 Bitmap) Bitmap {
 	pos1 := 0
 	pos2 := 0
 	length1 := x1.highlowcontainer.size()
@@ -120,7 +120,7 @@ main:
 }
 
 // to be called after lazy aggregates
-func (x1 *Bitmap) repairAfterLazy() {
+func (x1 Bitmap) repairAfterLazy() {
 	for pos := 0; pos < x1.highlowcontainer.size(); pos++ {
 		c := x1.highlowcontainer.getContainerAtIndex(pos)
 		switch c.(type) {
@@ -141,7 +141,7 @@ func (x1 *Bitmap) repairAfterLazy() {
 // FastAnd computes the intersection between many bitmaps quickly
 // Compared to the And function, it can take many bitmaps as input, thus saving the trouble
 // of manually calling "And" many times.
-func FastAnd(bitmaps ...*Bitmap) *Bitmap {
+func FastAnd(bitmaps ...Bitmap) Bitmap {
 	if len(bitmaps) == 0 {
 		return NewBitmap()
 	} else if len(bitmaps) == 1 {
@@ -156,7 +156,7 @@ func FastAnd(bitmaps ...*Bitmap) *Bitmap {
 
 // FastOr computes the union between many bitmaps quickly, as opposed to having to call Or repeatedly.
 // It might also be faster than calling Or repeatedly.
-func FastOr(bitmaps ...*Bitmap) *Bitmap {
+func FastOr(bitmaps ...Bitmap) Bitmap {
 	if len(bitmaps) == 0 {
 		return NewBitmap()
 	} else if len(bitmaps) == 1 {
@@ -173,7 +173,7 @@ func FastOr(bitmaps ...*Bitmap) *Bitmap {
 
 // HeapOr computes the union between many bitmaps quickly using a heap.
 // It might be faster than calling Or repeatedly.
-func HeapOr(bitmaps ...*Bitmap) *Bitmap {
+func HeapOr(bitmaps ...Bitmap) Bitmap {
 	if len(bitmaps) == 0 {
 		return NewBitmap()
 	}
@@ -195,7 +195,7 @@ func HeapOr(bitmaps ...*Bitmap) *Bitmap {
 // HeapXor computes the symmetric difference between many bitmaps quickly (as opposed to calling Xor repeated).
 // Internally, this function uses a heap.
 // It might be faster than calling Xor repeatedly.
-func HeapXor(bitmaps ...*Bitmap) *Bitmap {
+func HeapXor(bitmaps ...Bitmap) Bitmap {
 	if len(bitmaps) == 0 {
 		return NewBitmap()
 	}

--- a/parallel.go
+++ b/parallel.go
@@ -11,7 +11,7 @@ var defaultWorkerCount = runtime.NumCPU()
 type bitmapContainerKey struct {
 	key    uint16
 	idx    int
-	bitmap *Bitmap
+	bitmap Bitmap
 }
 
 type multipleContainers struct {
@@ -91,7 +91,7 @@ func (h *bitmapContainerHeap) Next(containers []container) multipleContainers {
 	}
 }
 
-func newBitmapContainerHeap(bitmaps ...*Bitmap) bitmapContainerHeap {
+func newBitmapContainerHeap(bitmaps ...Bitmap) bitmapContainerHeap {
 	// Initialize heap
 	var h bitmapContainerHeap = make([]bitmapContainerKey, 0, len(bitmaps))
 	for _, bitmap := range bitmaps {
@@ -139,7 +139,7 @@ func toBitmapContainer(c container) container {
 	return c
 }
 
-func appenderRoutine(bitmapChan chan<- *Bitmap, resultChan <-chan keyedContainer, expectedKeysChan <-chan int) {
+func appenderRoutine(bitmapChan chan<- Bitmap, resultChan <-chan keyedContainer, expectedKeysChan <-chan int) {
 	expectedKeys := -1
 	appendedKeys := 0
 	keys := make([]uint16, 0)
@@ -159,7 +159,7 @@ func appenderRoutine(bitmapChan chan<- *Bitmap, resultChan <-chan keyedContainer
 			expectedKeys = msg
 		}
 	}
-	answer := &Bitmap{
+	answer := Bitmap{
 		roaringArray{
 			make([]uint16, 0, expectedKeys),
 			make([]container, 0, expectedKeys),
@@ -180,7 +180,7 @@ func appenderRoutine(bitmapChan chan<- *Bitmap, resultChan <-chan keyedContainer
 // ParOr computes the union (OR) of all provided bitmaps in parallel,
 // where the parameter "parallelism" determines how many workers are to be used
 // (if it is set to 0, a default number of workers is chosen)
-func ParOr(parallelism int, bitmaps ...*Bitmap) *Bitmap {
+func ParOr(parallelism int, bitmaps ...Bitmap) Bitmap {
 
 	bitmapCount := len(bitmaps)
 	if bitmapCount == 0 {
@@ -195,7 +195,7 @@ func ParOr(parallelism int, bitmaps ...*Bitmap) *Bitmap {
 
 	h := newBitmapContainerHeap(bitmaps...)
 
-	bitmapChan := make(chan *Bitmap)
+	bitmapChan := make(chan Bitmap)
 	inputChan := make(chan multipleContainers, 128)
 	resultChan := make(chan keyedContainer, 32)
 	expectedKeysChan := make(chan int)
@@ -260,7 +260,7 @@ func ParOr(parallelism int, bitmaps ...*Bitmap) *Bitmap {
 // ParAnd computes the intersection (AND) of all provided bitmaps in parallel,
 // where the parameter "parallelism" determines how many workers are to be used
 // (if it is set to 0, a default number of workers is chosen)
-func ParAnd(parallelism int, bitmaps ...*Bitmap) *Bitmap {
+func ParAnd(parallelism int, bitmaps ...Bitmap) Bitmap {
 	bitmapCount := len(bitmaps)
 	if bitmapCount == 0 {
 		return NewBitmap()
@@ -274,7 +274,7 @@ func ParAnd(parallelism int, bitmaps ...*Bitmap) *Bitmap {
 
 	h := newBitmapContainerHeap(bitmaps...)
 
-	bitmapChan := make(chan *Bitmap)
+	bitmapChan := make(chan Bitmap)
 	inputChan := make(chan multipleContainers, 128)
 	resultChan := make(chan keyedContainer, 32)
 	expectedKeysChan := make(chan int)

--- a/priorityqueue.go
+++ b/priorityqueue.go
@@ -7,7 +7,7 @@ import "container/heap"
 ////////////
 
 type item struct {
-	value *Bitmap
+	value Bitmap
 	index int
 }
 
@@ -41,7 +41,7 @@ func (pq *priorityQueue) Pop() interface{} {
 	return item
 }
 
-func (pq *priorityQueue) update(item *item, value *Bitmap) {
+func (pq *priorityQueue) update(item *item, value Bitmap) {
 	item.value = value
 	heap.Fix(pq, item.index)
 }
@@ -51,7 +51,7 @@ func (pq *priorityQueue) update(item *item, value *Bitmap) {
 ////////////
 
 type containeritem struct {
-	value    *Bitmap
+	value    Bitmap
 	keyindex int
 	index    int
 }

--- a/real_data_benchmark_test.go
+++ b/real_data_benchmark_test.go
@@ -30,7 +30,7 @@ func init() {
 	}
 }
 
-func retrieveRealDataBitmaps(datasetName string, optimize bool) ([]*Bitmap, error) {
+func retrieveRealDataBitmaps(datasetName string, optimize bool) ([]Bitmap, error) {
 	gopath, ok := os.LookupEnv("GOPATH")
 	if !ok {
 		return nil, fmt.Errorf("GOPATH not set. It's required to locate real-roaring-datasets. Set GOPATH or disable BENCH_REAL_DATA")
@@ -61,7 +61,7 @@ func retrieveRealDataBitmaps(datasetName string, optimize bool) ([]*Bitmap, erro
 		}
 	}
 
-	bitmaps := make([]*Bitmap, len(zipFile.File))
+	bitmaps := make([]Bitmap, len(zipFile.File))
 	buf := make([]byte, largestFileSize)
 	var bufStep uint64 = 32768 // apparently the largest buffer zip can read
 	for i, f := range zipFile.File {
@@ -117,7 +117,7 @@ func retrieveRealDataBitmaps(datasetName string, optimize bool) ([]*Bitmap, erro
 	return bitmaps, nil
 }
 
-func benchmarkRealDataAggregate(b *testing.B, aggregator func(b []*Bitmap) uint64) {
+func benchmarkRealDataAggregate(b *testing.B, aggregator func(b []Bitmap) uint64) {
 	if !benchRealData {
 		b.SkipNow()
 	}
@@ -138,13 +138,13 @@ func benchmarkRealDataAggregate(b *testing.B, aggregator func(b []*Bitmap) uint6
 }
 
 func BenchmarkRealDataParOr(b *testing.B) {
-	benchmarkRealDataAggregate(b, func(bitmaps []*Bitmap) uint64 {
+	benchmarkRealDataAggregate(b, func(bitmaps []Bitmap) uint64 {
 		return ParOr(0, bitmaps...).GetCardinality()
 	})
 }
 
 func BenchmarkRealDataFastOr(b *testing.B) {
-	benchmarkRealDataAggregate(b, func(bitmaps []*Bitmap) uint64 {
+	benchmarkRealDataAggregate(b, func(bitmaps []Bitmap) uint64 {
 		return FastOr(bitmaps...).GetCardinality()
 	})
 }

--- a/rlecommon.go
+++ b/rlecommon.go
@@ -43,7 +43,7 @@ type searchOptions struct {
 }
 
 // And finds the intersection of rc and b.
-func (rc *runContainer32) And(b *Bitmap) *Bitmap {
+func (rc *runContainer32) And(b Bitmap) Bitmap {
 	out := NewBitmap()
 	for _, p := range rc.iv {
 		for i := p.start; i <= p.last; i++ {
@@ -56,7 +56,7 @@ func (rc *runContainer32) And(b *Bitmap) *Bitmap {
 }
 
 // Xor returns the exclusive-or of rc and b.
-func (rc *runContainer32) Xor(b *Bitmap) *Bitmap {
+func (rc *runContainer32) Xor(b Bitmap) Bitmap {
 	out := b.Clone()
 	for _, p := range rc.iv {
 		for v := p.start; v <= p.last; v++ {
@@ -71,7 +71,7 @@ func (rc *runContainer32) Xor(b *Bitmap) *Bitmap {
 }
 
 // Or returns the union of rc and b.
-func (rc *runContainer32) Or(b *Bitmap) *Bitmap {
+func (rc *runContainer32) Or(b Bitmap) Bitmap {
 	out := b.Clone()
 	for _, p := range rc.iv {
 		for v := p.start; v <= p.last; v++ {
@@ -101,7 +101,7 @@ type trial struct {
 }
 
 // And finds the intersection of rc and b.
-func (rc *runContainer16) And(b *Bitmap) *Bitmap {
+func (rc *runContainer16) And(b Bitmap) Bitmap {
 	out := NewBitmap()
 	for _, p := range rc.iv {
 		plast := p.last()
@@ -115,7 +115,7 @@ func (rc *runContainer16) And(b *Bitmap) *Bitmap {
 }
 
 // Xor returns the exclusive-or of rc and b.
-func (rc *runContainer16) Xor(b *Bitmap) *Bitmap {
+func (rc *runContainer16) Xor(b Bitmap) Bitmap {
 	out := b.Clone()
 	for _, p := range rc.iv {
 		plast := p.last()
@@ -132,7 +132,7 @@ func (rc *runContainer16) Xor(b *Bitmap) *Bitmap {
 }
 
 // Or returns the union of rc and b.
-func (rc *runContainer16) Or(b *Bitmap) *Bitmap {
+func (rc *runContainer16) Or(b Bitmap) Bitmap {
 	out := b.Clone()
 	for _, p := range rc.iv {
 		plast := p.last()

--- a/roaring.go
+++ b/roaring.go
@@ -186,7 +186,7 @@ func (rb Bitmap) GetSizeInBytes() uint64 {
 // of the Bitmap. It should correspond to the
 // number of bytes written when invoking WriteTo. You can expect
 // that this function is much cheaper computationally than WriteTo.
-func (rb Bitmap) GetSerializedSizeInBytes() uint64 {
+func (rb *Bitmap) GetSerializedSizeInBytes() uint64 {
 	return rb.highlowcontainer.serializedSizeInBytes()
 }
 
@@ -305,14 +305,14 @@ func (rb Bitmap) Maximum() uint32 {
 }
 
 // Contains returns true if the integer is contained in the bitmap
-func (rb Bitmap) Contains(x uint32) bool {
+func (rb *Bitmap) Contains(x uint32) bool {
 	hb := highbits(x)
 	c := rb.highlowcontainer.getContainer(hb)
 	return c != nil && c.contains(lowbits(x))
 }
 
 // ContainsInt returns true if the integer is contained in the bitmap (this is a convenience method, the parameter is casted to uint32 and Contains is called)
-func (rb Bitmap) ContainsInt(x int) bool {
+func (rb *Bitmap) ContainsInt(x int) bool {
 	return rb.Contains(uint32(x))
 }
 
@@ -390,7 +390,7 @@ func (rb *Bitmap) Remove(x uint32) {
 }
 
 // CheckedRemove removes the integer x from the bitmap and return true if the integer was effectively remove (and false if the integer was not present)
-func (rb Bitmap) CheckedRemove(x uint32) bool {
+func (rb *Bitmap) CheckedRemove(x uint32) bool {
 	// TODO: add unit tests for this method
 	hb := highbits(x)
 	i := rb.highlowcontainer.getIndex(hb)

--- a/roaring_test.go
+++ b/roaring_test.go
@@ -1,14 +1,15 @@
 package roaring
 
 import (
-	. "github.com/smartystreets/goconvey/convey"
-	"github.com/willf/bitset"
 	"log"
 	"math"
 	"math/rand"
 	"strconv"
 	"testing"
 	"unsafe"
+
+	. "github.com/smartystreets/goconvey/convey"
+	"github.com/willf/bitset"
 )
 
 func TestRoaringRangeEnd(t *testing.T) {
@@ -1515,7 +1516,7 @@ func rTest(N int) {
 	}
 }
 
-func equalsBitSet(a *bitset.BitSet, b *Bitmap) bool {
+func equalsBitSet(a *bitset.BitSet, b Bitmap) bool {
 	for i, e := a.NextSet(0); e; i, e = a.NextSet(i + 1) {
 		if !b.ContainsInt(int(i)) {
 			return false
@@ -1530,7 +1531,7 @@ func equalsBitSet(a *bitset.BitSet, b *Bitmap) bool {
 	return true
 }
 
-func equalsArray(a []int, b *Bitmap) bool {
+func equalsArray(a []int, b Bitmap) bool {
 	if uint64(len(a)) != b.GetCardinality() {
 		return false
 	}
@@ -1684,7 +1685,7 @@ func TestFlipBigA(t *testing.T) {
 			}
 
 			if float64(i) > checkTime {
-				var rb *Bitmap
+				var rb Bitmap
 
 				if (i & 1) == 0 {
 					rb = rb2

--- a/roaringcow_test.go
+++ b/roaringcow_test.go
@@ -1,13 +1,14 @@
 package roaring
 
 import (
-	. "github.com/smartystreets/goconvey/convey"
-	"github.com/willf/bitset"
 	"log"
 	"math/rand"
 	"strconv"
 	"testing"
 	"unsafe"
+
+	. "github.com/smartystreets/goconvey/convey"
+	"github.com/willf/bitset"
 )
 
 func TestCloneOfCOW(t *testing.T) {
@@ -1632,7 +1633,7 @@ func TestFlipBigACOW(t *testing.T) {
 			}
 
 			if float64(i) > checkTime {
-				var rb *Bitmap
+				var rb Bitmap
 
 				if (i & 1) == 0 {
 					rb = rb2

--- a/serialization_test.go
+++ b/serialization_test.go
@@ -13,6 +13,8 @@ import (
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSerializationOfEmptyBitmap(t *testing.T) {
@@ -310,7 +312,7 @@ func TestSerializationBasic3_042(t *testing.T) {
 
 func TestGobcoding043(t *testing.T) {
 	rb := BitmapOf(1, 2, 3, 4, 5, 100, 1000)
-
+	require.EqualValues(t, 7, rb.GetCardinality())
 	buf := new(bytes.Buffer)
 	encoder := gob.NewEncoder(buf)
 	err := encoder.Encode(rb)
@@ -324,6 +326,7 @@ func TestGobcoding043(t *testing.T) {
 	if err != nil {
 		t.Errorf("Gob decoding failed")
 	}
+	assert.EqualValues(t, 7, b.GetCardinality())
 
 	if !b.Equals(rb) {
 		t.Errorf("Decoded bitmap does not equal input bitmap")

--- a/smat.go
+++ b/smat.go
@@ -92,7 +92,7 @@ type smatContext struct {
 }
 
 type smatPair struct {
-	bm *Bitmap
+	bm Bitmap
 	bs *bitset.BitSet
 }
 
@@ -358,7 +358,7 @@ func (p *smatPair) checkEquals() {
 	}
 }
 
-func (p *smatPair) equalsBitSet(a *bitset.BitSet, b *Bitmap) bool {
+func (p *smatPair) equalsBitSet(a *bitset.BitSet, b Bitmap) bool {
 	for i, e := a.NextSet(0); e; i, e = a.NextSet(i + 1) {
 		if !b.ContainsInt(int(i)) {
 			fmt.Printf("in a bitset, not b bitmap, i: %d\n", i)


### PR DESCRIPTION
Removes the allocation of *Bitmap for initially empty Bitmaps. Passes all the tests. I've run this in my production which resulted in a few extra fixes.
```
benchmark                                             old ns/op     new ns/op     delta
BenchmarkNewBitmap-4                                  63.9          12.1          -81.06%
BenchmarkXorLopsided-4                                311536        184926        -40.64%
BenchmarkMarshalMsginterval16-4                       72.8          49.5          -32.01%
BenchmarkXor-4                                        1709543       1168515       -31.65%
BenchmarkEqualsSparse-4                               139756        103464        -25.97%
BenchmarkMarshalMsgaddHelper16-4                      94.6          71.6          -24.31%
BenchmarkMarshalMsgbitmapContainer-4                  69.4          53.3          -23.20%
BenchmarkMarshalMsgaddHelper32-4                      92.5          72.7          -21.41%
BenchmarkDecodebitmapContainer-4                      134           106           -20.90%
BenchmarkIntersectionLargeParallel-4                  3907711       3126745       -19.99%
BenchmarkEmptyArray-4                                 9.91          8.16          -17.66%
Benchmark100CountTrailingZeros-4                      74.2          61.7          -16.85%
BenchmarkMarshalMsgrunContainer16-4                   52.6          44.0          -16.35%
BenchmarkFromBitmap16-4                               18516         15696         -15.23%
BenchmarkDecodeaddHelper16-4                          324           275           -15.12%
BenchmarkDecodebitmapContainerShortIterator-4         120           102           -15.00%
BenchmarkSerializationDense-4                         9846          11576         +17.57%
BenchmarkMarshalMsguint16Slice-4                      30.3          25.8          -14.85%
BenchmarkAppendMsgrunIterator32-4                     24.8          29.1          +17.34%
Benchmark100OrigNumberOfTrailingZeros-4               783           676           -13.67%
BenchmarkCountRoaring-4                               53.5          61.8          +15.51%
BenchmarkDecodecontainerSerz-4                        124           108           -12.90%
BenchmarkIterateBitset-4                              499857        571316        +14.30%
BenchmarkDecodearrayContainer-4                       74.4          65.1          -12.50%
BenchmarkEncodeaddHelper16-4                          102           89.4          -12.35%
BenchmarkIntersectionRoaring-4                        1163          1020          -12.30%
BenchmarkSerializationMid-4                           92214         80881         -12.29%
BenchmarkAppendMsgaddHelper16-4                       41.7          36.6          -12.23%
BenchmarkEncodeinterval16-4                           44.2          39.1          -11.54%
BenchmarkDecodeuint16Slice-4                          19.2          17.0          -11.46%
BenchmarkMarshalMsgrunIterator16-4                    67.8          60.4          -10.91%
BenchmarkSequentialAdd-4                              15666674      13957442      -10.91%
BenchmarkMarshalMsginterval32-4                       54.3          48.9          -9.94%
BenchmarkAppendMsgarrayContainer-4                    11.0          9.94          -9.64%
BenchmarkPopcount-4                                   76.5          69.4          -9.28%
BenchmarkIntersectionLargeRoaring-4                   5554204       5042057       -9.22%
BenchmarkUnmarshalinterval16-4                        62.2          56.7          -8.84%
BenchmarkSparseIterateBitset-4                        2535579       2312568       -8.80%
BenchmarkAppendMsguint16Slice-4                       9.66          8.85          -8.39%
BenchmarkDecoderoaringArray-4                         228           209           -8.33%
BenchmarkSetBitset-4                                  28.1          25.9          -7.83%
BenchmarkDecodeinterval16-4                           117           108           -7.69%
BenchmarkMarshalMsguint32Slice-4                      27.7          25.6          -7.58%
BenchmarkMarshalMsgrunIterator32-4                    60.1          64.9          +7.99%
BenchmarkDecoderunIterator32-4                        219           203           -7.31%
BenchmarkEncoderunIterator16-4                        66.0          70.9          +7.42%
BenchmarkUnmarshaladdHelper32-4                       134           125           -6.72%
BenchmarkAppendMsgroaringArray-4                      24.3          22.7          -6.58%
BenchmarkAppendMsgrunIterator16-4                     24.2          25.9          +7.02%
BenchmarkDecoderunContainer32-4                       101           108           +6.93%
BenchmarkAppendMsgaddHelper32-4                       39.3          36.9          -6.11%
BenchmarkDecodeinterval32-4                           116           109           -6.03%
BenchmarkEncodeinterval32-4                           40.2          37.8          -5.97%
BenchmarkUnmarshalrunContainer32-4                    48.8          51.7          +5.94%
BenchmarkGetTestBitSet-4                              20.3          21.5          +5.91%
BenchmarkEncoderunIterator32-4                        66.5          70.0          +5.26%
BenchmarkEqualsClone-4                                104200        99138         -4.86%
BenchmarkEncodeaddHelper32-4                          88.2          92.7          +5.10%
BenchmarkAppendMsgcontainerSerz-4                     18.7          17.8          -4.81%
BenchmarkEncodebitmapContainer-4                      43.9          41.8          -4.78%
BenchmarkEncoderunContainer32-4                       34.2          35.9          +4.97%
BenchmarkAppendMsginterval16-4                        21.4          20.4          -4.67%
BenchmarkAppendMsgrunContainer32-4                    14.5          15.2          +4.83%
BenchmarkUnmarshalcontainerSerz-4                     65.4          62.4          -4.59%
BenchmarkUnmarshaluint16Slice-4                       10.5          11.0          +4.76%
BenchmarkUnmarshalbitmapContainerShortIterator-4      48.9          51.2          +4.70%
BenchmarkEncodeuint32Slice-4                          10.7          11.2          +4.67%
BenchmarkGetTestRoaring-4                             138           132           -4.35%
BenchmarkMarshalMsgcontainerSerz-4                    37.1          35.5          -4.31%
BenchmarkSparseIterateRoaring-4                       987885        945302        -4.31%
BenchmarkMarshalMsgarrayContainer-4                   36.7          38.3          +4.36%
BenchmarkUnmarshalrunIterator16-4                     99.8          104           +4.21%
BenchmarkUnmarshalrunIterator32-4                     100           104           +4.00%
BenchmarkUnionBitset-4                                4980019       5176528       +3.95%
BenchmarkEncoderoaringArray-4                         66.7          64.3          -3.60%
BenchmarkMarshalMsgrunContainer32-4                   45.5          44.0          -3.30%
BenchmarkAppendMsgrunContainer16-4                    14.7          15.2          +3.40%
BenchmarkAppendMsginterval32-4                        21.3          20.6          -3.29%
BenchmarkUnmarshaladdHelper16-4                       129           125           -3.10%
BenchmarkUnionRoaring-4                               271897        280234        +3.07%
BenchmarkDecoderunContainer16-4                       102           105           +2.94%
BenchmarkDecodeuint32Slice-4                          17.5          17.0          -2.86%
BenchmarkCountBitset-4                                15367         15812         +2.90%
BenchmarkAppendMsguint32Slice-4                       8.64          8.88          +2.78%
BenchmarkEncodeuint16Slice-4                          11.0          11.3          +2.73%
BenchmarkUnmarshalbitmapContainer-4                   59.4          57.9          -2.53%
BenchmarkUnmarshalinterval32-4                        56.8          55.4          -2.46%
BenchmarkUnmarshalroaringArray-4                      96.7          94.4          -2.38%
BenchmarkMarshalMsgroaringArray-4                     59.0          60.4          +2.37%
BenchmarkMarshalMsgbitmapContainerShortIterator-4     44.9          43.9          -2.23%
BenchmarkUnmarshaluint32Slice-4                       10.7          10.9          +1.87%
BenchmarkIntersectionBitset-4                         8299          8162          -1.65%
BenchmarkEncodebitmapContainerShortIterator-4         38.8          38.2          -1.55%
BenchmarkSerializationSparse-4                        178574        175841        -1.53%
BenchmarkIterateRoaring-4                             1019356       1004233       -1.48%
BenchmarkSetRoaring-4                                 74.0          75.1          +1.49%
BenchmarkAppendMsgbitmapContainerShortIterator-4      15.1          14.9          -1.32%
BenchmarkIntersectionCardinalityRoaring-4             273           270           -1.10%
BenchmarkAppendMsgbitmapContainer-4                   20.4          20.2          -0.98%
BenchmarkEncodearrayContainer-4                       20.6          20.4          -0.97%
BenchmarkDecodeaddHelper32-4                          259           257           -0.77%
BenchmarkUnmarshalarrayContainer-4                    31.4          31.2          -0.64%
BenchmarkUnmarshalrunContainer16-4                    50.5          50.8          +0.59%
BenchmarkDecoderunIterator16-4                        205           206           +0.49%
BenchmarkSparseContains-4                             117487        117824        +0.29%
BenchmarkEncodecontainerSerz-4                        39.6          39.5          -0.25%
BenchmarkFromBitmap32-4                               15954         15940         -0.09%

benchmark                                            old MB/s     new MB/s     speedup
BenchmarkDecodebitmapContainer-4                     163.85       205.61       1.25x
BenchmarkDecodeaddHelper16-4                         126.37       148.77       1.18x
BenchmarkDecodebitmapContainerShortIterator-4        74.95        88.10        1.18x
BenchmarkAppendMsgrunIterator32-4                    1533.09      1307.55      0.85x
BenchmarkDecodecontainerSerz-4                       56.12        64.51        1.15x
BenchmarkEncodeaddHelper16-4                         401.27       458.48       1.14x
BenchmarkDecodearrayContainer-4                      134.46       153.57       1.14x
BenchmarkAppendMsgaddHelper16-4                      982.16       1120.47      1.14x
BenchmarkEncodeinterval16-4                          316.42       357.72       1.13x
BenchmarkDecodeuint16Slice-4                         52.19        58.88        1.13x
BenchmarkAppendMsgarrayContainer-4                   912.85       1006.33      1.10x
BenchmarkUnmarshalinterval16-4                       225.13       247.09       1.10x
BenchmarkDecoderoaringArray-4                        201.39       219.97       1.09x
BenchmarkAppendMsguint16Slice-4                      103.51       112.96       1.09x
BenchmarkDecodeinterval16-4                          118.95       129.40       1.09x
BenchmarkDecoderunIterator32-4                       173.29       186.96       1.08x
BenchmarkDecoderunContainer32-4                      108.52       100.99       0.93x
BenchmarkEncoderunIterator16-4                       575.98       536.12       0.93x
BenchmarkUnmarshaladdHelper32-4                      304.20       325.90       1.07x
BenchmarkAppendMsgrunIterator16-4                    1567.14      1464.48      0.93x
BenchmarkAppendMsgroaringArray-4                     1891.42      2022.47      1.07x
BenchmarkDecodeinterval32-4                          119.78       128.01       1.07x
BenchmarkAppendMsgaddHelper32-4                      1044.18      1110.20      1.06x
BenchmarkEncodeinterval32-4                          348.36       370.03       1.06x
BenchmarkUnmarshalrunContainer32-4                   225.19       212.66       0.94x
BenchmarkEncoderunIterator32-4                       571.27       542.62       0.95x
BenchmarkAppendMsgcontainerSerz-4                    374.41       394.14       1.05x
BenchmarkEncodeaddHelper32-4                         465.02       442.08       0.95x
BenchmarkUnmarshalcontainerSerz-4                    107.01       112.26       1.05x
BenchmarkEncodebitmapContainer-4                     501.21       525.79       1.05x
BenchmarkEncodeuint32Slice-4                         93.84        89.48        0.95x
BenchmarkEncoderunContainer32-4                      321.19       306.32       0.95x
BenchmarkAppendMsgrunContainer32-4                   759.36       725.20       0.96x
BenchmarkAppendMsginterval16-4                       654.17       684.88       1.05x
BenchmarkUnmarshalbitmapContainerShortIterator-4     183.86       175.68       0.96x
BenchmarkUnmarshaluint16Slice-4                      94.88        90.84        0.96x
BenchmarkUnmarshalrunIterator16-4                    380.57       364.40       0.96x
BenchmarkAppendMsginterval32-4                       656.32       681.26       1.04x
BenchmarkUnmarshalrunIterator32-4                    378.75       364.98       0.96x
BenchmarkEncoderoaringArray-4                        689.90       715.22       1.04x
BenchmarkUnmarshaladdHelper16-4                      317.52       327.70       1.03x
BenchmarkDecodeuint32Slice-4                         56.99        58.80        1.03x
BenchmarkAppendMsgrunContainer16-4                   747.17       725.59       0.97x
BenchmarkAppendMsguint32Slice-4                      115.75       112.66       0.97x
BenchmarkUnmarshalbitmapContainer-4                  370.33       379.93       1.03x
BenchmarkUnmarshalroaringArray-4                     475.48       487.38       1.03x
BenchmarkEncodeuint16Slice-4                         90.72        88.52        0.98x
BenchmarkUnmarshalinterval32-4                       246.54       252.52       1.02x
BenchmarkDecoderunContainer16-4                      107.11       104.59       0.98x
BenchmarkUnmarshaluint32Slice-4                      93.79        91.97        0.98x
BenchmarkEncodebitmapContainerShortIterator-4        231.74       235.78       1.02x
BenchmarkAppendMsgbitmapContainer-4                  1076.74      1089.56      1.01x
BenchmarkAppendMsgbitmapContainerShortIterator-4     596.30       602.03       1.01x
BenchmarkDecodeaddHelper32-4                         157.92       159.09       1.01x
BenchmarkUnmarshalrunContainer16-4                   217.95       216.40       0.99x
BenchmarkUnmarshalarrayContainer-4                   318.40       320.65       1.01x
BenchmarkEncodearrayContainer-4                      486.08       489.09       1.01x
BenchmarkDecoderunIterator16-4                       185.04       184.14       1.00x
BenchmarkEncodecontainerSerz-4                       176.94       177.42       1.00x
BenchmarkEncoderunContainer16-4                      312.66       312.17       1.00x

benchmark                old allocs     new allocs     delta
BenchmarkNewBitmap-4     1              0              -100.00%

benchmark                old bytes     new bytes     delta
BenchmarkNewBitmap-4     112           0             -100.00%
```