### PR TITLE
Simplify runcontainer iterator

### DIFF
--- a/arraycontainer.go
+++ b/arraycontainer.go
@@ -33,7 +33,7 @@ func (ac *arrayContainer) getReverseIterator() shortIterable {
 }
 
 func (ac *arrayContainer) getManyIterator() manyIterable {
-	return &manyIterator{ac.content, 0}
+	return &shortIterator{ac.content, 0}
 }
 
 func (ac *arrayContainer) minimum() uint16 {

--- a/arraycontainer_test.go
+++ b/arraycontainer_test.go
@@ -401,3 +401,13 @@ func TestArrayIteratorPeekNext(t *testing.T) {
 func TestArrayIteratorAdvance(t *testing.T) {
 	testContainerIteratorAdvance(t, newArrayContainer())
 }
+
+// go test -bench BenchmarkShortIteratorAdvance -run -
+func BenchmarkShortIteratorAdvanceArray(b *testing.B) {
+	benchmarkContainerIteratorAdvance(b, newArrayContainer())
+}
+
+// go test -bench BenchmarkShortIteratorNext -run -
+func BenchmarkShortIteratorNextArray(b *testing.B) {
+	benchmarkContainerIteratorNext(b, newArrayContainer())
+}

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -407,6 +407,7 @@ func BenchmarkSparseIterateRoaring(b *testing.B) {
 // go test -bench BenchmarkSparseAdvance -run -
 func BenchmarkSparseAdvanceRoaring(b *testing.B) {
 	b.StopTimer()
+
 	s := NewBitmap()
 	initsize := 65000
 
@@ -416,7 +417,9 @@ func BenchmarkSparseAdvanceRoaring(b *testing.B) {
 
 	for _, gap := range []int{1, 2, 65, 650} {
 		b.Run(fmt.Sprintf("advance from %d", gap), func(b *testing.B) {
+			b.ReportAllocs()
 			b.StartTimer()
+
 			diff := uint32(0)
 
 			for n := 0; n < b.N; n++ {
@@ -438,8 +441,32 @@ func BenchmarkSparseAdvanceRoaring(b *testing.B) {
 }
 
 // go test -bench BenchmarkSparseAdvance -run -
+func BenchmarkSparseAdvanceOnHugeData(b *testing.B) {
+	b.ReportAllocs()
+
+	s := NewBitmap()
+	initsize := 6500000
+	sz := 100000000
+	r := rand.New(rand.NewSource(0))
+
+	for i := 0; i < initsize; i++ {
+		s.Add(uint32(r.Int31n(int32(sz))))
+	}
+
+	b.ResetTimer()
+
+	for n := 0; n < b.N; n++ {
+		val := uint32(n)
+
+		i := s.Iterator()
+		i.AdvanceIfNeeded(val)
+	}
+}
+
+// go test -bench BenchmarkSparseAdvance -run -
 func BenchmarkSparseAdvanceSequentially(b *testing.B) {
 	b.StopTimer()
+
 	s := NewBitmap()
 	initsize := 65000
 
@@ -449,7 +476,9 @@ func BenchmarkSparseAdvanceSequentially(b *testing.B) {
 
 	for _, gap := range []int{1, 2, 65, 650} {
 		b.Run(fmt.Sprintf("advance from %d", gap), func(b *testing.B) {
+			b.ReportAllocs()
 			b.StartTimer()
+
 			diff := uint32(0)
 
 			for n := 0; n < b.N; n++ {

--- a/bitmapcontainer_test.go
+++ b/bitmapcontainer_test.go
@@ -200,6 +200,16 @@ func TestBitmapIteratorAdvance(t *testing.T) {
 	testContainerIteratorAdvance(t, newBitmapContainer())
 }
 
+// go test -bench BenchmarkShortIteratorAdvance -run -
+func BenchmarkShortIteratorAdvanceBitmap(b *testing.B) {
+	benchmarkContainerIteratorAdvance(b, newBitmapContainer())
+}
+
+// go test -bench BenchmarkShortIteratorNext -run -
+func BenchmarkShortIteratorNextBitmap(b *testing.B) {
+	benchmarkContainerIteratorNext(b, newBitmapContainer())
+}
+
 func TestBitmapOffset(t *testing.T) {
 	nums := []uint16{10, 100, 1000}
 	expected := make([]int, len(nums))

--- a/manyiterator.go
+++ b/manyiterator.go
@@ -4,12 +4,7 @@ type manyIterable interface {
 	nextMany(hs uint32, buf []uint32) int
 }
 
-type manyIterator struct {
-	slice []uint16
-	loc   int
-}
-
-func (si *manyIterator) nextMany(hs uint32, buf []uint32) int {
+func (si *shortIterator) nextMany(hs uint32, buf []uint32) int {
 	n := 0
 	l := si.loc
 	s := si.slice

--- a/runcontainer.go
+++ b/runcontainer.go
@@ -1149,264 +1149,163 @@ func (rc *runContainer16) Add(k uint16) (wasNew bool) {
 
 //msgp:ignore runIterator
 
-// runIterator16 advice: you must call Next() at least once
-// before calling Cur(); and you should call HasNext()
-// before calling Next() to insure there are contents.
+// runIterator16 advice: you must call hasNext()
+// before calling next()/peekNext() to insure there are contents.
 type runIterator16 struct {
 	rc            *runContainer16
 	curIndex      int64
 	curPosInIndex uint16
-	curSeq        int64
 }
 
 // newRunIterator16 returns a new empty run container.
 func (rc *runContainer16) newRunIterator16() *runIterator16 {
-	return &runIterator16{rc: rc, curIndex: -1}
+	return &runIterator16{rc: rc, curIndex: 0, curPosInIndex: 0}
 }
 
-// HasNext returns false if calling Next will panic. It
+// hasNext returns false if calling next will panic. It
 // returns true when there is at least one more value
 // available in the iteration sequence.
 func (ri *runIterator16) hasNext() bool {
-	if len(ri.rc.iv) == 0 {
-		return false
-	}
-	if ri.curIndex == -1 {
-		return true
-	}
-	return ri.curSeq+1 < ri.rc.cardinality()
+	return int64(len(ri.rc.iv)) > ri.curIndex+1 ||
+		(int64(len(ri.rc.iv)) == ri.curIndex+1 && ri.rc.iv[ri.curIndex].length >= ri.curPosInIndex)
 }
 
-// cur returns the current value pointed to by the iterator.
-func (ri *runIterator16) cur() uint16 {
+// next returns the next value in the iteration sequence.
+func (ri *runIterator16) next() uint16 {
+	next := ri.rc.iv[ri.curIndex].start + ri.curPosInIndex
+
+	if ri.curPosInIndex == ri.rc.iv[ri.curIndex].length {
+		ri.curPosInIndex = 0
+		ri.curIndex++
+	} else {
+		ri.curPosInIndex++
+	}
+
+	return next
+}
+
+// peekNext returns the next value in the iteration sequence without advancing the iterator
+func (ri *runIterator16) peekNext() uint16 {
 	return ri.rc.iv[ri.curIndex].start + ri.curPosInIndex
 }
 
-// Next returns the next value in the iteration sequence.
-func (ri *runIterator16) next() uint16 {
-	if !ri.hasNext() {
-		panic("no Next available")
-	}
-	if ri.curIndex >= int64(len(ri.rc.iv)) {
-		panic("runIterator.Next() going beyond what is available")
-	}
-	if ri.curIndex == -1 {
-		// first time is special
-		ri.curIndex = 0
-	} else {
-		ri.curPosInIndex++
-		if int64(ri.rc.iv[ri.curIndex].start)+int64(ri.curPosInIndex) == int64(ri.rc.iv[ri.curIndex].last())+1 {
-			ri.curPosInIndex = 0
-			ri.curIndex++
-		}
-		ri.curSeq++
-	}
-	return ri.cur()
-}
-
-func (ri *runIterator16) peekNext() uint16 {
-	old := *ri
-	val := ri.next()
-	*ri = old
-
-	return val
-}
-
+// advanceIfNeeded advances as long as the next value is smaller than minval
 func (ri *runIterator16) advanceIfNeeded(minval uint16) {
-	if ri.hasNext() && ri.peekNext() < minval {
-		key := int64(minval)
-
-		opt := &searchOptions{
-			startIndex: ri.curIndex,
-			endxIndex:  int64(len(ri.rc.iv)),
-		}
-
-		// first time is special
-		if opt.startIndex == -1 {
-			opt.startIndex = 0
-		}
-
-		interval, isPresent, _ := ri.rc.search(key, opt)
-
-		// interval == -1 means, that the key is before the pointed interval
-		if interval == -1 && !isPresent {
-			return
-		}
-
-		// actualize curSeq with the number of skipped elements
-		if ri.curIndex >= 0 && ri.rc.iv[ri.curIndex].length <= ri.curPosInIndex {
-			ri.curSeq += int64(ri.rc.iv[ri.curIndex].length - ri.curPosInIndex + 1)
-		}
-
-		for j := ri.curIndex + 1; j < interval; j++ {
-			ri.curSeq += int64(ri.rc.iv[j].length + 1)
-		}
-
-		// if isPresent, than we should use the previous interval
-		if isPresent {
-			ri.curIndex = interval - 1
-		} else {
-			// otherwise we have interval where the last value is less than minval
-			ri.curIndex = interval
-		}
-
-		// we should set a position to the previous container, only if the iterator doesn't point on the first container
-		if ri.curIndex >= 0 {
-			ri.curPosInIndex = ri.rc.iv[ri.curIndex].length
-		}
+	if !ri.hasNext() || ri.peekNext() >= minval {
+		return
 	}
 
-	for ri.hasNext() && ri.peekNext() < minval {
-		ri.next()
+	opt := &searchOptions{
+		startIndex: ri.curIndex,
+		endxIndex:  int64(len(ri.rc.iv)),
+	}
+
+	// interval cannot be -1 because of minval > peekNext
+	interval, isPresent, _ := ri.rc.search(int64(minval), opt)
+
+	// if the minval is present, set the curPosIndex at the right position
+	if isPresent {
+		ri.curIndex = interval
+		ri.curPosInIndex = minval - ri.rc.iv[ri.curIndex].start
+	} else {
+		// otherwise interval is set to to the minimum index of rc.iv
+		// which comes strictly before the key, that's why we set the next interval
+		ri.curIndex = interval + 1
+		ri.curPosInIndex = 0
 	}
 }
 
-// remove removes the element that the iterator
-// is on from the run container. You can use
-// Cur if you want to double check what is about
-// to be deleted.
-func (ri *runIterator16) remove() uint16 {
-	n := ri.rc.cardinality()
-	if n == 0 {
-		panic("runIterator.Remove called on empty runContainer16")
-	}
-	cur := ri.cur()
-
-	ri.rc.deleteAt(&ri.curIndex, &ri.curPosInIndex, &ri.curSeq)
-	return cur
-}
-
-// runReverseIterator16 advice: you must call next() at least once
-// before calling cur(); and you should call hasNext()
+// runReverseIterator16 advice: you must call hasNext()
 // before calling next() to insure there are contents.
 type runReverseIterator16 struct {
 	rc            *runContainer16
 	curIndex      int64  // index into rc.iv
 	curPosInIndex uint16 // offset in rc.iv[curIndex]
-	curSeq        int64  // 0->cardinality, performance optimization in hasNext()
 }
 
 // newRunReverseIterator16 returns a new empty run iterator.
 func (rc *runContainer16) newRunReverseIterator16() *runReverseIterator16 {
-	return &runReverseIterator16{rc: rc, curIndex: -2}
+	index := int64(len(rc.iv)) - 1
+	pos := uint16(0)
+
+	if index >= 0 {
+		pos = rc.iv[index].length
+	}
+
+	return &runReverseIterator16{
+		rc:            rc,
+		curIndex:      index,
+		curPosInIndex: pos,
+	}
 }
 
 // hasNext returns false if calling next will panic. It
 // returns true when there is at least one more value
 // available in the iteration sequence.
 func (ri *runReverseIterator16) hasNext() bool {
-	if len(ri.rc.iv) == 0 {
-		return false
-	}
-	if ri.curIndex == -2 {
-		return true
-	}
-	return ri.rc.cardinality()-ri.curSeq > 1
-}
-
-// cur returns the current value pointed to by the iterator.
-func (ri *runReverseIterator16) cur() uint16 {
-	return ri.rc.iv[ri.curIndex].start + ri.curPosInIndex
+	return ri.curIndex > 0 || ri.curIndex == 0 && ri.curPosInIndex >= 0
 }
 
 // next returns the next value in the iteration sequence.
 func (ri *runReverseIterator16) next() uint16 {
-	if !ri.hasNext() {
-		panic("no next available")
-	}
-	if ri.curIndex == -1 {
-		panic("runReverseIterator.next() going beyond what is available")
-	}
-	if ri.curIndex == -2 {
-		// first time is special
-		ri.curIndex = int64(len(ri.rc.iv)) - 1
-		ri.curPosInIndex = ri.rc.iv[ri.curIndex].length
+	next := ri.rc.iv[ri.curIndex].start + ri.curPosInIndex
+
+	if ri.curPosInIndex > 0 {
+		ri.curPosInIndex--
 	} else {
-		if ri.curPosInIndex > 0 {
-			ri.curPosInIndex--
-		} else {
-			ri.curIndex--
+		ri.curIndex--
+
+		if ri.curIndex >= 0 {
 			ri.curPosInIndex = ri.rc.iv[ri.curIndex].length
 		}
-		ri.curSeq++
 	}
-	return ri.cur()
+
+	return next
 }
 
-// remove removes the element that the iterator
-// is on from the run container. You can use
-// cur if you want to double check what is about
-// to be deleted.
-func (ri *runReverseIterator16) remove() uint16 {
-	n := ri.rc.cardinality()
-	if n == 0 {
-		panic("runReverseIterator.Remove called on empty runContainer16")
-	}
-	cur := ri.cur()
-
-	ri.rc.deleteAt(&ri.curIndex, &ri.curPosInIndex, &ri.curSeq)
-	return cur
-}
-
-type manyRunIterator16 struct {
-	rc            *runContainer16
-	curIndex      int64
-	curPosInIndex uint16
-	curSeq        int64
-}
-
-func (rc *runContainer16) newManyRunIterator16() *manyRunIterator16 {
-	return &manyRunIterator16{rc: rc, curIndex: -1}
-}
-
-func (ri *manyRunIterator16) hasNext() bool {
-	if len(ri.rc.iv) == 0 {
-		return false
-	}
-	if ri.curIndex == -1 {
-		return true
-	}
-	return ri.curSeq+1 < ri.rc.cardinality()
+func (rc *runContainer16) newManyRunIterator16() *runIterator16 {
+	return rc.newRunIterator16()
 }
 
 // hs are the high bits to include to avoid needing to reiterate over the buffer in NextMany
-func (ri *manyRunIterator16) nextMany(hs uint32, buf []uint32) int {
+func (ri *runIterator16) nextMany(hs uint32, buf []uint32) int {
 	n := 0
+
 	if !ri.hasNext() {
 		return n
 	}
+
 	// start and end are inclusive
 	for n < len(buf) {
-		if ri.curIndex == -1 || int(ri.rc.iv[ri.curIndex].length-ri.curPosInIndex) <= 0 {
+		moreVals := 0
+
+		if ri.rc.iv[ri.curIndex].length >= ri.curPosInIndex {
+			// add as many as you can from this seq
+			moreVals = minOfInt(int(ri.rc.iv[ri.curIndex].length-ri.curPosInIndex)+1, len(buf)-n)
+			base := uint32(ri.rc.iv[ri.curIndex].start+ri.curPosInIndex) | hs
+
+			// allows BCE
+			buf2 := buf[n : n+moreVals]
+			for i := range buf2 {
+				buf2[i] = base + uint32(i)
+			}
+
+			// update values
+			n += moreVals
+		}
+
+		if moreVals+int(ri.curPosInIndex) > int(ri.rc.iv[ri.curIndex].length) {
 			ri.curPosInIndex = 0
 			ri.curIndex++
+
 			if ri.curIndex == int64(len(ri.rc.iv)) {
 				break
 			}
-			buf[n] = uint32(ri.rc.iv[ri.curIndex].start) | hs
-			if ri.curIndex != 0 {
-				ri.curSeq++
-			}
-			n++
-			// not strictly necessarily due to len(buf)-n min check, but saves some work
-			continue
+		} else {
+			ri.curPosInIndex += uint16(moreVals) //moreVals always fits in uint16
 		}
-		// add as many as you can from this seq
-		moreVals := minOfInt(int(ri.rc.iv[ri.curIndex].length-ri.curPosInIndex), len(buf)-n)
-
-		base := uint32(ri.rc.iv[ri.curIndex].start+ri.curPosInIndex+1) | hs
-
-		// allows BCE
-		buf2 := buf[n : n+moreVals]
-		for i := range buf2 {
-			buf2[i] = base + uint32(i)
-		}
-
-		// update values
-		ri.curPosInIndex += uint16(moreVals) //moreVals always fits in uint16
-		ri.curSeq += int64(moreVals)
-		n += moreVals
 	}
+
 	return n
 }
 
@@ -1414,21 +1313,19 @@ func (ri *manyRunIterator16) nextMany(hs uint32, buf []uint32) int {
 func (rc *runContainer16) removeKey(key uint16) (wasPresent bool) {
 
 	var index int64
-	var curSeq int64
 	index, wasPresent, _ = rc.search(int64(key), nil)
 	if !wasPresent {
 		return // already removed, nothing to do.
 	}
 	pos := key - rc.iv[index].start
-	rc.deleteAt(&index, &pos, &curSeq)
+	rc.deleteAt(&index, &pos)
 	return
 }
 
 // internal helper functions
 
-func (rc *runContainer16) deleteAt(curIndex *int64, curPosInIndex *uint16, curSeq *int64) {
+func (rc *runContainer16) deleteAt(curIndex *int64, curPosInIndex *uint16) {
 	rc.card--
-	*curSeq--
 	ci := *curIndex
 	pos := *curPosInIndex
 

--- a/runcontainer_gen.go
+++ b/runcontainer_gen.go
@@ -891,11 +891,6 @@ func (z *runIterator16) DecodeMsg(dc *msgp.Reader) (err error) {
 			if err != nil {
 				return
 			}
-		case "curSeq":
-			z.curSeq, err = dc.ReadInt64()
-			if err != nil {
-				return
-			}
 		default:
 			err = dc.Skip()
 			if err != nil {
@@ -908,9 +903,9 @@ func (z *runIterator16) DecodeMsg(dc *msgp.Reader) (err error) {
 
 // Deprecated: EncodeMsg implements msgp.Encodable
 func (z *runIterator16) EncodeMsg(en *msgp.Writer) (err error) {
-	// map header, size 4
+	// map header, size 3
 	// write "rc"
-	err = en.Append(0x84, 0xa2, 0x72, 0x63)
+	err = en.Append(0x83, 0xa2, 0x72, 0x63)
 	if err != nil {
 		return err
 	}
@@ -943,24 +938,15 @@ func (z *runIterator16) EncodeMsg(en *msgp.Writer) (err error) {
 	if err != nil {
 		return
 	}
-	// write "curSeq"
-	err = en.Append(0xa6, 0x63, 0x75, 0x72, 0x53, 0x65, 0x71)
-	if err != nil {
-		return err
-	}
-	err = en.WriteInt64(z.curSeq)
-	if err != nil {
-		return
-	}
 	return
 }
 
 // Deprecated: MarshalMsg implements msgp.Marshaler
 func (z *runIterator16) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
-	// map header, size 4
+	// map header, size 3
 	// string "rc"
-	o = append(o, 0x84, 0xa2, 0x72, 0x63)
+	o = append(o, 0x83, 0xa2, 0x72, 0x63)
 	if z.rc == nil {
 		o = msgp.AppendNil(o)
 	} else {
@@ -975,9 +961,6 @@ func (z *runIterator16) MarshalMsg(b []byte) (o []byte, err error) {
 	// string "curPosInIndex"
 	o = append(o, 0xad, 0x63, 0x75, 0x72, 0x50, 0x6f, 0x73, 0x49, 0x6e, 0x49, 0x6e, 0x64, 0x65, 0x78)
 	o = msgp.AppendUint16(o, z.curPosInIndex)
-	// string "curSeq"
-	o = append(o, 0xa6, 0x63, 0x75, 0x72, 0x53, 0x65, 0x71)
-	o = msgp.AppendInt64(o, z.curSeq)
 	return
 }
 
@@ -1023,11 +1006,6 @@ func (z *runIterator16) UnmarshalMsg(bts []byte) (o []byte, err error) {
 			if err != nil {
 				return
 			}
-		case "curSeq":
-			z.curSeq, bts, err = msgp.ReadInt64Bytes(bts)
-			if err != nil {
-				return
-			}
 		default:
 			bts, err = msgp.Skip(bts)
 			if err != nil {
@@ -1047,7 +1025,7 @@ func (z *runIterator16) Msgsize() (s int) {
 	} else {
 		s += z.rc.Msgsize()
 	}
-	s += 9 + msgp.Int64Size + 14 + msgp.Uint16Size + 7 + msgp.Int64Size
+	s += 9 + msgp.Int64Size + 14 + msgp.Uint16Size
 	return
 }
 


### PR DESCRIPTION
This pull request simplifies the logic of `runIterator*`. There are some reasons why:

* In my opinion, the logic is a little bit tricky, especially with different conditions check of `curIndex` [example 1](https://github.com/RoaringBitmap/roaring/blob/master/runcontainer.go#L1174), [example 2](https://github.com/RoaringBitmap/roaring/blob/master/runcontainer.go#L1193) and [example 3](https://github.com/RoaringBitmap/roaring/blob/master/runcontainer.go#L1320).
* I think that there is no need to hold the field `curSeq` [here](https://github.com/RoaringBitmap/roaring/blob/master/runcontainer.go#L1159), if we get rid of it, we will save 8 bytes on each allocation of `runIterator`. 
* I also took the liberty of getting rid of methods `cur` and `remove`, as they are declared as private, don't have any client and make the logic complicated as well.
* Declared `runIterator16` and `shortIterator` as `manyIterable`. Here I don't see any benefits of having separate structs `manyRunIterator16` and `manyIterator`.

Here are some benchmarks:

```
BenchmarkNexts/next__100.000000%-8         10488478      6516140       -37.87%
BenchmarkNexts/nextmany__100.000000%-8     1460777       1377149       -5.72%
BenchmarkNexts/next__50.000000%-8          7668041       7698551       +0.40%
BenchmarkNexts/nextmany__50.000000%-8      2267141       2081093       -8.21%
BenchmarkNexts/next__25.000000%-8          8333066       7938694       -4.73%
BenchmarkNexts/nextmany__25.000000%-8      2197860       2027136       -7.77%
BenchmarkNexts/next__12.500000%-8          7713889       7546096       -2.18%
BenchmarkNexts/nextmany__12.500000%-8      2184623       2101593       -3.80%
BenchmarkNexts/next__6.250000%-8           5720836       5208686       -8.95%
BenchmarkNexts/nextmany__6.250000%-8       1709961       1524555       -10.84%
BenchmarkNexts/next__3.125000%-8           5362623       5156951       -3.84%
BenchmarkNexts/nextmany__3.125000%-8       1508467       1462653       -3.04%
BenchmarkNexts/next__1.562500%-8           5342316       5151148       -3.58%
BenchmarkNexts/nextmany__1.562500%-8       1547501       1484155       -4.09%
BenchmarkNexts/next__0.390625%-8           5958044       5221611       -12.36%
BenchmarkNexts/nextmany__0.390625%-8       1617392       1576716       -2.51%
BenchmarkNexts/next__0.097656%-8           5773577       5589557       -3.19%
BenchmarkNexts/nextmany__0.097656%-8       1918443       1913017       -0.28%
BenchmarkNexts/next__0.012352%-8           9058896       8564912       -5.45%
BenchmarkNexts/nextmany__0.012352%-8       5713720       5405362       -5.40%
BenchmarkNextsRLE/next-8                   23196712      12829215      -44.69%
BenchmarkNextsRLE/nextmany-8               2750831       2814295       +2.31%
```

