### PR TITLE
Bitmap.Clear() retains preallocated slices for faster future ops

### DIFF
--- a/roaring.go
+++ b/roaring.go
@@ -146,9 +146,10 @@ func New() *Bitmap {
 	return &Bitmap{}
 }
 
-// Clear removes all content from the Bitmap and frees the memory
+// Clear resets the Bitmap to be logically empty, but may retain
+// some memory allocations that may speed up future operations
 func (rb *Bitmap) Clear() {
-	rb.highlowcontainer = *newRoaringArray()
+	rb.highlowcontainer.clear()
 }
 
 // ToArray creates a new slice containing all of the integers stored in the Bitmap in sorted order


### PR DESCRIPTION
Before this commit, Clear() would throw away any allocated slices, and
this change has Clear() instead resize slice lengths to 0, keeping the
underlying slice capacity.  Future operations that append() to the
slices might then see performance wins by avoiding some
memory allocations.

fromBuffer() is also enhanced to potentially reuse preallocated slice capacity.

An application that reuses a Bitmap instance via Clear() may see more performance gains than before.