### PR TITLE
Allow addOffset to use signed int offset

### DIFF
--- a/roaring_test.go
+++ b/roaring_test.go
@@ -160,16 +160,16 @@ func TestRoaringBitmapAddOffset(t *testing.T) {
 	array := []uint32{5580, 33722, 44031, 57276, 83097}
 	bmp := NewBitmap()
 	bmp.AddMany(array)
-	offtest := uint32(25000)
+	offtest := int32(25000)
 	cop := AddOffset(bmp, offtest)
 	// t.Logf("%T %v", cop, cop)
 	if len(array) != int(cop.GetCardinality()) {
 		t.Errorf("length diff %d!=%d", len(array), bmp.GetCardinality())
 		// t.FailNow()
 	}
-	expected := make([]uint32, len(array))
+	expected := make([]int32, len(array))
 	for i, x := range array {
-		expected[i] = x + offtest
+		expected[i] = int32(x) + offtest
 	}
 	wout := cop.ToArray()
 	t.Logf("%v, %v", wout, expected)
@@ -177,7 +177,7 @@ func TestRoaringBitmapAddOffset(t *testing.T) {
 		t.Errorf("length diff %d!=%d", len(wout), len(expected))
 	}
 	for i, x := range wout {
-		if x != expected[i] {
+		if int32(x) != expected[i] {
 			t.Errorf("found discrepancy %d!=%d", x, expected[i])
 		}
 	}


### PR DESCRIPTION
The function `addOffset()` took unsigned integer as arguement only.
Now it can take signed integer