### PR TITLE
Optimized `runIterator16.advanceIfNeeded` by using binary search

### DIFF
--- a/container_test.go
+++ b/container_test.go
@@ -71,7 +71,7 @@ func testContainerIteratorPeekNext(t *testing.T, c container) {
 }
 
 func testContainerIteratorAdvance(t *testing.T, con container) {
-	values := []uint16{0, 2, 15, 16, 31, 32, 33, 9999}
+	values := []uint16{2, 15, 16, 31, 32, 33, 9999}
 	for _, v := range values {
 		con.iadd(v)
 	}
@@ -80,7 +80,7 @@ func testContainerIteratorAdvance(t *testing.T, con container) {
 		minval   uint16
 		expected uint16
 	}{
-		{0, 0},
+		{0, 2},
 		{1, 2},
 		{2, 2},
 		{3, 15},
@@ -112,6 +112,10 @@ func testContainerIteratorAdvance(t *testing.T, con container) {
 
 	Convey("advance out of a container value", t, func() {
 		i := con.getShortIterator()
+
+		i.advanceIfNeeded(MaxUint16)
+		So(i.hasNext(), ShouldBeFalse)
+
 		i.advanceIfNeeded(MaxUint16)
 		So(i.hasNext(), ShouldBeFalse)
 	})

--- a/roaring.go
+++ b/roaring.go
@@ -262,7 +262,7 @@ func (ii *intIterator) AdvanceIfNeeded(minval uint32) {
 	if ii.HasNext() && (ii.hs>>16) == to {
 		ii.iter.advanceIfNeeded(lowbits(minval))
 
-		if !ii.HasNext() {
+		if !ii.iter.hasNext() {
 			ii.pos++
 			ii.init()
 		}

--- a/roaring_test.go
+++ b/roaring_test.go
@@ -2197,7 +2197,7 @@ func TestIteratorPeekNext(t *testing.T) {
 }
 
 func TestIteratorAdvance(t *testing.T) {
-	values := []uint32{0, 2, 15, 16, 31, 32, 33, 9999, MaxUint16}
+	values := []uint32{2, 15, 16, 31, 32, 33, 9999, MaxUint16}
 	bm := New()
 	for n := 0; n < len(values); n++ {
 		bm.Add(values[n])
@@ -2207,7 +2207,7 @@ func TestIteratorAdvance(t *testing.T) {
 		minval   uint32
 		expected uint32
 	}{
-		{0, 0},
+		{0, 2},
 		{1, 2},
 		{2, 2},
 		{3, 15},
@@ -2240,6 +2240,10 @@ func TestIteratorAdvance(t *testing.T) {
 
 	Convey("advance out of a container value", t, func() {
 		i := bm.Iterator()
+
+		i.AdvanceIfNeeded(MaxUint32)
+		So(i.HasNext(), ShouldBeFalse)
+
 		i.AdvanceIfNeeded(MaxUint32)
 		So(i.HasNext(), ShouldBeFalse)
 	})

--- a/shortiterator.go
+++ b/shortiterator.go
@@ -31,7 +31,7 @@ func (si *shortIterator) peekNext() uint16 {
 }
 
 func (si *shortIterator) advanceIfNeeded(minval uint16) {
-	if si.peekNext() < minval {
+	if si.hasNext() && si.peekNext() < minval {
 		si.loc = advanceUntil(si.slice, si.loc, len(si.slice), minval)
 	}
 }


### PR DESCRIPTION
This pull request aimed to optimize runIterator16.`advanceIfNeeded` by replacing a naive sequential loop with binary search approach.

Also, it fixes a bug in `IntIterator.AdvanceIfNeeded` with improper checking the state of `shortIterator` after calling `ii.iter.advanceIfNeeded`