### PR TITLE
Add FlipMaxRangeEnd tests and MaxRange

### DIFF
--- a/roaring_test.go
+++ b/roaring_test.go
@@ -9,6 +9,7 @@ import (
 	"unsafe"
 
 	. "github.com/smartystreets/goconvey/convey"
+	"github.com/stretchr/testify/assert"
 	"github.com/willf/bitset"
 )
 
@@ -2096,4 +2097,16 @@ func TestReverseIterator(t *testing.T) {
 			t.Error("expected HasNext() to be false")
 		}
 	}
+}
+
+func TestPackageFlipMaxRangeEnd(t *testing.T) {
+	var empty Bitmap
+	flipped := Flip(&empty, 0, MaxRange)
+	assert.EqualValues(t, MaxRange, flipped.GetCardinality())
+}
+
+func TestBitmapFlipMaxRangeEnd(t *testing.T) {
+	var bm Bitmap
+	bm.Flip(0, MaxRange)
+	assert.EqualValues(t, MaxRange, bm.GetCardinality())
 }

--- a/util.go
+++ b/util.go
@@ -17,6 +17,10 @@ const (
 	// MaxUint32 is the largest uint32 value.
 	MaxUint32 = 4294967295
 
+	// One more than the maximum allowed bitmap bit index. For use as an upper
+	// bound for ranges.
+	MaxRange uint64 = MaxUint32 + 1
+
 	// MaxUint16 is the largest 16 bit unsigned int.
 	// This is the largest value an interval16 can store.
 	MaxUint16 = 65535


### PR DESCRIPTION
TestPackageFlipMaxRangeEnd panics, and TestBitmapFlipMaxRangeEnd goes into an infinite loop. MaxRange is a desperately needed constant.