### PR TITLE
Peekable iterator

### DIFF
--- a/arraycontainer.go
+++ b/arraycontainer.go
@@ -24,7 +24,7 @@ func (ac *arrayContainer) fillLeastSignificant16bits(x []uint32, i int, mask uin
 	}
 }
 
-func (ac *arrayContainer) getShortIterator() shortIterable {
+func (ac *arrayContainer) getShortIterator() shortPeekable {
 	return &shortIterator{ac.content, 0}
 }
 

--- a/arraycontainer_test.go
+++ b/arraycontainer_test.go
@@ -393,3 +393,11 @@ func TestArrayContainerIand(t *testing.T) {
 		So(r[2], ShouldEqual, 150000)
 	})
 }
+
+func TestArrayIteratorPeekNext(t *testing.T) {
+	testContainerIteratorPeekNext(t, newArrayContainer())
+}
+
+func TestArrayIteratorAdvance(t *testing.T) {
+	testContainerIteratorAdvance(t, newArrayContainer())
+}

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -404,6 +404,21 @@ func BenchmarkSparseIterateRoaring(b *testing.B) {
 
 }
 
+// go test -bench BenchmarkSparseAdvance -run -
+func BenchmarkSparseAdvanceRoaring(b *testing.B) {
+	b.StopTimer()
+	s := NewBitmap()
+	initsize := 65000
+	for i := 0; i < initsize; i++ {
+		s.Add(uint32(i))
+	}
+	b.StartTimer()
+	for j := 0; j < b.N; j++ {
+		i := s.Iterator()
+		i.AdvanceIfNeeded(uint32(j % initsize))
+	}
+}
+
 // go test -bench BenchmarkIterate -run -
 func BenchmarkIterateBitset(b *testing.B) {
 	b.StopTimer()

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -414,13 +414,13 @@ func BenchmarkSparseAdvanceRoaring(b *testing.B) {
 		s.Add(uint32(i))
 	}
 
-	for _, gap := range []int{0, initsize / 2, initsize - 1} {
+	for _, gap := range []int{1, 2, 65, 650} {
 		b.Run(fmt.Sprintf("advance from %d", gap), func(b *testing.B) {
 			b.StartTimer()
 			diff := uint32(0)
 
 			for n := 0; n < b.N; n++ {
-				val := uint32(gap + (n % (initsize - gap)))
+				val := uint32((gap * n) % initsize)
 
 				i := s.Iterator()
 				i.AdvanceIfNeeded(val)
@@ -447,13 +447,13 @@ func BenchmarkSparseAdvanceSequentially(b *testing.B) {
 		s.Add(uint32(i))
 	}
 
-	for _, gap := range []int{0, initsize / 2, initsize - 1} {
+	for _, gap := range []int{1, 2, 65, 650} {
 		b.Run(fmt.Sprintf("advance from %d", gap), func(b *testing.B) {
 			b.StartTimer()
 			diff := uint32(0)
 
 			for n := 0; n < b.N; n++ {
-				val := uint32(gap + (n % (initsize - gap)))
+				val := uint32((gap * n) % initsize)
 
 				i := s.Iterator()
 

--- a/bitmapcontainer.go
+++ b/bitmapcontainer.go
@@ -115,8 +115,8 @@ func (bcsi *bitmapContainerShortIterator) peekNext() uint16 {
 }
 
 func (bcsi *bitmapContainerShortIterator) advanceIfNeeded(minval uint16) {
-	for bcsi.hasNext() && bcsi.peekNext() < minval {
-		bcsi.next()
+	if bcsi.hasNext() && bcsi.peekNext() < minval {
+		bcsi.i = bcsi.ptr.NextSetBit(int(minval))
 	}
 }
 

--- a/bitmapcontainer.go
+++ b/bitmapcontainer.go
@@ -110,11 +110,21 @@ func (bcsi *bitmapContainerShortIterator) hasNext() bool {
 	return bcsi.i >= 0
 }
 
+func (bcsi *bitmapContainerShortIterator) peekNext() uint16 {
+	return uint16(bcsi.i)
+}
+
+func (bcsi *bitmapContainerShortIterator) advanceIfNeeded(minval uint16) {
+	for bcsi.hasNext() && bcsi.peekNext() < minval {
+		bcsi.next()
+	}
+}
+
 func newBitmapContainerShortIterator(a *bitmapContainer) *bitmapContainerShortIterator {
 	return &bitmapContainerShortIterator{a, a.NextSetBit(0)}
 }
 
-func (bc *bitmapContainer) getShortIterator() shortIterable {
+func (bc *bitmapContainer) getShortIterator() shortPeekable {
 	return newBitmapContainerShortIterator(bc)
 }
 

--- a/bitmapcontainer_test.go
+++ b/bitmapcontainer_test.go
@@ -193,65 +193,11 @@ func TestBitmapPrevSet(t *testing.T) {
 }
 
 func TestBitmapIteratorPeekNext(t *testing.T) {
-	testSize := 5000
-	bc := newBitmapContainer()
-	for i := 0; i < testSize; i++ {
-		bc.iadd(uint16(i))
-	}
-
-	i := bc.getShortIterator()
-
-	for i.hasNext() {
-		p := i.peekNext()
-		n := i.next()
-
-		if p != n {
-			t.Fatalf("n!=p %d!=%d", n, p)
-		}
-	}
+	testContainerIteratorPeekNext(t, newBitmapContainer())
 }
 
 func TestBitmapIteratorAdvance(t *testing.T) {
-	values := []uint16{0, 2, 15, 16, 31, 32, 33, 9999}
-	bc := newBitmapContainer()
-	for _, v := range values {
-		bc.iadd(v)
-	}
-
-	cases := []struct {
-		minval   uint16
-		expected uint16
-	}{
-		{0, 0},
-		{1, 2},
-		{2, 2},
-		{3, 15},
-		{30, 31},
-		{33, 33},
-		{9998, 9999},
-	}
-
-	for j, c := range cases {
-		i := bc.getShortIterator()
-		i.advanceIfNeeded(c.minval)
-
-		if !i.hasNext() {
-			t.Error("expected hasNext() to be true")
-		}
-
-		if i.peekNext() != c.expected {
-			t.Errorf("Test %d fail, expected %d got %d", j, c.expected, i.peekNext())
-		}
-	}
-
-	{
-		i := bc.getShortIterator()
-		i.advanceIfNeeded(MaxUint16)
-
-		if i.hasNext() {
-			t.Error("expected hasNext() to be false")
-		}
-	}
+	testContainerIteratorAdvance(t, newBitmapContainer())
 }
 
 func TestBitmapOffset(t *testing.T) {

--- a/container_test.go
+++ b/container_test.go
@@ -115,6 +115,17 @@ func testContainerIteratorAdvance(t *testing.T, con container) {
 		i.advanceIfNeeded(MaxUint16)
 		So(i.hasNext(), ShouldBeFalse)
 	})
+
+	Convey("advance on a value that is less than the pointed value", t, func() {
+		i := con.getShortIterator()
+		i.advanceIfNeeded(29)
+		So(i.hasNext(), ShouldBeTrue)
+		So(i.peekNext(), ShouldEqual, 31)
+
+		i.advanceIfNeeded(13)
+		So(i.hasNext(), ShouldBeTrue)
+		So(i.peekNext(), ShouldEqual, 31)
+	})
 }
 
 func TestContainerReverseIterator(t *testing.T) {

--- a/container_test.go
+++ b/container_test.go
@@ -52,6 +52,71 @@ func checkContent(c container, s []uint16) bool {
 	return !fail
 }
 
+func testContainerIteratorPeekNext(t *testing.T, c container) {
+	testSize := 5000
+	for i := 0; i < testSize; i++ {
+		c.iadd(uint16(i))
+	}
+
+	Convey("shortIterator peekNext", t, func() {
+		i := c.getShortIterator()
+
+		for i.hasNext() {
+			So(i.peekNext(), ShouldEqual, i.next())
+			testSize--
+		}
+
+		So(testSize, ShouldEqual, 0)
+	})
+}
+
+func testContainerIteratorAdvance(t *testing.T, con container) {
+	values := []uint16{0, 2, 15, 16, 31, 32, 33, 9999}
+	for _, v := range values {
+		con.iadd(v)
+	}
+
+	cases := []struct {
+		minval   uint16
+		expected uint16
+	}{
+		{0, 0},
+		{1, 2},
+		{2, 2},
+		{3, 15},
+		{30, 31},
+		{33, 33},
+		{9998, 9999},
+	}
+
+	Convey("advance by using a new short iterator", t, func() {
+		for _, c := range cases {
+			i := con.getShortIterator()
+			i.advanceIfNeeded(c.minval)
+
+			So(i.hasNext(), ShouldBeTrue)
+			So(i.peekNext(), ShouldEqual, c.expected)
+		}
+	})
+
+	Convey("advance by using the same short iterator", t, func() {
+		i := con.getShortIterator()
+
+		for _, c := range cases {
+			i.advanceIfNeeded(c.minval)
+
+			So(i.hasNext(), ShouldBeTrue)
+			So(i.peekNext(), ShouldEqual, c.expected)
+		}
+	})
+
+	Convey("advance out of a container value", t, func() {
+		i := con.getShortIterator()
+		i.advanceIfNeeded(MaxUint16)
+		So(i.hasNext(), ShouldBeFalse)
+	})
+}
+
 func TestContainerReverseIterator(t *testing.T) {
 	Convey("ArrayReverseIterator", t, func() {
 		content := []uint16{1, 3, 5, 7, 9}

--- a/roaring_test.go
+++ b/roaring_test.go
@@ -2187,15 +2187,13 @@ func TestIteratorPeekNext(t *testing.T) {
 	for n := 0; n < len(values); n++ {
 		bm.Add(values[n])
 	}
-	i := bm.Iterator()
-	for i.HasNext() {
-		p := i.PeekNext()
-		v := i.Next()
 
-		if p != v {
-			t.Errorf("expected %d got %d", v, p)
+	Convey("Test IntIterator PeekNext", t, func() {
+		i := bm.Iterator()
+		for i.HasNext() {
+			So(i.PeekNext(), ShouldEqual, i.Next())
 		}
-	}
+	})
 }
 
 func TestIteratorAdvance(t *testing.T) {
@@ -2219,27 +2217,32 @@ func TestIteratorAdvance(t *testing.T) {
 		{MaxUint16, MaxUint16},
 	}
 
-	for j, c := range cases {
+	Convey("advance by using a new int iterator", t, func() {
+		for _, c := range cases {
+			i := bm.Iterator()
+			i.AdvanceIfNeeded(c.minval)
+
+			So(i.HasNext(), ShouldBeTrue)
+			So(i.PeekNext(), ShouldEqual, c.expected)
+		}
+	})
+
+	Convey("advance by using the same int iterator", t, func() {
 		i := bm.Iterator()
-		i.AdvanceIfNeeded(c.minval)
 
-		if !i.HasNext() {
-			t.Error("expected HasNext() to be true")
+		for _, c := range cases {
+			i.AdvanceIfNeeded(c.minval)
+
+			So(i.HasNext(), ShouldBeTrue)
+			So(i.PeekNext(), ShouldEqual, c.expected)
 		}
+	})
 
-		if i.PeekNext() != c.expected {
-			t.Errorf("Test %d fail, expected %d got %d", j, c.expected, i.PeekNext())
-		}
-	}
-
-	{
+	Convey("advance out of a container value", t, func() {
 		i := bm.Iterator()
 		i.AdvanceIfNeeded(MaxUint32)
-
-		if i.HasNext() {
-			t.Error("expected HasNext() to be false")
-		}
-	}
+		So(i.HasNext(), ShouldBeFalse)
+	})
 }
 
 func TestPackageFlipMaxRangeEnd(t *testing.T) {

--- a/roaring_test.go
+++ b/roaring_test.go
@@ -2243,6 +2243,17 @@ func TestIteratorAdvance(t *testing.T) {
 		i.AdvanceIfNeeded(MaxUint32)
 		So(i.HasNext(), ShouldBeFalse)
 	})
+
+	Convey("advance on a value that is less than the pointed value", t, func() {
+		i := bm.Iterator()
+		i.AdvanceIfNeeded(29)
+		So(i.HasNext(), ShouldBeTrue)
+		So(i.PeekNext(), ShouldEqual, 31)
+
+		i.AdvanceIfNeeded(13)
+		So(i.HasNext(), ShouldBeTrue)
+		So(i.PeekNext(), ShouldEqual, 31)
+	})
 }
 
 func TestPackageFlipMaxRangeEnd(t *testing.T) {

--- a/roaringarray.go
+++ b/roaringarray.go
@@ -39,7 +39,7 @@ type container interface {
 	not(start, final int) container        // range is [firstOfRange,lastOfRange)
 	inot(firstOfRange, endx int) container // i stands for inplace, range is [firstOfRange,endx)
 	xor(r container) container
-	getShortIterator() shortIterable
+	getShortIterator() shortPeekable
 	getReverseIterator() shortIterable
 	getManyIterator() manyIterable
 	contains(i uint16) bool

--- a/runcontainer.go
+++ b/runcontainer.go
@@ -1204,6 +1204,20 @@ func (ri *runIterator16) next() uint16 {
 	return ri.cur()
 }
 
+func (ri *runIterator16) peekNext() uint16 {
+	old := *ri
+	val := ri.next()
+	*ri = old
+
+	return val
+}
+
+func (ri *runIterator16) advanceIfNeeded(minval uint16) {
+	for ri.hasNext() && ri.peekNext() < minval {
+		ri.next()
+	}
+}
+
 // remove removes the element that the iterator
 // is on from the run container. You can use
 // Cur if you want to double check what is about
@@ -1993,7 +2007,7 @@ func (rc *runContainer16) fillLeastSignificant16bits(x []uint32, i int, mask uin
 	}
 }
 
-func (rc *runContainer16) getShortIterator() shortIterable {
+func (rc *runContainer16) getShortIterator() shortPeekable {
 	return rc.newRunIterator16()
 }
 

--- a/runcontainer_test.go
+++ b/runcontainer_test.go
@@ -2397,6 +2397,14 @@ func TestAllContainerMethodsAllContainerTypesWithData067(t *testing.T) {
 
 }
 
+func TestRuntimeIteratorPeekNext(t *testing.T) {
+	testContainerIteratorPeekNext(t, newRunContainer16())
+}
+
+func TestRuntimeIteratorAdvance(t *testing.T) {
+	testContainerIteratorAdvance(t, newRunContainer16())
+}
+
 // generate random contents, then return that same
 // logical content in three different container types
 func getRandomSameThreeContainers(tr trial) (*arrayContainer, *runContainer16, *bitmapContainer) {

--- a/shortiterator.go
+++ b/shortiterator.go
@@ -5,6 +5,12 @@ type shortIterable interface {
 	next() uint16
 }
 
+type shortPeekable interface {
+	shortIterable
+	peekNext() uint16
+	advanceIfNeeded(minval uint16)
+}
+
 type shortIterator struct {
 	slice []uint16
 	loc   int
@@ -18,6 +24,16 @@ func (si *shortIterator) next() uint16 {
 	a := si.slice[si.loc]
 	si.loc++
 	return a
+}
+
+func (si *shortIterator) peekNext() uint16 {
+	return si.slice[si.loc]
+}
+
+func (si *shortIterator) advanceIfNeeded(minval uint16) {
+	if si.peekNext() < minval {
+		si.loc = advanceUntil(si.slice, si.loc, len(si.slice), minval)
+	}
 }
 
 type reverseIterator struct {


### PR DESCRIPTION
Implements the ability to skip values by using `IntPeekable` interface. Was inspired by https://github.com/RoaringBitmap/RoaringBitmap implementation. 

This should be very useful for `threshold intersection` algorithms such as `CPMerge` and `MergeSkip` described in `Efficient Merging and Filtering Algorithms for Approximate String Searches` and `Simple and Efficient Algorithm for Approximate Dictionary Matching`. Go implementations can be founded here https://github.com/alldroll/suggest/tree/master/pkg/merger