### PR TITLE
Fixed bug with runtime container "index out of range".

### DIFF
--- a/container_test.go
+++ b/container_test.go
@@ -71,7 +71,7 @@ func testContainerIteratorPeekNext(t *testing.T, c container) {
 }
 
 func testContainerIteratorAdvance(t *testing.T, con container) {
-	values := []uint16{2, 15, 16, 31, 32, 33, 9999}
+	values := []uint16{1, 2, 15, 16, 31, 32, 33, 9999}
 	for _, v := range values {
 		con.iadd(v)
 	}
@@ -80,8 +80,8 @@ func testContainerIteratorAdvance(t *testing.T, con container) {
 		minval   uint16
 		expected uint16
 	}{
-		{0, 2},
-		{1, 2},
+		{0, 1},
+		{1, 1},
 		{2, 2},
 		{3, 15},
 		{30, 31},

--- a/roaring_test.go
+++ b/roaring_test.go
@@ -2197,7 +2197,7 @@ func TestIteratorPeekNext(t *testing.T) {
 }
 
 func TestIteratorAdvance(t *testing.T) {
-	values := []uint32{2, 15, 16, 31, 32, 33, 9999, MaxUint16}
+	values := []uint32{1, 2, 15, 16, 31, 32, 33, 9999, MaxUint16}
 	bm := New()
 	for n := 0; n < len(values); n++ {
 		bm.Add(values[n])
@@ -2207,8 +2207,8 @@ func TestIteratorAdvance(t *testing.T) {
 		minval   uint32
 		expected uint32
 	}{
-		{0, 2},
-		{1, 2},
+		{0, 1},
+		{1, 1},
 		{2, 2},
 		{3, 15},
 		{30, 31},

--- a/runcontainer.go
+++ b/runcontainer.go
@@ -1250,7 +1250,10 @@ func (ri *runIterator16) advanceIfNeeded(minval uint16) {
 			ri.curIndex = interval
 		}
 
-		ri.curPosInIndex = ri.rc.iv[ri.curIndex].length
+		// we should set a position to the previous container, only if the iterator doesn't point on the first container
+		if ri.curIndex >= 0 {
+			ri.curPosInIndex = ri.rc.iv[ri.curIndex].length
+		}
 	}
 
 	for ri.hasNext() && ri.peekNext() < minval {


### PR DESCRIPTION
I have found a really tricky bug. When we are trying to advance a `runIterator16` on an item, that is located in the first `interval16` after the `start` item, we are getting an error "index out of range".  This pull request fixes this bug and checks it through tests