### PR TITLE
add flushCopyOnWrite() call so that source bitmaps can be unmapped.

### DIFF
--- a/roaring.go
+++ b/roaring.go
@@ -1363,6 +1363,10 @@ func (rb *Bitmap) GetCopyOnWrite() (val bool) {
 	return rb.highlowcontainer.copyOnWrite
 }
 
+func (rb *Bitmap) FlushCopyOnWrite() {
+	return rb.highlowcontainer.flushCopyOnWrite()
+}
+
 // FlipInt calls Flip after casting the parameters (convenience method)
 func FlipInt(bm *Bitmap, rangeStart, rangeEnd int) *Bitmap {
 	return Flip(bm, uint64(rangeStart), uint64(rangeEnd))

--- a/roaring.go
+++ b/roaring.go
@@ -1364,7 +1364,7 @@ func (rb *Bitmap) GetCopyOnWrite() (val bool) {
 }
 
 func (rb *Bitmap) FlushCopyOnWrite() {
-	return rb.highlowcontainer.flushCopyOnWrite()
+	rb.highlowcontainer.flushCopyOnWrite()
 }
 
 // FlipInt calls Flip after casting the parameters (convenience method)

--- a/roaring.go
+++ b/roaring.go
@@ -1363,8 +1363,11 @@ func (rb *Bitmap) GetCopyOnWrite() (val bool) {
 	return rb.highlowcontainer.copyOnWrite
 }
 
-func (rb *Bitmap) FlushCopyOnWrite() {
-	rb.highlowcontainer.flushCopyOnWrite()
+// clone all containers which have needCopyOnWrite set to true
+// This can be used to make sure it is safe to munmap a []byte
+// that the roaring array may still have a reference to.
+func (rb *Bitmap) CloneCopyOnWriteContainers() {
+	rb.highlowcontainer.cloneCopyOnWriteContainers()
 }
 
 // FlipInt calls Flip after casting the parameters (convenience method)

--- a/roaringarray.go
+++ b/roaringarray.go
@@ -283,7 +283,11 @@ func (ra *roaringArray) clone() *roaringArray {
 	return &sa
 }
 
-func (ra *roaringArray) flushCopyOnWrite() {
+
+// clone all containers which have needCopyOnWrite set to true
+// This can be used to make sure it is safe to munmap a []byte
+// that the roaring array may still have a reference to.
+func (ra *roaringArray) cloneCopyOnWriteContainers() {
 	for i, needCopyOnWrite := range ra.needCopyOnWrite {
 		if needCopyOnWrite {
 			ra.containers[i] = ra.containers[i].clone()

--- a/roaringarray.go
+++ b/roaringarray.go
@@ -283,6 +283,15 @@ func (ra *roaringArray) clone() *roaringArray {
 	return &sa
 }
 
+func (ra *roaringArray) flushCopyOnWrite() {
+	for i, needCopyOnWrite := range ra.needCopyOnWrite {
+		if needCopyOnWrite {
+			ra.containers[i] = ra.containers[i].clone()
+			ra.needCopyOnWrite[i] = false
+		}
+	}
+}
+
 // unused function:
 //func (ra *roaringArray) containsKey(x uint16) bool {
 //	return (ra.binarySearch(0, int64(len(ra.keys)), x) >= 0)

--- a/roaringcow_test.go
+++ b/roaringcow_test.go
@@ -3,6 +3,7 @@ package roaring
 import (
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/willf/bitset"
+	"bytes"
 	"log"
 	"math/rand"
 	"strconv"
@@ -1885,4 +1886,27 @@ func TestFlipVerySmallCOW(t *testing.T) {
 		rbcard := rb.GetCardinality()
 		So(rbcard, ShouldEqual, 9)
 	})
+}
+
+func TestCloneCOWContainers(t *testing.T) {
+	Convey("test CloneCopyOnWriteContainers", t, func() {
+		rb := NewBitmap()
+		rb.AddRange(0,3000)
+		buf := &bytes.Buffer{}
+		rb.WriteTo(buf)
+
+		newRb1 := NewBitmap()
+		newRb1.FromBuffer(buf.Bytes())
+		newRb1.CloneCopyOnWriteContainers()
+
+		rb2 := NewBitmap()
+		rb2.AddRange(3000,6000)
+		buf.Reset()
+		rb2.WriteTo(buf)
+
+		So(newRb1.ToArray(), ShouldResemble, rb.ToArray())
+
+		})
+
+
 }

--- a/serialization_test.go
+++ b/serialization_test.go
@@ -945,8 +945,11 @@ func TestBitmapFromBufferCOW(t *testing.T) {
 	newRb2 := NewBitmap()
 	newRb2.FromBuffer(buf2.Bytes())
 	rbor1 := Or(newRb1, newRb2)
-	rbor2 := rbor1.Clone()
-	rbor3 := Or(newRb1.Clone(), newRb2.Clone())
+	rbor2 := rbor1
+	rbor3 := Or(newRb1, newRb2)
+	rbor1.CloneCopyOnWriteContainers()
+	rbor2.CloneCopyOnWriteContainers()
+	rbor3.CloneCopyOnWriteContainers()
 	buf1.Reset()
 	buf2.Reset()
 	rbbogus.WriteTo(buf1)


### PR DESCRIPTION
This adds FlushCopyOnWrite() to address https://github.com/RoaringBitmap/roaring/issues/219. Interested in hearing what testing we should be doing. Also, I think it is right not to touch the roaring array's CopyOnWrite field. Is that correct?

@lemire @maciej 