### PR TITLE
benchmark on Bitmap.Clear()

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -697,3 +697,27 @@ func BenchmarkXorLopsided(b *testing.B) {
 		s.Clone().Xor(x2)
 	}
 }
+
+func BenchmarkBitmapReuseWithoutClear(b *testing.B) {
+	for j := 0; j < b.N; j++ {
+		s := NewBitmap()
+		for i := 0; i < 100000; i++ {
+			s.Add(uint32(i * 4096))
+		}
+	}
+}
+
+func BenchmarkBitmapReuseWithClear(b *testing.B) {
+	s := NewBitmap()
+	for i := 0; i < 100000; i++ {
+		s.Add(uint32(i * 4096))
+	}
+	b.ResetTimer()
+
+	for j := 0; j < b.N; j++ {
+		s.Clear() // reuse the same bitmap
+		for i := 0; i < 100000; i++ {
+			s.Add(uint32(i * 4096))
+		}
+	}
+}


### PR DESCRIPTION
Added two benchmarks -- one that allocates a brand new Bitmap on every
cycle, and another that reuses a single Bitmap instance on every cycle
via Clear().  I picked scenario numbers that attempt to produce more
underlying allocations in order to highlight the effect.

The numbers before the Clear() optimization...
```
  BenchmarkBitmapReuseWithoutClear-8  500   2935449 ns/op   1103698 B/op   25049 allocs/op
  BenchmarkBitmapReuseWithClear-8     500   2919375 ns/op   1103698 B/op   25049 allocs/op
```
From that, Clear() does not seem to have significant advantage over
just allocating a brand new Bitmap in time or memory used.

The numbers after the Clear() optimization that reuse slices...
```
  BenchmarkBitmapReuseWithoutClear-8  500   2904732 ns/op   1103698 B/op   25049 allocs/op
  BenchmarkBitmapReuseWithClear-8     500   2717967 ns/op    550001 B/op   25000 allocs/op
```
I also have the sense that reuse of memory seems to have a beneficial
effect in my app's higher-level usage of roaring, where I suspect
there's more time for GC to kick in compared to micro-benchmarks.