### PR TITLE
Faster ParOr

### DIFF
--- a/aggregation_test.go
+++ b/aggregation_test.go
@@ -268,6 +268,19 @@ func testAggregations(t *testing.T,
 			t.Error()
 		}
 	})
+
+	t.Run("issue 178", func(t *testing.T) {
+		ba1 := []uint32{3585028, 65901253, 143441994, 211160474, 286511937, 356744840, 434332509, 502812785, 576097614, 646557334, 714794241, 775083485, 833704249, 889329147, 941367043}
+		ba2 := []uint32{17883, 54494426, 113908938, 174519827, 235465665, 296685741, 357644666, 420192495, 476104304, 523046142, 577855081, 634889665, 692460635, 751350463, 809989192, 863494316, 919127240}
+
+		r1 := BitmapOf(ba1...)
+		r2 := BitmapOf(ba2...)
+
+		result := or(r1, r2)
+		if result.GetCardinality() != 32 {
+			t.Errorf("Expected bitmap of cardinality %d, got %d", 32, result.GetCardinality())
+		}
+	})
 }
 
 func TestParAggregations(t *testing.T) {

--- a/aggregation_test.go
+++ b/aggregation_test.go
@@ -215,7 +215,7 @@ func testAggregations(t *testing.T,
 		bigxor := Xor(Xor(rb1, rb2), rb3)
 
 		if or != nil && !or(rb1, rb2, rb3).Equals(rb1) {
-			t.Error()
+			t.Errorf("Expected bitmap of cardinality %d, got %d", rb1.GetCardinality(), or(rb1, rb2, rb3).GetCardinality())
 		}
 
 		if and != nil && !and(rb1, rb2, rb3).Equals(bigand) {
@@ -257,7 +257,7 @@ func testAggregations(t *testing.T,
 		bigxor := Xor(Xor(rb1, rb2), rb3)
 
 		if or != nil && !or(rb1, rb2, rb3).Equals(rb1) {
-			t.Error()
+			t.Errorf("Expected bitmap of cardinality %d, got %d", rb1.GetCardinality(), or(rb1, rb2, rb3).GetCardinality())
 		}
 
 		if and != nil && !and(rb1, rb2, rb3).Equals(bigand) {
@@ -279,6 +279,14 @@ func TestParAggregations(t *testing.T) {
 	}
 
 	testAggregations(t, andFunc, orFunc, nil)
+}
+
+func TestParHeapAggregations(t *testing.T) {
+	orFunc := func(bitmaps ...*Bitmap) *Bitmap {
+		return ParHeapOr(0, bitmaps...)
+	}
+
+	testAggregations(t, nil, orFunc, nil)
 }
 
 func TestFastAggregations(t *testing.T) {

--- a/arraycontainer.go
+++ b/arraycontainer.go
@@ -803,19 +803,12 @@ func (ac *arrayContainer) negateRange(buffer []uint16, startIndex, lastIndex, st
 	}
 }
 
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-
 func (ac *arrayContainer) isFull() bool {
 	return false
 }
 
 func (ac *arrayContainer) andArray(value2 *arrayContainer) container {
-	desiredcapacity := min(ac.getCardinality(), value2.getCardinality())
+	desiredcapacity := minOfInt(ac.getCardinality(), value2.getCardinality())
 	answer := newArrayContainerCapacity(desiredcapacity)
 	length := intersection2by2(
 		ac.content,
@@ -953,7 +946,7 @@ func (ac *arrayContainer) toEfficientContainer() container {
 	card := ac.getCardinality()
 	sizeAsArrayContainer := arrayContainerSizeInBytes(card)
 
-	if sizeAsRunContainer <= min(sizeAsBitmapContainer, sizeAsArrayContainer) {
+	if sizeAsRunContainer <= minOfInt(sizeAsBitmapContainer, sizeAsArrayContainer) {
 		return newRunContainer16FromArray(ac)
 	}
 	if card <= arrayDefaultMaxSize {

--- a/bitmapcontainer.go
+++ b/bitmapcontainer.go
@@ -953,7 +953,7 @@ func (bc *bitmapContainer) toEfficientContainer() container {
 	card := bc.getCardinality()
 	sizeAsArrayContainer := arrayContainerSizeInBytes(card)
 
-	if sizeAsRunContainer <= min(sizeAsBitmapContainer, sizeAsArrayContainer) {
+	if sizeAsRunContainer <= minOfInt(sizeAsBitmapContainer, sizeAsArrayContainer) {
 		return newRunContainer16FromBitmapContainer(bc)
 	}
 	if card <= arrayDefaultMaxSize {

--- a/parallel.go
+++ b/parallel.go
@@ -376,13 +376,8 @@ func ParOr(parallelism int, bitmaps ...*Bitmap) *Bitmap {
 		chunkCount = int(keyRange)
 	} else {
 		chunkCount = parallelism * 4
-		if int(keyRange)%chunkCount > 0 {
-			chunkSize = (int(keyRange) / chunkCount) + 1
-		} else {
-			chunkSize = int(keyRange) / chunkCount
-		}
+		chunkSize = (int(keyRange) + chunkCount - 1) / chunkCount
 	}
-	//fmt.Printf("cc %d cs %d r %d d %d\n", chunkCount, chunkSize, int(keyRange)%chunkSize, chunkCount*chunkSize-int(keyRange))
 
 	if chunkCount*chunkSize < int(keyRange) {
 		// it's fine to panic to indicate an implementation error
@@ -603,7 +598,6 @@ func lazyIOrOnRange(ra1, ra2 *roaringArray, start, last uint16) *roaringArray {
 			}
 		}
 	}
-
 	if idx2 < length2 {
 		key2 = ra2.getKeyAtIndex(idx2)
 		for key2 <= last {

--- a/parallel.go
+++ b/parallel.go
@@ -4,6 +4,7 @@ import (
 	"container/heap"
 	"runtime"
 	"sync"
+	"fmt"
 )
 
 var defaultWorkerCount = runtime.NumCPU()
@@ -177,10 +178,11 @@ func appenderRoutine(bitmapChan chan<- *Bitmap, resultChan <-chan keyedContainer
 	bitmapChan <- answer
 }
 
-// ParOr computes the union (OR) of all provided bitmaps in parallel,
+// ParHeapOr computes the union (OR) of all provided bitmaps in parallel,
 // where the parameter "parallelism" determines how many workers are to be used
 // (if it is set to 0, a default number of workers is chosen)
-func ParOr(parallelism int, bitmaps ...*Bitmap) *Bitmap {
+// ParHeapOr uses a heap to compute the union. For rare cases it might be faster than ParOr
+func ParHeapOr(parallelism int, bitmaps ...*Bitmap) *Bitmap {
 
 	bitmapCount := len(bitmaps)
 	if bitmapCount == 0 {
@@ -328,4 +330,288 @@ func ParAnd(parallelism int, bitmaps ...*Bitmap) *Bitmap {
 	close(expectedKeysChan)
 
 	return bitmap
+}
+
+// ParOr computes the union (OR) of all provided bitmaps in parallel,
+// where the parameter "parallelism" determines how many workers are to be used
+// (if it is set to 0, a default number of workers is chosen)
+func ParOr(parallelism int, bitmaps ...*Bitmap) *Bitmap {
+	var lKey uint16 = MaxUint16
+	var hKey uint16 = 0
+
+	bitmapsFiltered := bitmaps[:0]
+	for _, b := range bitmaps {
+		if !b.IsEmpty() {
+			bitmapsFiltered = append(bitmapsFiltered, b)
+		}
+	}
+	bitmaps = bitmapsFiltered
+
+	for _, b := range bitmaps {
+		lKey = minOfUint16(lKey, b.highlowcontainer.keys[0])
+		hKey = maxOfUint16(hKey, b.highlowcontainer.keys[b.highlowcontainer.size()-1])
+	}
+
+	if lKey == MaxUint16 && hKey == 0 {
+		return New()
+	} else if len(bitmaps) == 1 {
+		return bitmaps[0]
+	}
+
+	keyRange := hKey - lKey + 1
+	if keyRange == 1 {
+		// revert to FastOr. Since the key range is 0
+		// no container-level aggregation parallelism is achievable
+		return FastOr(bitmaps...)
+	}
+
+	if parallelism == 0 {
+		parallelism = defaultWorkerCount
+	}
+
+	var chunkSize int
+	var chunkCount int
+	if parallelism*4 > int(keyRange) {
+		chunkSize = 1
+		chunkCount = int(keyRange)
+	} else {
+		chunkCount = parallelism * 4
+		if int(keyRange)%chunkCount > 0 {
+			chunkSize = (int(keyRange) / chunkCount) + 1
+		} else {
+			chunkSize = int(keyRange) / chunkCount
+		}
+	}
+	//fmt.Printf("cc %d cs %d r %d d %d\n", chunkCount, chunkSize, int(keyRange)%chunkSize, chunkCount*chunkSize-int(keyRange))
+
+	if chunkCount*chunkSize < int(keyRange) {
+		// it's fine to panic to indicate an implementation error
+		panic(fmt.Sprintf("invariant check failed: chunkCount * chunkSize >= keyRange, %d * %d < %d", chunkCount, chunkSize, keyRange))
+	}
+
+	chunks := make([]*roaringArray, chunkCount)
+
+	chunkSpecChan := make(chan parChunkSpec, minOfInt(maxOfInt(64, 2*parallelism), int(chunkCount)))
+	chunkChan := make(chan parChunk, minOfInt(32, int(chunkCount)))
+
+	orFunc := func() {
+		for spec := range chunkSpecChan {
+			ra := lazyOrOnRange(&bitmaps[0].highlowcontainer, &bitmaps[1].highlowcontainer, spec.start, spec.end)
+			for _, b := range bitmaps[2:] {
+				ra = lazyIOrOnRange(ra, &b.highlowcontainer, spec.start, spec.end)
+			}
+
+			for i, c := range ra.containers {
+				ra.containers[i] = repairAfterLazy(c)
+			}
+
+			chunkChan <- parChunk{ra, spec.idx}
+		}
+	}
+
+	for i := 0; i < parallelism; i++ {
+		go orFunc()
+	}
+
+	go func() {
+		for i := 0; i < chunkCount; i++ {
+			spec := parChunkSpec{
+				start: uint16(int(lKey) + i*chunkSize),
+				end:   uint16(minOfInt((i+1)*chunkSize-1+int(lKey), int(hKey))),
+				idx:   int(i),
+			}
+			chunkSpecChan <- spec
+		}
+	}()
+
+	chunksRemaining := chunkCount
+	for chunk := range chunkChan {
+		chunks[chunk.idx] = chunk.ra
+		chunksRemaining--
+		if chunksRemaining == 0 {
+			break
+		}
+	}
+	close(chunkChan)
+	close(chunkSpecChan)
+
+	containerCount := 0
+	for _, chunk := range chunks {
+		containerCount += chunk.size()
+	}
+
+	result := Bitmap{
+		roaringArray{
+			containers:      make([]container, containerCount),
+			keys:            make([]uint16, containerCount),
+			needCopyOnWrite: make([]bool, containerCount),
+		},
+	}
+
+	resultOffset := 0
+	for _, chunk := range chunks {
+		copy(result.highlowcontainer.containers[resultOffset:], chunk.containers)
+		copy(result.highlowcontainer.keys[resultOffset:], chunk.keys)
+		copy(result.highlowcontainer.needCopyOnWrite[resultOffset:], chunk.needCopyOnWrite)
+		resultOffset += chunk.size()
+	}
+
+	return &result
+}
+
+type parChunkSpec struct {
+	start uint16
+	end   uint16
+	idx   int
+}
+
+type parChunk struct {
+	ra  *roaringArray
+	idx int
+}
+
+func (c parChunk) size() int {
+	return c.ra.size()
+}
+
+func parNaiveStartAt(ra *roaringArray, start uint16, last uint16) int {
+	for idx, key := range ra.keys {
+		if key >= start && key <= last {
+			return idx
+		} else if key > last {
+			break
+		}
+	}
+	return ra.size()
+}
+
+func lazyOrOnRange(ra1, ra2 *roaringArray, start, last uint16) *roaringArray {
+	answer := newRoaringArray()
+	length1 := ra1.size()
+	length2 := ra2.size()
+
+	idx1 := parNaiveStartAt(ra1, start, last)
+	idx2 := parNaiveStartAt(ra2, start, last)
+
+	var key1 uint16
+	var key2 uint16
+	if idx1 < length1 && idx2 < length2 {
+		key1 = ra1.getKeyAtIndex(idx1)
+		key2 = ra2.getKeyAtIndex(idx2)
+
+		for key1 <= last && key2 <= last {
+
+			if key1 < key2 {
+				answer.appendCopy(*ra1, idx1)
+				idx1++
+				if idx1 >= length1 {
+					break
+				}
+				key1 = ra1.getKeyAtIndex(idx1)
+			} else if key1 > key2 {
+				answer.appendCopy(*ra2, idx2)
+				idx2++
+				if idx2 >= length2 {
+					break
+				}
+				key2 = ra2.getKeyAtIndex(idx2)
+			} else {
+				c1 := ra1.getFastContainerAtIndex(idx1, false)
+
+				answer.appendContainer(key1, c1.lazyOR(ra2.getContainerAtIndex(idx2)), false)
+				idx1++
+				idx2++
+				if idx1 >= length1 || idx2 >= length2 {
+					break
+				}
+
+				key1 = ra1.getKeyAtIndex(idx1)
+				key2 = ra2.getKeyAtIndex(idx2)
+			}
+		}
+	}
+
+	if idx2 < length2 {
+		key2 := ra2.getKeyAtIndex(idx2)
+		for key2 <= last {
+			answer.appendContainer(key2, ra2.getContainerAtIndex(idx2), true)
+			idx2++
+			if idx2 >= length2 {
+				break
+			}
+			key2 = ra2.getKeyAtIndex(idx2)
+		}
+	} else if idx1 < length1 {
+		key1 := ra1.getKeyAtIndex(idx1)
+		for key1 <= last {
+			answer.appendContainer(key1, ra1.getContainerAtIndex(idx1), true)
+			idx1++
+			if idx1 >= length1 {
+				break
+			}
+			key1 = ra1.getKeyAtIndex(idx1)
+		}
+	}
+	return answer
+}
+
+func lazyIOrOnRange(ra1, ra2 *roaringArray, start, last uint16) *roaringArray {
+	length1 := ra1.size()
+	length2 := ra2.size()
+
+	idx1 := 0
+	idx2 := parNaiveStartAt(ra2, start, last)
+
+	var key1 uint16
+	var key2 uint16
+	if idx1 < length1 && idx2 < length2 {
+		key1 = ra1.getKeyAtIndex(idx1)
+		key2 = ra2.getKeyAtIndex(idx2)
+
+		for key1 <= last && key2 <= last {
+			if key1 < key2 {
+				idx1++
+				if idx1 >= length1 {
+					break
+				}
+				key1 = ra1.getKeyAtIndex(idx1)
+			} else if key1 > key2 {
+				ra1.insertNewKeyValueAt(idx1, key2, ra2.getContainerAtIndex(idx2))
+				ra1.needCopyOnWrite[idx1] = true
+				idx2++
+				idx1++
+				length1++
+				if idx2 >= length2 {
+					break
+				}
+				key2 = ra2.getKeyAtIndex(idx2)
+			} else {
+				c1 := ra1.getFastContainerAtIndex(idx1, true)
+
+				ra1.containers[idx1] = c1.lazyIOR(ra2.getContainerAtIndex(idx2))
+				ra1.needCopyOnWrite[idx1] = false
+				idx1++
+				idx2++
+				if idx1 >= length1 || idx2 >= length2 {
+					break
+				}
+
+				key1 = ra1.getKeyAtIndex(idx1)
+				key2 = ra2.getKeyAtIndex(idx2)
+			}
+		}
+	}
+
+	if idx2 < length2 {
+		key2 := ra2.getKeyAtIndex(idx2)
+		for key2 <= last {
+			ra1.appendContainer(key2, ra2.getContainerAtIndex(idx2), true)
+			idx2++
+			if idx2 >= length2 {
+				break
+			}
+			key2 = ra2.getKeyAtIndex(idx2)
+		}
+	}
+	return ra1
 }

--- a/parallel.go
+++ b/parallel.go
@@ -529,7 +529,7 @@ func lazyOrOnRange(ra1, ra2 *roaringArray, start, last uint16) *roaringArray {
 	if idx2 < length2 {
 		key2 = ra2.getKeyAtIndex(idx2)
 		for key2 <= last {
-			answer.appendContainer(key2, ra2.getContainerAtIndex(idx2), true)
+			answer.appendCopy(*ra2, idx2)
 			idx2++
 			if idx2 == length2 {
 				break
@@ -541,7 +541,7 @@ func lazyOrOnRange(ra1, ra2 *roaringArray, start, last uint16) *roaringArray {
 	if idx1 < length1 {
 		key1 = ra1.getKeyAtIndex(idx1)
 		for key1 <= last {
-			answer.appendContainer(key1, ra1.getContainerAtIndex(idx1), true)
+			answer.appendCopy(*ra1, idx1)
 			idx1++
 			if idx1 == length1 {
 				break
@@ -601,7 +601,7 @@ func lazyIOrOnRange(ra1, ra2 *roaringArray, start, last uint16) *roaringArray {
 	if idx2 < length2 {
 		key2 = ra2.getKeyAtIndex(idx2)
 		for key2 <= last {
-			ra1.appendContainer(key2, ra2.getContainerAtIndex(idx2), true)
+			ra1.appendCopy(*ra2, idx2)
 			idx2++
 			if idx2 >= length2 {
 				break

--- a/real_data_benchmark_test.go
+++ b/real_data_benchmark_test.go
@@ -169,6 +169,13 @@ func BenchmarkRealDataNextMany(b *testing.B) {
 func BenchmarkRealDataParOr(b *testing.B) {
 	benchmarkRealDataAggregate(b, func(bitmaps []*Bitmap) uint64 {
 		return ParOr(0, bitmaps...).GetCardinality()
+		//return ParHeapOr(0, bitmaps...).GetCardinality()
+	})
+}
+
+func BenchmarkRealDataParHeapOr(b *testing.B) {
+	benchmarkRealDataAggregate(b, func(bitmaps []*Bitmap) uint64 {
+		return ParHeapOr(0, bitmaps...).GetCardinality()
 	})
 }
 

--- a/rle16.go
+++ b/rle16.go
@@ -1248,7 +1248,7 @@ func (ri *manyRunIterator16) nextMany(hs uint32, buf []uint32) int {
 			continue
 		}
 		// add as many as you can from this seq
-		moreVals := min(int(ri.rc.iv[ri.curIndex].length-ri.curPosInIndex), len(buf)-n)
+		moreVals := minOfInt(int(ri.rc.iv[ri.curIndex].length-ri.curPosInIndex), len(buf)-n)
 
 		base := uint32(ri.rc.iv[ri.curIndex].start+ri.curPosInIndex+1) | hs
 

--- a/rlei.go
+++ b/rlei.go
@@ -663,7 +663,7 @@ func (rc *runContainer16) toEfficientContainer() container {
 	sizeAsBitmapContainer := bitmapContainerSizeInBytes()
 	card := int(rc.cardinality())
 	sizeAsArrayContainer := arrayContainerSizeInBytes(card)
-	if sizeAsRunContainer <= min(sizeAsBitmapContainer, sizeAsArrayContainer) {
+	if sizeAsRunContainer <= minOfInt(sizeAsBitmapContainer, sizeAsArrayContainer) {
 		return rc
 	}
 	if card <= arrayDefaultMaxSize {

--- a/roaringarray.go
+++ b/roaringarray.go
@@ -297,6 +297,23 @@ func (ra *roaringArray) getContainerAtIndex(i int) container {
 	return ra.containers[i]
 }
 
+func (ra *roaringArray) getFastContainerAtIndex(i int, needsWriteable bool) container {
+	c := ra.getContainerAtIndex(i)
+	switch t := c.(type) {
+	case *arrayContainer:
+		c = t.toBitmapContainer()
+	case *runContainer16:
+		if !t.isFull() {
+			c = t.toBitmapContainer()
+		}
+	case *bitmapContainer:
+		if needsWriteable && ra.needCopyOnWrite[i] {
+			c = ra.containers[i].clone()
+		}
+	}
+	return c
+}
+
 func (ra *roaringArray) getWritableContainerAtIndex(i int) container {
 	if ra.needCopyOnWrite[i] {
 		ra.containers[i] = ra.containers[i].clone()

--- a/util.go
+++ b/util.go
@@ -292,3 +292,24 @@ func minOfUint16(a, b uint16) uint16 {
 	}
 	return b
 }
+
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func maxUint16(a, b uint16) uint16 {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func minUint16(a, b uint16) uint16 {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/util.go
+++ b/util.go
@@ -264,3 +264,31 @@ func getRandomPermutation(n int) []int {
 	}
 	return m
 }
+
+func minOfInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func maxOfInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func maxOfUint16(a, b uint16) uint16 {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func minOfUint16(a, b uint16) uint16 {
+	if a < b {
+		return a
+	}
+	return b
+}


### PR DESCRIPTION
This commit introduces a faster _ParOr_. The algorithm is described informally in #140.

Benchmark data shows significant improvement compared to previous algorithm.

Benchmarks run on 15' 2017 MacBook Pro Intel(R) Core(TM) i7-7700HQ CPU @ 2.80GHz
```
benchmark                                           old ns/op     new ns/op     delta
BenchmarkRealDataParOr/census-income_srt-8          269673        194486        -27.88%
BenchmarkRealDataParOr/census-income-8              395797        310505        -21.55%
BenchmarkRealDataParOr/census1881_srt-8             723821        402359        -44.41%
BenchmarkRealDataParOr/census1881-8                 718247        573550        -20.15%
BenchmarkRealDataParOr/dimension_003-8              7466247       2197374       -70.57%
BenchmarkRealDataParOr/dimension_008-8              3062717       833368        -72.79%
BenchmarkRealDataParOr/dimension_033-8              474489        302080        -36.34%
BenchmarkRealDataParOr/uscensus2000-8               1912128       1092854       -42.85%
BenchmarkRealDataParOr/weather_sept_85_srt-8        370585        178577        -51.81%
BenchmarkRealDataParOr/weather_sept_85-8            1272372       1142709       -10.19%
BenchmarkRealDataParOr/wikileaks-noquotes_srt-8     290843        123167        -57.65%
BenchmarkRealDataParOr/wikileaks-noquotes-8         330745        152330        -53.94%
```

The previous algorithm is exposed in the public API as `ParHeapOr` somehow resembling the convention in `fastaggregation.go`.

Resolves #140

It's the second revision of the pull request. It fixed bugs found in #164

I've compared the cardinalities on /Real data/ dataset https://gist.github.com/maciej/add052d10c5edad2eb74eceda7484f07 semin-manually. They are the same, so I'm leaving #169 for later