### PR TITLE
Reduce buffering in WriteTo

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -469,6 +469,7 @@ func BenchmarkSparseIterateBitset(b *testing.B) {
 }
 
 func BenchmarkSerializationSparse(b *testing.B) {
+	b.ReportAllocs()
 	b.StopTimer()
 	r := rand.New(rand.NewSource(0))
 	s := NewBitmap()
@@ -487,6 +488,7 @@ func BenchmarkSerializationSparse(b *testing.B) {
 }
 
 func BenchmarkSerializationMid(b *testing.B) {
+	b.ReportAllocs()
 	b.StopTimer()
 	r := rand.New(rand.NewSource(0))
 	s := NewBitmap()
@@ -505,6 +507,7 @@ func BenchmarkSerializationMid(b *testing.B) {
 }
 
 func BenchmarkSerializationDense(b *testing.B) {
+	b.ReportAllocs()
 	b.StopTimer()
 	r := rand.New(rand.NewSource(0))
 	s := NewBitmap()

--- a/roaringarray.go
+++ b/roaringarray.go
@@ -457,8 +457,7 @@ func (ra *roaringArray) serializedSizeInBytes() uint64 {
 //
 // spec: https://github.com/RoaringBitmap/RoaringFormatSpec
 //
-func (ra *roaringArray) toBytes() ([]byte, error) {
-	stream := &bytes.Buffer{}
+func (ra *roaringArray) writeTo(w io.Writer) (n int64, err error) {
 	hasRun := ra.hasRunCompression()
 	isRunSizeInBytes := 0
 	cookieSize := 8
@@ -523,33 +522,29 @@ func (ra *roaringArray) toBytes() ([]byte, error) {
 		}
 	}
 
-	_, err := stream.Write(buf[:nw])
+	written, err := w.Write(buf[:nw])
 	if err != nil {
-		return nil, err
+		return n, err
 	}
-	for i, c := range ra.containers {
-		_ = i
-		_, err := c.writeTo(stream)
+	n += int64(written)
+
+	for _, c := range ra.containers {
+		written, err := c.writeTo(w)
 		if err != nil {
-			return nil, err
+			return n, err
 		}
+		n += int64(written)
 	}
-	return stream.Bytes(), nil
+	return n, nil
 }
 
 //
 // spec: https://github.com/RoaringBitmap/RoaringFormatSpec
 //
-func (ra *roaringArray) writeTo(out io.Writer) (int64, error) {
-	by, err := ra.toBytes()
-	if err != nil {
-		return 0, err
-	}
-	n, err := out.Write(by)
-	if err == nil && n < len(by) {
-		err = io.ErrShortWrite
-	}
-	return int64(n), err
+func (ra *roaringArray) toBytes() ([]byte, error) {
+	var buf bytes.Buffer
+	_, err := ra.writeTo(&buf)
+	return buf.Bytes(), err
 }
 
 func (ra *roaringArray) fromBuffer(buf []byte) (int64, error) {


### PR DESCRIPTION
This greatly reduces allocations when the writer has enough space to
hold the serialized bitmap.

```
name                   old time/op    new time/op    delta
SerializationSparse-8     127µs ± 6%      50µs ± 4%  -60.17%  (p=0.008 n=5+5)
SerializationMid-8       54.4µs ± 4%     8.2µs ± 4%  -84.98%  (p=0.008 n=5+5)
SerializationDense-8     6.43µs ± 4%    0.66µs ±13%  -89.78%  (p=0.008 n=5+5)

name                   old alloc/op   new alloc/op   delta
SerializationSparse-8     410kB ± 0%      12kB ± 0%  -96.97%  (p=0.008 n=5+5)
SerializationMid-8        277kB ± 0%       1kB ± 0%  -99.50%  (p=0.008 n=5+5)
SerializationDense-8     37.0kB ± 0%     0.1kB ± 0%  -99.61%  (p=0.008 n=5+5)

name                   old allocs/op  new allocs/op  delta
SerializationSparse-8      8.00 ± 0%      2.00 ± 0%  -75.00%  (p=0.008 n=5+5)
SerializationMid-8         10.0 ± 0%       2.0 ± 0%  -80.00%  (p=0.008 n=5+5)
SerializationDense-8       5.00 ± 0%      2.00 ± 0%  -60.00%  (p=0.008 n=5+5)
```

#163 points out that buffering may be preferred to calling `Write` on the underlying `io.Writer` many times but I think this change provides the most flexibility. It allows a user to provide a `bytes.Buffer` or `bufio.Writer` as the `io.Writer` if they want additional buffering.

Our use-case is that we're hashing the serialized representation of the bitmap but not actually storing the serialized representation in most cases -- we don't want the serialized representation buffered at all.