### PR TITLE
Adds bitmap.NextMany() functionality 

### DIFF
--- a/aggregation_test.go
+++ b/aggregation_test.go
@@ -7,9 +7,9 @@ import (
 )
 
 func testAggregations(t *testing.T,
-	and func(bitmaps ... *Bitmap) *Bitmap,
-	or func(bitmaps ... *Bitmap) *Bitmap,
-	xor func(bitmaps ... *Bitmap) *Bitmap) {
+	and func(bitmaps ...*Bitmap) *Bitmap,
+	or func(bitmaps ...*Bitmap) *Bitmap,
+	xor func(bitmaps ...*Bitmap) *Bitmap) {
 
 	t.Run("simple case", func(t *testing.T) {
 		rb1 := NewBitmap()
@@ -271,10 +271,10 @@ func testAggregations(t *testing.T,
 }
 
 func TestParAggregations(t *testing.T) {
-	andFunc := func(bitmaps ... *Bitmap) *Bitmap {
+	andFunc := func(bitmaps ...*Bitmap) *Bitmap {
 		return ParAnd(0, bitmaps...)
 	}
-	orFunc := func(bitmaps ... *Bitmap) *Bitmap {
+	orFunc := func(bitmaps ...*Bitmap) *Bitmap {
 		return ParOr(0, bitmaps...)
 	}
 

--- a/arraycontainer.go
+++ b/arraycontainer.go
@@ -28,6 +28,10 @@ func (ac *arrayContainer) getShortIterator() shortIterable {
 	return &shortIterator{ac.content, 0}
 }
 
+func (ac *arrayContainer) getManyIterator() manyIterable {
+	return &manyIterator{ac.content, 0}
+}
+
 func (ac *arrayContainer) minimum() uint16 {
 	return ac.content[0] // assume not empty
 }

--- a/manyiterator.go
+++ b/manyiterator.go
@@ -1,0 +1,23 @@
+package roaring
+
+type manyIterable interface {
+	nextMany(hs uint32, buf []uint32) int
+}
+
+type manyIterator struct {
+	slice []uint16
+	loc   int
+}
+
+func (si *manyIterator) nextMany(hs uint32, buf []uint32) int {
+	n := 0
+	l := si.loc
+	s := si.slice
+	for n < len(buf) && l < len(s) {
+		buf[n] = uint32(s[l]) | hs
+		l++
+		n++
+	}
+	si.loc = l
+	return n
+}

--- a/rlei.go
+++ b/rlei.go
@@ -180,6 +180,10 @@ func (rc *runContainer16) getShortIterator() shortIterable {
 	return rc.newRunIterator16()
 }
 
+func (rc *runContainer16) getManyIterator() manyIterable {
+	return rc.newManyRunIterator16()
+}
+
 // add the values in the range [firstOfRange, endx). endx
 // is still abe to express 2^16 because it is an int not an uint16.
 func (rc *runContainer16) iaddRange(firstOfRange, endx int) container {

--- a/roaringarray.go
+++ b/roaringarray.go
@@ -38,6 +38,7 @@ type container interface {
 	inot(firstOfRange, endx int) container // i stands for inplace, range is [firstOfRange,endx)
 	xor(r container) container
 	getShortIterator() shortIterable
+	getManyIterator() manyIterable
 	contains(i uint16) bool
 	maximum() uint16
 	minimum() uint16


### PR DESCRIPTION
A higher performance bulk next method. +tests +benchmarks

From issue #123 

Sorry this has taken such a long time to put together.

Starting with the Bulk next functionality as hopefully it is less contentious.

In the end I went with a separate iterator as I was struggling to make the code compatible with a mixed `next`/`nextMany` mode (the existing iterator essentially prefetches the next value).

Also let me know areas you feel are missing tests/edge cases.

Anyway, the fun part! Benchmarks!

```
go test -bench BenchmarkNexts -benchmem -run -; and env BENCH_REAL_DATA=1 go test -bench BenchmarkRealDataNext -benchmem -run -
goos: darwin
goarch: amd64
pkg: git.soma.salesforce.com/WaveDataLib/vendor/github.com/RoaringBitmap/roaring
BenchmarkNexts/next__100.000000%-8         	     200	   9521314 ns/op	     288 B/op	       9 allocs/op
BenchmarkNexts/nextmany__100.000000%-8     	    1000	   1372220 ns/op	   16688 B/op	      10 allocs/op
BenchmarkNexts/next__50.000000%-8          	     200	   7505332 ns/op	     304 B/op	      17 allocs/op
BenchmarkNexts/nextmany__50.000000%-8      	    1000	   2268082 ns/op	   16944 B/op	      18 allocs/op
BenchmarkNexts/next__25.000000%-8          	     200	   7994177 ns/op	     544 B/op	      32 allocs/op
BenchmarkNexts/nextmany__25.000000%-8      	    1000	   2193432 ns/op	   17424 B/op	      33 allocs/op
BenchmarkNexts/next__12.500000%-8          	     200	   7530191 ns/op	    1056 B/op	      63 allocs/op
BenchmarkNexts/nextmany__12.500000%-8      	    1000	   2165133 ns/op	   18416 B/op	      64 allocs/op
BenchmarkNexts/next__6.250000%-8           	     300	   4945158 ns/op	    3984 B/op	     124 allocs/op
BenchmarkNexts/nextmany__6.250000%-8       	    1000	   1440372 ns/op	   20368 B/op	     125 allocs/op
BenchmarkNexts/next__3.125000%-8           	     300	   4958086 ns/op	    7888 B/op	     246 allocs/op
BenchmarkNexts/nextmany__3.125000%-8       	    1000	   1438189 ns/op	   24272 B/op	     247 allocs/op
BenchmarkNexts/next__1.562500%-8           	     300	   4776907 ns/op	   15696 B/op	     490 allocs/op
BenchmarkNexts/nextmany__1.562500%-8       	    1000	   1438678 ns/op	   32080 B/op	     491 allocs/op
BenchmarkNexts/next__0.390625%-8           	     300	   4920443 ns/op	   62576 B/op	    1955 allocs/op
BenchmarkNexts/nextmany__0.390625%-8       	    1000	   1464602 ns/op	   78960 B/op	    1956 allocs/op
BenchmarkNexts/next__0.097656%-8           	     300	   5364751 ns/op	  250069 B/op	    7814 allocs/op
BenchmarkNexts/nextmany__0.097656%-8       	    1000	   1877289 ns/op	  266448 B/op	    7815 allocs/op
BenchmarkNexts/next__0.012352%-8           	     200	   7851239 ns/op	 1976632 B/op	   61769 allocs/op
BenchmarkNexts/nextmany__0.012352%-8       	     300	   4957780 ns/op	 1993008 B/op	   61770 allocs/op
BenchmarkNextsRLE/next-8                   	     100	  20446490 ns/op	     560 B/op	      17 allocs/op
BenchmarkNextsRLE/nextmany-8               	     500	   2441484 ns/op	    8752 B/op	      18 allocs/op
PASS
ok  	git.soma.salesforce.com/WaveDataLib/vendor/github.com/RoaringBitmap/roaring	45.162s
goos: darwin
goarch: amd64
pkg: git.soma.salesforce.com/WaveDataLib/vendor/github.com/RoaringBitmap/roaring
BenchmarkRealDataNext/census-income_srt-8         	      10	 126063551 ns/op	   31664 B/op	     891 allocs/op
BenchmarkRealDataNext/census-income-8             	      10	 103090878 ns/op	   31296 B/op	     968 allocs/op
BenchmarkRealDataNext/census1881_srt-8            	     100	  14180454 ns/op	   90816 B/op	    2738 allocs/op
BenchmarkRealDataNext/census1881-8                	     100	  10721427 ns/op	   56448 B/op	    1664 allocs/op
BenchmarkRealDataNext/dimension_003-8             	      20	  82011816 ns/op	 1277696 B/op	   32187 allocs/op
BenchmarkRealDataNext/dimension_008-8             	      20	  60217097 ns/op	  542528 B/op	   14334 allocs/op
BenchmarkRealDataNext/dimension_033-8             	      20	  80506341 ns/op	   64880 B/op	    1941 allocs/op
BenchmarkRealDataNext/uscensus2000-8              	   10000	    172225 ns/op	   80672 B/op	    2421 allocs/op
BenchmarkRealDataNext/weather_sept_85_srt-8       	       5	 313757812 ns/op	   78976 B/op	    2368 allocs/op
BenchmarkRealDataNext/weather_sept_85-8           	      10	 177623417 ns/op	   92016 B/op	    3056 allocs/op
BenchmarkRealDataNext/wikileaks-noquotes_srt-8    	     300	   5656957 ns/op	   60000 B/op	    1775 allocs/op
BenchmarkRealDataNext/wikileaks-noquotes-8        	     300	   5930431 ns/op	   70144 B/op	    2092 allocs/op
BenchmarkRealDataNextMany/census-income_srt-8     	     300	   5854518 ns/op	   48096 B/op	     892 allocs/op
BenchmarkRealDataNextMany/census-income-8         	     100	  17181030 ns/op	   50560 B/op	     969 allocs/op
BenchmarkRealDataNextMany/census1881_srt-8        	    2000	   1061879 ns/op	  107200 B/op	    2739 allocs/op
BenchmarkRealDataNextMany/census1881-8            	    1000	   1291917 ns/op	   72832 B/op	    1665 allocs/op
BenchmarkRealDataNextMany/dimension_003-8         	     200	   6272633 ns/op	 1294080 B/op	   32188 allocs/op
BenchmarkRealDataNextMany/dimension_008-8         	     500	   3566583 ns/op	  558912 B/op	   14335 allocs/op
BenchmarkRealDataNextMany/dimension_033-8         	     500	   3721705 ns/op	   81264 B/op	    1942 allocs/op
BenchmarkRealDataNextMany/uscensus2000-8          	   10000	    140842 ns/op	   97056 B/op	    2422 allocs/op
BenchmarkRealDataNextMany/weather_sept_85_srt-8   	     100	  15765233 ns/op	   95360 B/op	    2369 allocs/op
BenchmarkRealDataNextMany/weather_sept_85-8       	      50	  33426390 ns/op	  117376 B/op	    3057 allocs/op
BenchmarkRealDataNextMany/wikileaks-noquotes_srt-8          3000	    468985 ns/op	   76384 B/op	    1776 allocs/op
BenchmarkRealDataNextMany/wikileaks-noquotes-8              2000	   1025329 ns/op	   86528 B/op	    2093 allocs/op
PASS
ok  	git.soma.salesforce.com/WaveDataLib/vendor/github.com/RoaringBitmap/roaring	84.778s
```

Summary of synthetic benchmarks
```
Density	 	 Speedup
100.000000% 	 -85.6%
50.000000% 	 -69.8%
25.000000% 	 -72.6%
12.500000% 	 -71.2%
6.250000% 	 -70.9%
3.125000% 	 -71.0%
1.562500% 	 -69.9%
0.390625% 	 -70.2%
0.097656% 	 -65.0%
0.012352% 	 -36.9%
RLE 	 	 -88.1%
```
3-4x faster
Drop in improvement is due to more iterator allocation overhead from sparse containers

Summary of Real-world benchmarks
```
Test	 	 Speedup
census-income_srt-8         	-95.4%
census-income-8             	-83.3%
census1881_srt-8            	-92.5%
census1881-8                	-88.0%
dimension_003-8             	-92.4%
dimension_008-8             	-94.1%
dimension_033-8             	-95.4%
uscensus2000-8              	-18.2%
weather_sept_85_srt-8       	-95.0%
weather_sept_85-8           	-81.2%
wikileaks-noquotes_srt-8    	-91.7%
wikileaks-noquotes-8        	-82.7%
```
5-20x faster