### PR TITLE
Improve MarshalBinary and UnmarshalBinary performance

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -525,6 +525,38 @@ func BenchmarkSerializationDense(b *testing.B) {
 	}
 }
 
+func BenchmarkMarshalBinary(b *testing.B) {
+	r := rand.New(rand.NewSource(0))
+	s := NewBitmap()
+	sz := 10000000
+	initsize := 65000
+	for i := 0; i < initsize; i++ {
+		s.Add(uint32(r.Int31n(int32(sz))))
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for j := 0; j < b.N; j++ {
+		s.MarshalBinary()
+	}
+}
+
+func BenchmarkUnmarshalBinary(b *testing.B) {
+	r := rand.New(rand.NewSource(0))
+	s := NewBitmap()
+	sz := 10000000
+	initsize := 65000
+	for i := 0; i < initsize; i++ {
+		s.Add(uint32(r.Int31n(int32(sz))))
+	}
+	data, _ := s.MarshalBinary()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for j := 0; j < b.N; j++ {
+		ub := NewBitmap()
+		ub.UnmarshalBinary(data)
+	}
+}
+
 func BenchmarkEqualsSparse(b *testing.B) {
 	b.StopTimer()
 	r := rand.New(rand.NewSource(0))

--- a/roaring.go
+++ b/roaring.go
@@ -6,7 +6,6 @@
 package roaring
 
 import (
-	"bufio"
 	"bytes"
 	"encoding/base64"
 	"fmt"
@@ -110,29 +109,15 @@ func (rb *Bitmap) ReadFromMsgpack(stream io.Reader) (int64, error) {
 }
 
 // MarshalBinary implements the encoding.BinaryMarshaler interface for the bitmap
+// (same as ToBytes)
 func (rb *Bitmap) MarshalBinary() ([]byte, error) {
-	var buf bytes.Buffer
-	writer := bufio.NewWriter(&buf)
-	_, err := rb.WriteTo(writer)
-	if err != nil {
-		return nil, err
-	}
-	err = writer.Flush()
-	if err != nil {
-		return nil, err
-	}
-	return buf.Bytes(), nil
+	return rb.ToBytes()
 }
 
 // UnmarshalBinary implements the encoding.BinaryUnmarshaler interface for the bitmap
 func (rb *Bitmap) UnmarshalBinary(data []byte) error {
-	var buf bytes.Buffer
-	_, err := buf.Write(data)
-	if err != nil {
-		return err
-	}
-	reader := bufio.NewReader(&buf)
-	_, err = rb.ReadFrom(reader)
+	r := bytes.NewReader(data)
+	_, err := rb.ReadFrom(r)
 	return err
 }
 


### PR DESCRIPTION
- Makes `MarshalBinary` an alias to `ToBytes`
- Removes unnecessary intermediate `bufio.Reader` from `UnmarshalBinary`
```
name               old time/op    new time/op    delta
MarshalBinary-4       125µs ± 3%      69µs ± 0%  -44.26%  (p=0.008 n=5+5)
UnmarshalBinary-4     100µs ± 0%      58µs ± 3%  -41.85%  (p=0.016 n=4+5)

name               old alloc/op   new alloc/op   delta
MarshalBinary-4       509kB ± 0%     276kB ± 0%  -45.73%  (p=0.079 n=4+5)
UnmarshalBinary-4     291kB ± 0%     155kB ± 0%  -46.60%  (p=0.008 n=5+5)

name               old allocs/op  new allocs/op  delta
MarshalBinary-4        10.0 ± 0%       9.0 ± 0%  -10.00%  (p=0.008 n=5+5)
UnmarshalBinary-4       340 ± 0%       337 ± 0%   -0.88%  (p=0.008 n=5+5)
```