### PR TITLE
Fix for issue #191 - reverseIterator hasNext() termination condition is incorrect

### DIFF
--- a/bitmapcontainer_test.go
+++ b/bitmapcontainer_test.go
@@ -130,6 +130,11 @@ func TestBitmapContainerReverseIterator(t *testing.T) {
 			for i := 9; i >= 4; i-- {
 				v := it.next()
 				So(v, ShouldEqual, uint16(i))
+				if i > 4 {
+					So(it.hasNext(), ShouldBeTrue)
+				} else if i == 4 {
+					So(it.hasNext(), ShouldBeFalse)
+				}
 			}
 			So(it.hasNext(), ShouldBeFalse)
 			So(func() { it.next() }, ShouldPanic)

--- a/container_test.go
+++ b/container_test.go
@@ -62,6 +62,7 @@ func TestContainerReverseIterator(t *testing.T) {
 			So(si.next(), ShouldEqual, content[i])
 			i--
 		}
+		So(i, ShouldEqual, -1)
 	})
 }
 

--- a/roaring.go
+++ b/roaring.go
@@ -268,6 +268,8 @@ func (ii *intReverseIterator) init() {
 	if ii.pos >= 0 {
 		ii.iter = ii.highlowcontainer.getContainerAtIndex(ii.pos).getReverseIterator()
 		ii.hs = uint32(ii.highlowcontainer.getKeyAtIndex(ii.pos)) << 16
+	} else {
+		ii.iter = nil
 	}
 }
 
@@ -284,7 +286,7 @@ func (ii *intReverseIterator) Next() uint32 {
 func newIntReverseIterator(a *Bitmap) *intReverseIterator {
 	p := new(intReverseIterator)
 	p.highlowcontainer = &a.highlowcontainer
-	p.pos = len(a.highlowcontainer.containers) - 1
+	p.pos = a.highlowcontainer.size() - 1
 	p.init()
 	return p
 }

--- a/roaring_test.go
+++ b/roaring_test.go
@@ -2018,6 +2018,20 @@ func TestReverseIterator(t *testing.T) {
 			}
 			n--
 		}
+
+		// HasNext() was terminating early - add test
+		i = bm.ReverseIterator()
+		n = len(values) - 1
+		for ; n >= 0; n-- {
+			v := i.Next()
+			if values[n] != v {
+				t.Errorf("expected %d got %d", values[n], v)
+			}
+			if n > 0 && !i.HasNext() {
+				t.Errorf("expected HaveNext()=true for n=%d, values[n]=%d", n, values[n])
+				t.FailNow()
+			}
+		}
 	}
 	{
 		bm := New()

--- a/runcontainer_test.go
+++ b/runcontainer_test.go
@@ -312,6 +312,11 @@ func TestRleRunReverseIterator16(t *testing.T) {
 			So(it.hasNext(), ShouldBeTrue)
 			for i := 9; i >= 4; i-- {
 				So(it.next(), ShouldEqual, uint16(i))
+				if i > 4 {
+					So(it.hasNext(), ShouldBeTrue)
+				} else if i == 4 {
+					So(it.hasNext(), ShouldBeFalse)
+				}
 			}
 			So(it.hasNext(), ShouldBeFalse)
 			So(func() { it.next() }, ShouldPanic)

--- a/shortiterator.go
+++ b/shortiterator.go
@@ -26,7 +26,7 @@ type reverseIterator struct {
 }
 
 func (si *reverseIterator) hasNext() bool {
-	return si.loc > 0
+	return si.loc >= 0
 }
 
 func (si *reverseIterator) next() uint16 {


### PR DESCRIPTION
Update shortiterator.go hasNext and add tests for this and similar issues in the other container types.

The changes in roaring.go seemed reasonable after looking at the many Iterator code.