### PR TITLE
Add 64 bit implementation of roaring.Bitmap

### DIFF
--- a/manyiterator.go
+++ b/manyiterator.go
@@ -2,6 +2,7 @@ package roaring
 
 type manyIterable interface {
 	nextMany(hs uint32, buf []uint32) int
+	nextMany64(hs uint64, buf []uint64) int
 }
 
 func (si *shortIterator) nextMany(hs uint32, buf []uint32) int {
@@ -10,6 +11,19 @@ func (si *shortIterator) nextMany(hs uint32, buf []uint32) int {
 	s := si.slice
 	for n < len(buf) && l < len(s) {
 		buf[n] = uint32(s[l]) | hs
+		l++
+		n++
+	}
+	si.loc = l
+	return n
+}
+
+func (si *shortIterator) nextMany64(hs uint64, buf []uint64) int {
+	n := 0
+	l := si.loc
+	s := si.slice
+	for n < len(buf) && l < len(s) {
+		buf[n] = uint64(s[l]) | hs
 		l++
 		n++
 	}

--- a/roaring.go
+++ b/roaring.go
@@ -346,7 +346,9 @@ func newIntReverseIterator(a *Bitmap) *intReverseIterator {
 // ManyIntIterable allows you to iterate over the values in a Bitmap
 type ManyIntIterable interface {
 	// pass in a buffer to fill up with values, returns how many values were returned
-	NextMany([]uint32) int
+	NextMany(buf []uint32) int
+	// pass in a buffer to fill up with 64 bit values, returns how many values were returned
+	NextMany64(hs uint64, buf []uint64) int
 }
 
 type manyIntIterator struct {
@@ -372,6 +374,25 @@ func (ii *manyIntIterator) NextMany(buf []uint32) int {
 			break
 		}
 		moreN := ii.iter.nextMany(ii.hs, buf[n:])
+		n += moreN
+		if moreN == 0 {
+			ii.pos = ii.pos + 1
+			ii.init()
+		}
+	}
+
+	return n
+}
+
+func (ii *manyIntIterator) NextMany64(hs64 uint64, buf []uint64) int {
+	hs := uint64(ii.hs) | hs64
+	n := 0
+	for n < len(buf) {
+		if ii.iter == nil {
+			break
+		}
+
+		moreN := ii.iter.nextMany64(hs, buf[n:])
 		n += moreN
 		if moreN == 0 {
 			ii.pos = ii.pos + 1
@@ -1522,4 +1543,8 @@ func (rb *Bitmap) Stats() Statistics {
 		}
 	}
 	return stats
+}
+
+func (rb *Bitmap) FillLeastSignificant32bits(x []uint64, i uint64, mask uint64) {
+	rb.ManyIterator().NextMany64(mask, x[i:])
 }

--- a/roaring.go
+++ b/roaring.go
@@ -385,13 +385,13 @@ func (ii *manyIntIterator) NextMany(buf []uint32) int {
 }
 
 func (ii *manyIntIterator) NextMany64(hs64 uint64, buf []uint64) int {
-	hs := uint64(ii.hs) | hs64
 	n := 0
 	for n < len(buf) {
 		if ii.iter == nil {
 			break
 		}
 
+		hs := uint64(ii.hs) | hs64
 		moreN := ii.iter.nextMany64(hs, buf[n:])
 		n += moreN
 		if moreN == 0 {

--- a/roaring64/aggregation64_test.go
+++ b/roaring64/aggregation64_test.go
@@ -237,6 +237,15 @@ func TestParAggregations(t *testing.T) {
 	}
 }
 
+func TestParAggregations2(t *testing.T) {
+	orFunc := func(bitmaps ...*Bitmap) *Bitmap {
+		return ParOr(0, bitmaps...)
+	}
+	t.Run(fmt.Sprintf("par0"), func(t *testing.T) {
+		testAggregations(t, nil, orFunc, nil)
+	})
+}
+
 /*
 func TestParHeapAggregations(t *testing.T) {
 	orFunc := func(bitmaps ...*Bitmap) *Bitmap {

--- a/roaring64/aggregation64_test.go
+++ b/roaring64/aggregation64_test.go
@@ -222,7 +222,7 @@ func assertAggregation(t *testing.T, expected uint64, aggr func(bitmaps ...*Bitm
 }
 
 func TestParAggregations(t *testing.T) {
-	for _, p := range [...]int{1, 2, 4} {
+	for _, p := range [...]int{0, 1, 2, 4} {
 		//andFunc := func(bitmaps ...*Bitmap) *Bitmap {
 		//	return ParAnd(p, bitmaps...)
 		//}

--- a/roaring64/aggregation64_test.go
+++ b/roaring64/aggregation64_test.go
@@ -1,0 +1,256 @@
+package roaring64
+
+// to run just these tests: go test -run TestParAggregations
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func testAggregations(t *testing.T,
+	and func(bitmaps ...*Bitmap) *Bitmap,
+	or func(bitmaps ...*Bitmap) *Bitmap,
+	xor func(bitmaps ...*Bitmap) *Bitmap) {
+
+	t.Run("simple case", func(t *testing.T) {
+		rb1 := NewBitmap()
+		rb2 := NewBitmap()
+		rb1.Add(uint64(1))
+		rb2.Add(uint64(2))
+
+		assertAggregation(t, 0, and, rb1, rb2)
+		assertAggregation(t, 2, or, rb1, rb2)
+		assertAggregation(t, 2, xor, rb1, rb2)
+	})
+
+	t.Run("aggregate nothing", func(t *testing.T) {
+		assertAggregation(t, 0, and)
+		assertAggregation(t, 0, or)
+		assertAggregation(t, 0, xor)
+	})
+
+	t.Run("single bitmap", func(t *testing.T) {
+		rb := BitmapOf(1, 2, 3)
+
+		assertAggregation(t, 3, and, rb)
+		assertAggregation(t, 3, or, rb)
+		assertAggregation(t, 3, xor, rb)
+	})
+
+	t.Run("empty and single elem bitmaps", func(t *testing.T) {
+		rb1 := NewBitmap()
+		rb2 := BitmapOf(1)
+
+		assertAggregation(t, 0, and, rb1, rb2)
+		assertAggregation(t, 1, or, rb1, rb2)
+		assertAggregation(t, 1, xor, rb1, rb2)
+	})
+
+	t.Run("two single elem disjoint sets", func(t *testing.T) {
+		rb1 := BitmapOf(1)
+		rb2 := BitmapOf(2)
+
+		assertAggregation(t, 0, and, rb1, rb2)
+		assertAggregation(t, 2, or, rb1, rb2)
+	})
+
+	t.Run("3 bitmaps with CoW set (not in order of definition)", func(t *testing.T) {
+		rb1 := NewBitmap()
+		rb2 := NewBitmap()
+		rb3 := NewBitmap()
+		rb1.SetCopyOnWrite(true)
+		rb2.SetCopyOnWrite(true)
+		rb3.SetCopyOnWrite(true)
+		rb1.Add(uint64(1))
+		rb1.Add(uint64(100000))
+		rb2.Add(uint64(200000))
+		rb3.Add(uint64(1))
+		rb3.Add(uint64(300000))
+
+		assertAggregation(t, 0, and, rb2, rb1, rb3)
+		assertAggregation(t, 4, or, rb2, rb1, rb3)
+		assertAggregation(t, 3, xor, rb2, rb1, rb3)
+	})
+
+	t.Run("3 bitmaps (not in order of definition)", func(t *testing.T) {
+		rb1 := NewBitmap()
+		rb2 := NewBitmap()
+		rb3 := NewBitmap()
+		rb1.Add(uint64(1))
+		rb1.Add(uint64(100000))
+		rb2.Add(uint64(200000))
+		rb3.Add(uint64(1))
+		rb3.Add(uint64(300000))
+
+		assertAggregation(t, 0, and, rb2, rb1, rb3)
+		assertAggregation(t, 4, or, rb2, rb1, rb3)
+		assertAggregation(t, 3, xor, rb2, rb1, rb3)
+	})
+
+	t.Run("3 bitmaps", func(t *testing.T) {
+		rb1 := NewBitmap()
+		rb2 := NewBitmap()
+		rb3 := NewBitmap()
+		rb1.Add(uint64(1))
+		rb1.Add(uint64(100000))
+		rb2.Add(uint64(200000))
+		rb3.Add(uint64(1))
+		rb3.Add(uint64(300000))
+
+		assertAggregation(t, 0, and, rb1, rb2, rb3)
+		assertAggregation(t, 4, or, rb1, rb2, rb3)
+		assertAggregation(t, 3, xor, rb1, rb2, rb3)
+	})
+
+	t.Run("3 bitmaps with CoW set", func(t *testing.T) {
+		rb1 := NewBitmap()
+		rb2 := NewBitmap()
+		rb3 := NewBitmap()
+		rb1.SetCopyOnWrite(true)
+		rb2.SetCopyOnWrite(true)
+		rb3.SetCopyOnWrite(true)
+		rb1.Add(uint64(1))
+		rb1.Add(uint64(100000))
+		rb2.Add(uint64(200000))
+		rb3.Add(uint64(1))
+		rb3.Add(uint64(300000))
+
+		assertAggregation(t, 0, and, rb1, rb2, rb3)
+		assertAggregation(t, 4, or, rb1, rb2, rb3)
+		assertAggregation(t, 3, xor, rb1, rb2, rb3)
+	})
+
+	t.Run("advanced case", func(t *testing.T) {
+		rb1 := NewBitmap()
+		rb2 := NewBitmap()
+		rb3 := NewBitmap()
+		for i := uint64(0); i < 1000000; i += 3 {
+			rb1.Add(i)
+		}
+		for i := uint64(0); i < 1000000; i += 7 {
+			rb2.Add(i)
+		}
+		for i := uint64(0); i < 1000000; i += 1001 {
+			rb3.Add(i)
+		}
+		for i := uint64(1000000); i < 2000000; i += 1001 {
+			rb1.Add(i)
+		}
+		for i := uint64(1000000); i < 2000000; i += 3 {
+			rb2.Add(i)
+		}
+		for i := uint64(1000000); i < 2000000; i += 7 {
+			rb3.Add(i)
+		}
+
+		rb1.Or(rb2)
+		rb1.Or(rb3)
+		bigand := And(And(rb1, rb2), rb3)
+		bigxor := Xor(Xor(rb1, rb2), rb3)
+
+		if or != nil {
+			assert.True(t, or(rb1, rb2, rb3).Equals(rb1))
+		}
+
+		if and != nil {
+			assert.True(t, and(rb1, rb2, rb3).Equals(bigand))
+		}
+
+		if xor != nil {
+			assert.True(t, xor(rb1, rb2, rb3).Equals(bigxor))
+		}
+	})
+
+	t.Run("advanced case with runs", func(t *testing.T) {
+		rb1 := NewBitmap()
+		rb2 := NewBitmap()
+		rb3 := NewBitmap()
+		for i := uint64(500); i < 75000; i++ {
+			rb1.Add(i)
+		}
+		for i := uint64(0); i < 1000000; i += 7 {
+			rb2.Add(i)
+		}
+		for i := uint64(0); i < 1000000; i += 1001 {
+			rb3.Add(i)
+		}
+		for i := uint64(1000000); i < 2000000; i += 1001 {
+			rb1.Add(i)
+		}
+		for i := uint64(1000000); i < 2000000; i += 3 {
+			rb2.Add(i)
+		}
+		for i := uint64(1000000); i < 2000000; i += 7 {
+			rb3.Add(i)
+		}
+		rb1.RunOptimize()
+
+		rb1.Or(rb2)
+		rb1.Or(rb3)
+		bigand := And(And(rb1, rb2), rb3)
+		bigxor := Xor(Xor(rb1, rb2), rb3)
+
+		if or != nil {
+			assert.True(t, or(rb1, rb2, rb3).Equals(rb1))
+		}
+
+		if and != nil {
+			assert.True(t, and(rb1, rb2, rb3).Equals(bigand))
+		}
+
+		if xor != nil {
+			assert.True(t, xor(rb1, rb2, rb3).Equals(bigxor))
+		}
+	})
+
+	t.Run("issue 178", func(t *testing.T) {
+		ba1 := []uint64{3585028, 65901253, 143441994, 211160474, 286511937, 356744840, 434332509, 502812785, 576097614, 646557334, 714794241, 775083485, 833704249, 889329147, 941367043}
+		ba2 := []uint64{17883, 54494426, 113908938, 174519827, 235465665, 296685741, 357644666, 420192495, 476104304, 523046142, 577855081, 634889665, 692460635, 751350463, 809989192, 863494316, 919127240}
+
+		r1 := BitmapOf(ba1...)
+		r2 := BitmapOf(ba2...)
+
+		assertAggregation(t, 32, or, r1, r2)
+	})
+}
+
+func assertAggregation(t *testing.T, expected uint64, aggr func(bitmaps ...*Bitmap) *Bitmap, bitmaps ...*Bitmap) {
+	if aggr != nil {
+		assert.Equal(t, aggr(bitmaps...).GetCardinality(), expected)
+	}
+}
+
+func TestParAggregations(t *testing.T) {
+	for _, p := range [...]int{1, 2, 4} {
+		//andFunc := func(bitmaps ...*Bitmap) *Bitmap {
+		//	return ParAnd(p, bitmaps...)
+		//}
+		orFunc := func(bitmaps ...*Bitmap) *Bitmap {
+			return ParOr(p, bitmaps...)
+		}
+
+		t.Run(fmt.Sprintf("par%d", p), func(t *testing.T) {
+			//testAggregations(t, andFunc, orFunc, nil)
+			testAggregations(t, nil, orFunc, nil)
+		})
+	}
+}
+
+/*
+func TestParHeapAggregations(t *testing.T) {
+	orFunc := func(bitmaps ...*Bitmap) *Bitmap {
+		return ParHeapOr(0, bitmaps...)
+	}
+
+	testAggregations(t, nil, orFunc, nil)
+}
+*/
+
+func TestFastAggregations(t *testing.T) {
+	testAggregations(t, nil, FastOr, nil)
+}
+
+//func TestHeapAggregations(t *testing.T) {
+//	testAggregations(t, nil, HeapOr, HeapXor)
+//}

--- a/roaring64/aggregation64_test.go
+++ b/roaring64/aggregation64_test.go
@@ -143,6 +143,9 @@ func testAggregations(t *testing.T,
 		for i := uint64(1000000); i < 2000000; i += 7 {
 			rb3.Add(i)
 		}
+		for i := uint64(1000000000000000); i < 20000000000000000; i += 100000000000 {
+			rb3.Add(i)
+		}
 
 		rb1.Or(rb2)
 		rb1.Or(rb3)

--- a/roaring64/fastaggregation64.go
+++ b/roaring64/fastaggregation64.go
@@ -1,0 +1,37 @@
+package roaring64
+
+// FastAnd computes the intersection between many bitmaps quickly
+// Compared to the And function, it can take many bitmaps as input, thus saving the trouble
+// of manually calling "And" many times.
+func FastAnd(bitmaps ...*Bitmap) *Bitmap {
+	if len(bitmaps) == 0 {
+		return NewBitmap()
+	} else if len(bitmaps) == 1 {
+		return bitmaps[0].Clone()
+	}
+	answer := And(bitmaps[0], bitmaps[1])
+	for _, bm := range bitmaps[2:] {
+		answer.And(bm)
+	}
+	return answer
+}
+
+// FastOr computes the union between many bitmaps quickly, as opposed to having to call Or repeatedly.
+// It might also be faster than calling Or repeatedly.
+func FastOr(bitmaps ...*Bitmap) *Bitmap {
+	if len(bitmaps) == 0 {
+		return NewBitmap()
+	} else if len(bitmaps) == 1 {
+		return bitmaps[0].Clone()
+	}
+	//answer := lazyOR(bitmaps[0], bitmaps[1])
+	answer := Or(bitmaps[0], bitmaps[1])
+	for _, bm := range bitmaps[2:] {
+		//answer = answer.lazyOR(bm)
+		answer.Or(bm)
+	}
+	// here is where repairAfterLazy is called.
+	//answer.repairAfterLazy()
+	return answer
+}
+

--- a/roaring64/fastaggregation64_test.go
+++ b/roaring64/fastaggregation64_test.go
@@ -1,0 +1,42 @@
+package roaring64
+
+// to run just these tests: go test -run TestFastAggregations*
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+
+
+func TestFastAggregationsAdvanced_run(t *testing.T) {
+	rb1 := NewBitmap()
+	rb2 := NewBitmap()
+	rb3 := NewBitmap()
+	for i := uint64(500); i < 75000; i++ {
+		rb1.Add(i)
+	}
+	for i := uint64(0); i < 1000000; i += 7 {
+		rb2.Add(i)
+	}
+	for i := uint64(0); i < 1000000; i += 1001 {
+		rb3.Add(i)
+	}
+	for i := uint64(1000000); i < 2000000; i += 1001 {
+		rb1.Add(i)
+	}
+	for i := uint64(1000000); i < 2000000; i += 3 {
+		rb2.Add(i)
+	}
+	for i := uint64(1000000); i < 2000000; i += 7 {
+		rb3.Add(i)
+	}
+	rb1.RunOptimize()
+	rb1.Or(rb2)
+	rb1.Or(rb3)
+	bigand := And(And(rb1, rb2), rb3)
+
+	assert.True(t, FastOr(rb1, rb2, rb3).Equals(rb1))
+	assert.True(t, FastAnd(rb1, rb2, rb3).Equals(bigand))
+}
+

--- a/roaring64/iterables64.go
+++ b/roaring64/iterables64.go
@@ -1,0 +1,167 @@
+package roaring64
+
+import "github.com/RoaringBitmap/roaring"
+
+// IntIterable allows you to iterate over the values in a Bitmap
+type IntIterable64 interface {
+	HasNext() bool
+	Next() uint64
+}
+
+// IntPeekable allows you to look at the next value without advancing and
+// advance as long as the next value is smaller than minval
+type IntPeekable64 interface {
+	IntIterable64
+	// PeekNext peeks the next value without advancing the iterator
+	PeekNext() uint64
+	// AdvanceIfNeeded advances as long as the next value is smaller than minval
+	AdvanceIfNeeded(minval uint64)
+}
+
+type intIterator struct {
+	pos              int
+	hs               uint64
+	iter             roaring.IntPeekable
+	highlowcontainer *roaringArray64
+}
+
+// HasNext returns true if there are more integers to iterate over
+func (ii *intIterator) HasNext() bool {
+	return ii.pos < ii.highlowcontainer.size()
+}
+
+func (ii *intIterator) init() {
+	if ii.highlowcontainer.size() > ii.pos {
+		ii.iter = ii.highlowcontainer.getContainerAtIndex(ii.pos).Iterator()
+		ii.hs = uint64(ii.highlowcontainer.getKeyAtIndex(ii.pos)) << 16
+	}
+}
+
+// Next returns the next integer
+func (ii *intIterator) Next() uint64 {
+	x := uint64(ii.iter.Next()) | ii.hs
+	if !ii.iter.HasNext() {
+		ii.pos = ii.pos + 1
+		ii.init()
+	}
+	return x
+}
+
+// PeekNext peeks the next value without advancing the iterator
+func (ii *intIterator) PeekNext() uint64 {
+	return uint64(ii.iter.PeekNext()&maxLowBit) | ii.hs
+}
+
+// AdvanceIfNeeded advances as long as the next value is smaller than minval
+func (ii *intIterator) AdvanceIfNeeded(minval uint64) {
+	to := minval >> 32
+
+	for ii.HasNext() && (ii.hs>>32) < to {
+		ii.pos++
+		ii.init()
+	}
+
+	if ii.HasNext() && (ii.hs>>32) == to {
+		ii.iter.AdvanceIfNeeded(lowbits(minval))
+
+		if !ii.iter.HasNext() {
+			ii.pos++
+			ii.init()
+		}
+	}
+}
+
+func newIntIterator(a *Bitmap) *intIterator {
+	p := new(intIterator)
+	p.pos = 0
+	p.highlowcontainer = &a.highlowcontainer
+	p.init()
+	return p
+}
+
+type intReverseIterator struct {
+	pos              int
+	hs               uint64
+	iter             roaring.IntIterable
+	highlowcontainer *roaringArray64
+}
+
+// HasNext returns true if there are more integers to iterate over
+func (ii *intReverseIterator) HasNext() bool {
+	return ii.pos >= 0
+}
+
+func (ii *intReverseIterator) init() {
+	if ii.pos >= 0 {
+		ii.iter = ii.highlowcontainer.getContainerAtIndex(ii.pos).ReverseIterator()
+		ii.hs = uint64(ii.highlowcontainer.getKeyAtIndex(ii.pos)) << 32
+	} else {
+		ii.iter = nil
+	}
+}
+
+// Next returns the next integer
+func (ii *intReverseIterator) Next() uint64 {
+	x := uint64(ii.iter.Next()) | ii.hs
+	if !ii.iter.HasNext() {
+		ii.pos = ii.pos - 1
+		ii.init()
+	}
+	return x
+}
+
+func newIntReverseIterator(a *Bitmap) *intReverseIterator {
+	p := new(intReverseIterator)
+	p.highlowcontainer = &a.highlowcontainer
+	p.pos = a.highlowcontainer.size() - 1
+	p.init()
+	return p
+}
+
+// ManyIntIterable allows you to iterate over the values in a Bitmap
+type ManyIntIterable64 interface {
+	// pass in a buffer to fill up with values, returns how many values were returned
+	NextMany([]uint64) int
+}
+
+type manyIntIterator struct {
+	pos              int
+	hs               uint64
+	iter             roaring.ManyIntIterable
+	highlowcontainer *roaringArray64
+}
+
+func (ii *manyIntIterator) init() {
+	if ii.highlowcontainer.size() > ii.pos {
+		ii.iter = ii.highlowcontainer.getContainerAtIndex(ii.pos).ManyIterator()
+		ii.hs = uint64(ii.highlowcontainer.getKeyAtIndex(ii.pos)) << 32
+	} else {
+		ii.iter = nil
+	}
+}
+
+func (ii *manyIntIterator) NextMany(buf []uint64) int {
+	n := 0
+	for n < len(buf) {
+		if ii.iter == nil {
+			break
+		}
+		moreN := ii.iter.NextMany64(ii.hs, buf[n:])
+		n += moreN
+		if moreN == 0 {
+			ii.pos = ii.pos + 1
+			ii.init()
+		}
+	}
+
+	return n
+}
+
+func newManyIntIterator(a *Bitmap) *manyIntIterator {
+	p := new(manyIntIterator)
+	p.pos = 0
+	p.highlowcontainer = &a.highlowcontainer
+	p.init()
+	return p
+}
+

--- a/roaring64/iterables64_test.go
+++ b/roaring64/iterables64_test.go
@@ -1,0 +1,183 @@
+package roaring64
+
+import (
+	"math"
+	"testing"
+
+	"github.com/RoaringBitmap/roaring"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReverseIteratorCount(t *testing.T) {
+	array := []int{2, 63, 64, 65, 4095, 4096, 4097, 4159, 4160, 4161, 5000, 20000, 66666, 140140}
+	for _, testSize := range array {
+		b := New()
+		for i := uint64(0); i < uint64(testSize); i++ {
+			b.Add(i)
+		}
+		it := b.ReverseIterator()
+		count := 0
+		for it.HasNext() {
+			it.Next()
+			count++
+		}
+
+		assert.Equal(t, testSize, count)
+	}
+}
+
+func TestReverseIterator(t *testing.T) {
+	t.Run("#1", func(t *testing.T) {
+		values := []uint64{0, 2, 15, 16, 31, 32, 33, 9999, roaring.MaxUint16, roaring.MaxUint32, roaring.MaxUint32*2, math.MaxUint64}
+		bm := New()
+		for n := 0; n < len(values); n++ {
+			bm.Add(values[n])
+		}
+		i := bm.ReverseIterator()
+		n := len(values) - 1
+
+		for i.HasNext() {
+			assert.EqualValues(t, i.Next(), values[n])
+			n--
+		}
+
+		// HasNext() was terminating early - add test
+		i = bm.ReverseIterator()
+		n = len(values) - 1
+		for ; n >= 0; n-- {
+			assert.EqualValues(t, i.Next(), values[n])
+			assert.False(t, n > 0 && !i.HasNext())
+		}
+	})
+
+	t.Run("#2", func(t *testing.T) {
+		bm := New()
+		i := bm.ReverseIterator()
+
+		assert.False(t, i.HasNext())
+	})
+
+	t.Run("#3", func(t *testing.T) {
+		bm := New()
+		bm.AddInt(0)
+		i := bm.ReverseIterator()
+
+		assert.True(t, i.HasNext())
+		assert.EqualValues(t, 0, i.Next())
+		assert.False(t, i.HasNext())
+	})
+
+	t.Run("#4", func(t *testing.T) {
+		bm := New()
+		bm.AddInt(9999)
+		i := bm.ReverseIterator()
+
+		assert.True(t, i.HasNext())
+		assert.EqualValues(t, 9999, i.Next())
+		assert.False(t, i.HasNext())
+	})
+
+	t.Run("#5", func(t *testing.T) {
+		bm := New()
+		bm.AddInt(roaring.MaxUint16)
+		i := bm.ReverseIterator()
+
+		assert.True(t, i.HasNext())
+		assert.EqualValues(t, roaring.MaxUint16, i.Next())
+		assert.False(t, i.HasNext())
+	})
+
+	t.Run("#6", func(t *testing.T) {
+		bm := New()
+		bm.Add(roaring.MaxUint32)
+		i := bm.ReverseIterator()
+
+		assert.True(t, i.HasNext())
+		assert.EqualValues(t, uint32(roaring.MaxUint32), i.Next())
+		assert.False(t, i.HasNext())
+	})
+}
+
+func TestIteratorPeekNext(t *testing.T) {
+	values := []uint64{0, 2, 15, 16, 31, 32, 33, 9999, roaring.MaxUint16, roaring.MaxUint32, roaring.MaxUint32*2, math.MaxUint64}
+	bm := New()
+
+	for n := 0; n < len(values); n++ {
+		bm.Add(values[n])
+	}
+
+	i := bm.Iterator()
+	assert.True(t, i.HasNext())
+
+	for i.HasNext() {
+		assert.Equal(t, i.PeekNext(), i.Next())
+	}
+}
+
+func TestIteratorAdvance(t *testing.T) {
+	values := []uint64{1, 2, 15, 16, 31, 32, 33, 9999, roaring.MaxUint16}
+	bm := New()
+
+	for n := 0; n < len(values); n++ {
+		bm.Add(values[n])
+	}
+
+	cases := []struct {
+		minval   uint64
+		expected uint64
+	}{
+		{0, 1},
+		{1, 1},
+		{2, 2},
+		{3, 15},
+		{30, 31},
+		{33, 33},
+		{9998, 9999},
+		{roaring.MaxUint16, roaring.MaxUint16},
+	}
+
+	t.Run("advance by using a new int iterator", func(t *testing.T) {
+		for _, c := range cases {
+			i := bm.Iterator()
+			i.AdvanceIfNeeded(c.minval)
+
+			assert.True(t, i.HasNext())
+			assert.Equal(t, c.expected, i.PeekNext())
+		}
+	})
+
+	t.Run("advance by using the same int iterator", func(t *testing.T) {
+		i := bm.Iterator()
+
+		for _, c := range cases {
+			i.AdvanceIfNeeded(c.minval)
+
+			assert.True(t, i.HasNext())
+			assert.Equal(t, c.expected, i.PeekNext())
+		}
+	})
+
+	t.Run("advance out of a container value", func(t *testing.T) {
+		i := bm.Iterator()
+
+		i.AdvanceIfNeeded(roaring.MaxUint32)
+		assert.False(t, i.HasNext())
+
+		i.AdvanceIfNeeded(roaring.MaxUint32)
+		assert.False(t, i.HasNext())
+	})
+
+	t.Run("advance on a value that is less than the pointed value", func(t *testing.T) {
+		i := bm.Iterator()
+		i.AdvanceIfNeeded(29)
+
+		assert.True(t, i.HasNext())
+		assert.EqualValues(t, 31, i.PeekNext())
+
+		i.AdvanceIfNeeded(13)
+
+		assert.True(t, i.HasNext())
+		assert.EqualValues(t, 31, i.PeekNext())
+	})
+}
+

--- a/roaring64/parallel64.go
+++ b/roaring64/parallel64.go
@@ -1,0 +1,291 @@
+package roaring64
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/RoaringBitmap/roaring"
+)
+
+var defaultWorkerCount = runtime.NumCPU()
+
+
+// ParOr computes the union (OR) of all provided bitmaps in parallel,
+// where the parameter "parallelism" determines how many workers are to be used
+// (if it is set to 0, a default number of workers is chosen)
+func ParOr(parallelism int, bitmaps ...*Bitmap) *Bitmap {
+	var lKey uint32 = MaxUint32
+	var hKey uint32
+
+	bitmapsFiltered := bitmaps[:0]
+	for _, b := range bitmaps {
+		if !b.IsEmpty() {
+			bitmapsFiltered = append(bitmapsFiltered, b)
+		}
+	}
+	bitmaps = bitmapsFiltered
+
+	for _, b := range bitmaps {
+		lKey = minOfUint32(lKey, b.highlowcontainer.keys[0])
+		hKey = maxOfUint32(hKey, b.highlowcontainer.keys[b.highlowcontainer.size()-1])
+	}
+
+	if lKey == MaxUint32 && hKey == 0 {
+		return New()
+	} else if len(bitmaps) == 1 {
+		return bitmaps[0]
+	}
+
+	keyRange := hKey - lKey + 1
+	if keyRange == 1 {
+		// revert to FastOr. Since the key range is 0
+		// no container-level aggregation parallelism is achievable
+		return FastOr(bitmaps...)
+	}
+
+	if parallelism == 0 {
+		parallelism = defaultWorkerCount
+	}
+
+	var chunkSize int
+	var chunkCount int
+	if parallelism*4 > int(keyRange) {
+		chunkSize = 1
+		chunkCount = int(keyRange)
+	} else {
+		chunkCount = parallelism * 4
+		chunkSize = (int(keyRange) + chunkCount - 1) / chunkCount
+	}
+
+	if chunkCount*chunkSize < int(keyRange) {
+		// it's fine to panic to indicate an implementation error
+		panic(fmt.Sprintf("invariant check failed: chunkCount * chunkSize < keyRange, %d * %d < %d", chunkCount, chunkSize, keyRange))
+	}
+
+	chunks := make([]*roaringArray64, chunkCount)
+
+	chunkSpecChan := make(chan parChunkSpec, minOfInt(maxOfInt(64, 2*parallelism), int(chunkCount)))
+	chunkChan := make(chan parChunk, minOfInt(32, int(chunkCount)))
+
+	orFunc := func() {
+		for spec := range chunkSpecChan {
+			ra := orOnRange(&bitmaps[0].highlowcontainer, &bitmaps[1].highlowcontainer, spec.start, spec.end)
+			for _, b := range bitmaps[2:] {
+				ra = iorOnRange(ra, &b.highlowcontainer, spec.start, spec.end)
+			}
+
+			chunkChan <- parChunk{ra, spec.idx}
+		}
+	}
+
+	for i := 0; i < parallelism; i++ {
+		go orFunc()
+	}
+
+	go func() {
+		for i := 0; i < chunkCount; i++ {
+			spec := parChunkSpec{
+				start: uint32(int(lKey) + i*chunkSize),
+				end:   uint32(minOfInt(int(lKey)+(i+1)*chunkSize-1, int(hKey))),
+				idx:   int(i),
+			}
+			chunkSpecChan <- spec
+		}
+	}()
+
+	chunksRemaining := chunkCount
+	for chunk := range chunkChan {
+		chunks[chunk.idx] = chunk.ra
+		chunksRemaining--
+		if chunksRemaining == 0 {
+			break
+		}
+	}
+	close(chunkChan)
+	close(chunkSpecChan)
+
+	containerCount := 0
+	for _, chunk := range chunks {
+		containerCount += chunk.size()
+	}
+
+	result := Bitmap{
+		roaringArray64{
+			containers:      make([]*roaring.Bitmap, containerCount),
+			keys:            make([]uint32, containerCount),
+			needCopyOnWrite: make([]bool, containerCount),
+		},
+	}
+
+	resultOffset := 0
+	for _, chunk := range chunks {
+		copy(result.highlowcontainer.containers[resultOffset:], chunk.containers)
+		copy(result.highlowcontainer.keys[resultOffset:], chunk.keys)
+		copy(result.highlowcontainer.needCopyOnWrite[resultOffset:], chunk.needCopyOnWrite)
+		resultOffset += chunk.size()
+	}
+
+	return &result
+}
+
+type parChunkSpec struct {
+	start uint32
+	end   uint32
+	idx   int
+}
+
+type parChunk struct {
+	ra  *roaringArray64
+	idx int
+}
+
+func (c parChunk) size() int {
+	return c.ra.size()
+}
+
+func parNaiveStartAt(ra *roaringArray64, start uint32, last uint32) int {
+	for idx, key := range ra.keys {
+		if key >= start && key <= last {
+			return idx
+		} else if key > last {
+			break
+		}
+	}
+	return ra.size()
+}
+
+func orOnRange(ra1, ra2 *roaringArray64, start, last uint32) *roaringArray64 {
+	answer := &roaringArray64{}
+	length1 := ra1.size()
+	length2 := ra2.size()
+
+	idx1 := parNaiveStartAt(ra1, start, last)
+	idx2 := parNaiveStartAt(ra2, start, last)
+
+	var key1 uint32
+	var key2 uint32
+	if idx1 < length1 && idx2 < length2 {
+		key1 = ra1.getKeyAtIndex(idx1)
+		key2 = ra2.getKeyAtIndex(idx2)
+
+		for key1 <= last && key2 <= last {
+
+			if key1 < key2 {
+				answer.appendCopy(*ra1, idx1)
+				idx1++
+				if idx1 == length1 {
+					break
+				}
+				key1 = ra1.getKeyAtIndex(idx1)
+			} else if key1 > key2 {
+				answer.appendCopy(*ra2, idx2)
+				idx2++
+				if idx2 == length2 {
+					break
+				}
+				key2 = ra2.getKeyAtIndex(idx2)
+			} else {
+				c1 := ra1.getContainerAtIndex(idx1)
+
+				//answer.appendContainer(key1, c1.lazyOR(ra2.getContainerAtIndex(idx2)), false)
+				answer.appendContainer(key1, roaring.Or(c1, ra2.getContainerAtIndex(idx2)), false)
+				idx1++
+				idx2++
+				if idx1 == length1 || idx2 == length2 {
+					break
+				}
+
+				key1 = ra1.getKeyAtIndex(idx1)
+				key2 = ra2.getKeyAtIndex(idx2)
+			}
+		}
+	}
+
+	if idx2 < length2 {
+		key2 = ra2.getKeyAtIndex(idx2)
+		for key2 <= last {
+			answer.appendCopy(*ra2, idx2)
+			idx2++
+			if idx2 == length2 {
+				break
+			}
+			key2 = ra2.getKeyAtIndex(idx2)
+		}
+	}
+
+	if idx1 < length1 {
+		key1 = ra1.getKeyAtIndex(idx1)
+		for key1 <= last {
+			answer.appendCopy(*ra1, idx1)
+			idx1++
+			if idx1 == length1 {
+				break
+			}
+			key1 = ra1.getKeyAtIndex(idx1)
+		}
+	}
+	return answer
+}
+
+func iorOnRange(ra1, ra2 *roaringArray64, start, last uint32) *roaringArray64 {
+	length1 := ra1.size()
+	length2 := ra2.size()
+
+	idx1 := 0
+	idx2 := parNaiveStartAt(ra2, start, last)
+
+	var key1 uint32
+	var key2 uint32
+	if idx1 < length1 && idx2 < length2 {
+		key1 = ra1.getKeyAtIndex(idx1)
+		key2 = ra2.getKeyAtIndex(idx2)
+
+		for key1 <= last && key2 <= last {
+			if key1 < key2 {
+				idx1++
+				if idx1 >= length1 {
+					break
+				}
+				key1 = ra1.getKeyAtIndex(idx1)
+			} else if key1 > key2 {
+				ra1.insertNewKeyValueAt(idx1, key2, ra2.getContainerAtIndex(idx2))
+				ra1.needCopyOnWrite[idx1] = true
+				idx2++
+				idx1++
+				length1++
+				if idx2 >= length2 {
+					break
+				}
+				key2 = ra2.getKeyAtIndex(idx2)
+			} else {
+				c1 := ra1.getWritableContainerAtIndex(idx1)
+
+				//ra1.containers[idx1] = c1.lazyIOR(ra2.getContainerAtIndex(idx2))
+				c1.Or(ra2.getContainerAtIndex(idx2))
+                                ra1.setContainerAtIndex(idx1, c1)
+                   
+				ra1.needCopyOnWrite[idx1] = false
+				idx1++
+				idx2++
+				if idx1 >= length1 || idx2 >= length2 {
+					break
+				}
+
+				key1 = ra1.getKeyAtIndex(idx1)
+				key2 = ra2.getKeyAtIndex(idx2)
+			}
+		}
+	}
+	if idx2 < length2 {
+		key2 = ra2.getKeyAtIndex(idx2)
+		for key2 <= last {
+			ra1.appendCopy(*ra2, idx2)
+			idx2++
+			if idx2 >= length2 {
+				break
+			}
+			key2 = ra2.getKeyAtIndex(idx2)
+		}
+	}
+	return ra1
+}

--- a/roaring64/roaring64.go
+++ b/roaring64/roaring64.go
@@ -281,7 +281,6 @@ func (rb *Bitmap) Add(x uint64) {
 
 // CheckedAdd adds the integer x to the bitmap and return true  if it was added (false if the integer was already present)
 func (rb *Bitmap) CheckedAdd(x uint64) bool {
-	// TODO: add unit tests for this method
 	hb := highbits(x)
 	i := rb.highlowcontainer.getIndex(hb)
 	if i >= 0 {
@@ -290,6 +289,7 @@ func (rb *Bitmap) CheckedAdd(x uint64) bool {
 	}
 	newBitmap := roaring.NewBitmap()
 	newBitmap.Add(lowbits(x))
+	rb.highlowcontainer.insertNewKeyValueAt(-i-1, hb, newBitmap)
 	return true
 }
 

--- a/roaring64/roaring64.go
+++ b/roaring64/roaring64.go
@@ -313,7 +313,6 @@ func (rb *Bitmap) Remove(x uint64) {
 
 // CheckedRemove removes the integer x from the bitmap and return true if the integer was effectively remove (and false if the integer was not present)
 func (rb *Bitmap) CheckedRemove(x uint64) bool {
-	// TODO: add unit tests for this method
 	hb := highbits(x)
 	i := rb.highlowcontainer.getIndex(hb)
 	if i >= 0 {

--- a/roaring64/roaring64.go
+++ b/roaring64/roaring64.go
@@ -936,7 +936,7 @@ func (rb *Bitmap) AddMany(dat []uint64) {
 func (rb *Bitmap) getOrCreateContainer(hb uint32) *roaring.Bitmap {
 	i := rb.highlowcontainer.getIndex(hb)
 	if i >= 0 {
-		return rb.highlowcontainer.getContainerAtIndex(i)
+		return rb.highlowcontainer.getWritableContainerAtIndex(i)
 	}
 	c := roaring.NewBitmap()
 	rb.highlowcontainer.insertNewKeyValueAt(-i-1, hb, c)

--- a/roaring64/roaring64.go
+++ b/roaring64/roaring64.go
@@ -2,7 +2,10 @@ package roaring64
 
 import (
 	"bytes"
+	"encoding/binary"
+	"encoding/base64"
 	"fmt"
+	"io"
 	"strconv"
 
 	"github.com/RoaringBitmap/roaring"
@@ -11,6 +14,120 @@ import (
 // Bitmap represents a compressed bitmap where you can add integers.
 type Bitmap struct {
 	highlowcontainer roaringArray64
+}
+
+// ToBase64 serializes a bitmap as Base64
+func (rb *Bitmap) ToBase64() (string, error) {
+        buf := new(bytes.Buffer)
+        _, err := rb.WriteTo(buf)
+        return base64.StdEncoding.EncodeToString(buf.Bytes()), err
+
+}
+
+// FromBase64 deserializes a bitmap from Base64
+func (rb *Bitmap) FromBase64(str string) (int64, error) {
+        data, err := base64.StdEncoding.DecodeString(str)
+        if err != nil {
+                return 0, err
+        }
+        buf := bytes.NewBuffer(data)
+
+        return rb.ReadFrom(buf)
+}
+
+func (rb *Bitmap) ToBytes() ([]byte, error) {
+        var buf bytes.Buffer
+        _, err := rb.WriteTo(&buf)
+        return buf.Bytes(), err
+}
+
+func (rb *Bitmap) WriteTo(stream io.Writer) (int64, error) {
+    
+    var n int64
+	buf := make([]byte, 8)
+	binary.LittleEndian.PutUint64(buf, uint64(rb.highlowcontainer.size()))
+    written, err := stream.Write(buf)
+    if err != nil {
+        return n, err
+    }
+    n += int64(written)
+	pos := 0
+    keyBuf := make([]byte, 4)
+	for pos < rb.highlowcontainer.size() {
+		c := rb.highlowcontainer.getContainerAtIndex(pos)
+		binary.LittleEndian.PutUint32(keyBuf, rb.highlowcontainer.getKeyAtIndex(pos))
+		pos++
+    	written, err = stream.Write(keyBuf)
+    	n += int64(written)
+    	if err != nil {
+        	return n, err
+    	}
+    	written, err := c.WriteTo(stream)
+    	n += int64(written)
+    	if err != nil {
+        	return n, err
+    	}
+	}
+    return n, nil
+}
+
+// ReadFrom reads a serialized version of this bitmap from stream.
+// The format is compatible with other RoaringBitmap
+// implementations (Java, C) and is documented here:
+// https://github.com/RoaringBitmap/RoaringFormatSpec
+func (rb *Bitmap) ReadFrom(stream io.Reader) (p int64, err error) {
+
+    // TODO: Add buffer interning as in base roaring package.
+
+    sizeBuf := make([]byte, 8)
+    var n int
+    n, err = stream.Read(sizeBuf)
+    if n == 0 || err != nil {
+        return int64(n), fmt.Errorf("error in bitmap.readFrom: could not read number of containers: %s", err)
+    }
+    p += int64(n)
+	size := binary.LittleEndian.Uint64(sizeBuf)
+    rb.highlowcontainer = roaringArray64{}
+	rb.highlowcontainer.keys = make([]uint32, size)
+	rb.highlowcontainer.containers = make([]*roaring.Bitmap, size)
+	rb.highlowcontainer.needCopyOnWrite = make([]bool, size)
+    keyBuf := make([]byte, 4)
+    for i := uint64(0); i < size; i++ {
+    	n, err = stream.Read(keyBuf)
+    	if n == 0 || err != nil {
+        	return int64(n), fmt.Errorf("error in bitmap.readFrom: could not read key #%d: %s", i, err)
+    	}
+    	p += int64(n)
+		rb.highlowcontainer.keys[i] = binary.LittleEndian.Uint32(keyBuf)
+        rb.highlowcontainer.containers[i] = roaring.NewBitmap()       
+        n, err := rb.highlowcontainer.containers[i].ReadFrom(stream)
+    	if n == 0 || err != nil {
+        	return int64(n), fmt.Errorf("Could not deserialize bitmap for key #%d: %s", i, err)
+    	}
+    	p += int64(n)
+    }
+
+    return p, nil
+}
+
+func (rb *Bitmap) FromBuffer(data []byte) (p int64, err error) {
+
+    // TODO: Add buffer interning as in base roaring package.
+    buf := bytes.NewBuffer(data)
+    return rb.ReadFrom(buf)
+}
+
+// MarshalBinary implements the encoding.BinaryMarshaler interface for the bitmap
+// (same as ToBytes)
+func (rb *Bitmap) MarshalBinary() ([]byte, error) {
+        return rb.ToBytes()
+}
+
+// UnmarshalBinary implements the encoding.BinaryUnmarshaler interface for the bitmap
+func (rb *Bitmap) UnmarshalBinary(data []byte) error {
+        r := bytes.NewReader(data)
+        _, err := rb.ReadFrom(r)
+        return err
 }
 
 // RunOptimize attempts to further compress the runs of consecutive values found in the bitmap

--- a/roaring64/roaring64.go
+++ b/roaring64/roaring64.go
@@ -846,7 +846,7 @@ func (rb *Bitmap) Flip(rangeStart, rangeEnd uint64) {
 	hbLast := uint64(highbits(rangeEnd))
 	lbLast := uint64(lowbits(rangeEnd))
 
-	var max uint64 = maxLowBit
+	var max uint64 = maxLowBit+1
 	for hb := hbStart; hb <= hbLast; hb++ {
 		var containerStart uint64
 		if hb == hbStart {
@@ -868,7 +868,9 @@ func (rb *Bitmap) Flip(rangeStart, rangeEnd uint64) {
 		} else { // *think* the range of ones must never be empty.
 			c := roaring.NewBitmap()
 			c.Flip(containerStart, containerLast)
-			rb.highlowcontainer.insertNewKeyValueAt(-i-1, uint32(hb), c)
+			if !c.IsEmpty() {
+				rb.highlowcontainer.insertNewKeyValueAt(-i-1, uint32(hb), c)
+			}
 		}
 	}
 }
@@ -974,7 +976,7 @@ func Flip(rb *Bitmap, rangeStart, rangeEnd uint64) *Bitmap {
 	// copy the containers before the active area
 	answer.highlowcontainer.appendCopiesUntil(rb.highlowcontainer, uint32(hbStart))
 
-	var max uint64 = maxLowBit
+	var max uint64 = maxLowBit+1
 	for hb := hbStart; hb <= hbLast; hb++ {
 		var containerStart uint64
 		if hb == hbStart {
@@ -997,7 +999,9 @@ func Flip(rb *Bitmap, rangeStart, rangeEnd uint64) *Bitmap {
 		} else { // *think* the range of ones must never be empty.
 			c := roaring.NewBitmap()
 			c.Flip(containerStart, containerLast)
-			answer.highlowcontainer.insertNewKeyValueAt(-i-1, uint32(hb), c)
+			if !c.IsEmpty() {
+				answer.highlowcontainer.insertNewKeyValueAt(-i-1, uint32(hb), c)
+			}
 		}
 	}
 	// copy the containers after the active area.

--- a/roaring64/roaring64.go
+++ b/roaring64/roaring64.go
@@ -1,0 +1,1060 @@
+package roaring64
+
+import (
+	"bytes"
+	"fmt"
+	"strconv"
+
+	"github.com/RoaringBitmap/roaring"
+)
+
+// Bitmap represents a compressed bitmap where you can add integers.
+type Bitmap struct {
+	highlowcontainer roaringArray64
+}
+
+// RunOptimize attempts to further compress the runs of consecutive values found in the bitmap
+func (rb *Bitmap) RunOptimize() {
+	rb.highlowcontainer.runOptimize()
+}
+
+// HasRunCompression returns true if the bitmap benefits from run compression
+func (rb *Bitmap) HasRunCompression() bool {
+	return rb.highlowcontainer.hasRunCompression()
+}
+
+// NewBitmap creates a new empty Bitmap (see also New)
+func NewBitmap() *Bitmap {
+	return &Bitmap{}
+}
+
+// New creates a new empty Bitmap (same as NewBitmap)
+func New() *Bitmap {
+	return &Bitmap{}
+}
+
+// Clear resets the Bitmap to be logically empty, but may retain
+// some memory allocations that may speed up future operations
+func (rb *Bitmap) Clear() {
+	rb.highlowcontainer.clear()
+}
+
+// ToArray creates a new slice containing all of the integers stored in the Bitmap in sorted order
+func (rb *Bitmap) ToArray() []uint64 {
+	array := make([]uint64, rb.GetCardinality())
+	pos := 0
+	pos2 := uint64(0)
+
+	for pos < rb.highlowcontainer.size() {
+		hs := uint64(rb.highlowcontainer.getKeyAtIndex(pos)) << 32
+		c := rb.highlowcontainer.getContainerAtIndex(pos)
+		pos++
+		c.FillLeastSignificant32bits(array, pos2, hs)
+		pos2 += c.GetCardinality()
+	}
+	return array
+}
+
+// GetSizeInBytes estimates the memory usage of the Bitmap. Note that this
+// might differ slightly from the amount of bytes required for persistent storage
+func (rb *Bitmap) GetSizeInBytes() uint64 {
+	size := uint64(8)
+	for _, c := range rb.highlowcontainer.containers {
+		size += uint64(2) + c.GetSizeInBytes()
+	}
+	return size
+}
+
+// String creates a string representation of the Bitmap
+func (rb *Bitmap) String() string {
+	// inspired by https://github.com/fzandona/goroar/
+	var buffer bytes.Buffer
+	start := []byte("{")
+	buffer.Write(start)
+	i := rb.Iterator()
+	counter := 0
+	if i.HasNext() {
+		counter = counter + 1
+		buffer.WriteString(strconv.FormatInt(int64(i.Next()), 10))
+	}
+	for i.HasNext() {
+		buffer.WriteString(",")
+		counter = counter + 1
+		// to avoid exhausting the memory
+		if counter > 0x40000 {
+			buffer.WriteString("...")
+			break
+		}
+		buffer.WriteString(strconv.FormatInt(int64(i.Next()), 10))
+	}
+	buffer.WriteString("}")
+	return buffer.String()
+}
+
+// Iterator creates a new IntPeekable to iterate over the integers contained in the bitmap, in sorted order;
+// the iterator becomes invalid if the bitmap is modified (e.g., with Add or Remove).
+func (rb *Bitmap) Iterator() IntPeekable64 {
+	return newIntIterator(rb)
+}
+
+// ReverseIterator creates a new IntIterable to iterate over the integers contained in the bitmap, in sorted order;
+// the iterator becomes invalid if the bitmap is modified (e.g., with Add or Remove).
+func (rb *Bitmap) ReverseIterator() IntIterable64 {
+	return newIntReverseIterator(rb)
+}
+
+// ManyIterator creates a new ManyIntIterable to iterate over the integers contained in the bitmap, in sorted order;
+// the iterator becomes invalid if the bitmap is modified (e.g., with Add or Remove).
+func (rb *Bitmap) ManyIterator() ManyIntIterable64 {
+	return newManyIntIterator(rb)
+}
+
+// Clone creates a copy of the Bitmap
+func (rb *Bitmap) Clone() *Bitmap {
+	ptr := new(Bitmap)
+	ptr.highlowcontainer = *rb.highlowcontainer.clone()
+	return ptr
+}
+
+// Minimum get the smallest value stored in this roaring bitmap, assumes that it is not empty
+func (rb *Bitmap) Minimum() uint64 {
+	return uint64(rb.highlowcontainer.containers[0].Minimum()) | (uint64(rb.highlowcontainer.keys[0]) << 32)
+}
+
+// Maximum get the largest value stored in this roaring bitmap, assumes that it is not empty
+func (rb *Bitmap) Maximum() uint64 {
+	lastindex := len(rb.highlowcontainer.containers) - 1
+	return uint64(rb.highlowcontainer.containers[lastindex].Maximum()) | (uint64(rb.highlowcontainer.keys[lastindex]) << 32)
+}
+
+// Contains returns true if the integer is contained in the bitmap
+func (rb *Bitmap) Contains(x uint64) bool {
+	hb := highbits(x)
+	c := rb.highlowcontainer.getContainer(hb)
+	return c != nil && c.Contains(lowbits(x))
+}
+
+// ContainsInt returns true if the integer is contained in the bitmap (this is a convenience method, the parameter is casted to uint64 and Contains is called)
+func (rb *Bitmap) ContainsInt(x int) bool {
+	return rb.Contains(uint64(x))
+}
+
+// Equals returns true if the two bitmaps contain the same integers
+func (rb *Bitmap) Equals(o interface{}) bool {
+	srb, ok := o.(*Bitmap)
+	if ok {
+		return srb.highlowcontainer.equals(rb.highlowcontainer)
+	}
+	return false
+}
+
+// Add the integer x to the bitmap
+func (rb *Bitmap) Add(x uint64) {
+	hb := highbits(x)
+	ra := &rb.highlowcontainer
+	i := ra.getIndex(hb)
+	if i >= 0 {
+		ra.getWritableContainerAtIndex(i).Add(lowbits(x))
+	} else {
+		newBitmap := roaring.NewBitmap()
+		newBitmap.Add(lowbits(x))
+		rb.highlowcontainer.insertNewKeyValueAt(-i-1, hb, newBitmap)
+	}
+}
+
+// CheckedAdd adds the integer x to the bitmap and return true  if it was added (false if the integer was already present)
+func (rb *Bitmap) CheckedAdd(x uint64) bool {
+	// TODO: add unit tests for this method
+	hb := highbits(x)
+	i := rb.highlowcontainer.getIndex(hb)
+	if i >= 0 {
+		c := rb.highlowcontainer.getWritableContainerAtIndex(i)
+		return c.CheckedAdd(lowbits(x))
+	}
+	newBitmap := roaring.NewBitmap()
+	newBitmap.Add(lowbits(x))
+	return true
+}
+
+// AddInt adds the integer x to the bitmap (convenience method: the parameter is casted to uint32 and we call Add)
+func (rb *Bitmap) AddInt(x int) {
+	rb.Add(uint64(x))
+}
+
+// Remove the integer x from the bitmap
+func (rb *Bitmap) Remove(x uint64) {
+	hb := highbits(x)
+	i := rb.highlowcontainer.getIndex(hb)
+	if i >= 0 {
+		c := rb.highlowcontainer.getWritableContainerAtIndex(i)
+		c.Remove(lowbits(x))
+		if c.IsEmpty() {
+			rb.highlowcontainer.removeAtIndex(i)
+		}
+	}
+}
+
+// CheckedRemove removes the integer x from the bitmap and return true if the integer was effectively remove (and false if the integer was not present)
+func (rb *Bitmap) CheckedRemove(x uint64) bool {
+	// TODO: add unit tests for this method
+	hb := highbits(x)
+	i := rb.highlowcontainer.getIndex(hb)
+	if i >= 0 {
+		c := rb.highlowcontainer.getWritableContainerAtIndex(i)
+		removed := c.CheckedRemove(lowbits(x))
+		if removed && c.IsEmpty() {
+			rb.highlowcontainer.removeAtIndex(i)
+		}
+		return removed
+	}
+	return false
+}
+
+// IsEmpty returns true if the Bitmap is empty (it is faster than doing (GetCardinality() == 0))
+func (rb *Bitmap) IsEmpty() bool {
+	return rb.highlowcontainer.size() == 0
+}
+
+// GetCardinality returns the number of integers contained in the bitmap
+func (rb *Bitmap) GetCardinality() uint64 {
+	size := uint64(0)
+	for _, c := range rb.highlowcontainer.containers {
+		size += c.GetCardinality()
+	}
+	return size
+}
+
+// Rank returns the number of integers that are smaller or equal to x (Rank(infinity) would be GetCardinality())
+func (rb *Bitmap) Rank(x uint64) uint64 {
+	size := uint64(0)
+	for i := 0; i < rb.highlowcontainer.size(); i++ {
+		key := rb.highlowcontainer.getKeyAtIndex(i)
+		if key > highbits(x) {
+			return size
+		}
+		if key < highbits(x) {
+			size += rb.highlowcontainer.getContainerAtIndex(i).GetCardinality()
+		} else {
+			return size + rb.highlowcontainer.getContainerAtIndex(i).Rank(lowbits(x))
+		}
+	}
+	return size
+}
+
+// Select returns the xth integer in the bitmap
+func (rb *Bitmap) Select(x uint64) (uint64, error) {
+	cardinality := rb.GetCardinality()
+	if cardinality <= x {
+		return 0, fmt.Errorf("can't find %dth integer in a bitmap with only %d items", x, cardinality)
+	}
+
+	remaining := x
+	for i := 0; i < rb.highlowcontainer.size(); i++ {
+		c := rb.highlowcontainer.getContainerAtIndex(i)
+		if bitmapSize := c.GetCardinality(); remaining >= bitmapSize {
+			remaining -= bitmapSize
+		} else {
+			key := rb.highlowcontainer.getKeyAtIndex(i)
+			selected, err := c.Select(uint32(remaining))
+			if err != nil {
+				return 0, err
+			}
+			return uint64(key)<<32 + uint64(selected), nil
+		}
+	}
+	return 0, fmt.Errorf("can't find %dth integer in a bitmap with only %d items", x, cardinality)
+}
+
+// And computes the intersection between two bitmaps and stores the result in the current bitmap
+func (rb *Bitmap) And(x2 *Bitmap) {
+	pos1 := 0
+	pos2 := 0
+	intersectionsize := 0
+	length1 := rb.highlowcontainer.size()
+	length2 := x2.highlowcontainer.size()
+
+main:
+	for {
+		if pos1 < length1 && pos2 < length2 {
+			s1 := rb.highlowcontainer.getKeyAtIndex(pos1)
+			s2 := x2.highlowcontainer.getKeyAtIndex(pos2)
+			for {
+				if s1 == s2 {
+					c1 := rb.highlowcontainer.getWritableContainerAtIndex(pos1)
+					c2 := x2.highlowcontainer.getContainerAtIndex(pos2)
+					c1.And(c2)
+					if !c1.IsEmpty() {
+						rb.highlowcontainer.replaceKeyAndContainerAtIndex(intersectionsize, s1, c1, false)
+						intersectionsize++
+					}
+					pos1++
+					pos2++
+					if (pos1 == length1) || (pos2 == length2) {
+						break main
+					}
+					s1 = rb.highlowcontainer.getKeyAtIndex(pos1)
+					s2 = x2.highlowcontainer.getKeyAtIndex(pos2)
+				} else if s1 < s2 {
+					pos1 = rb.highlowcontainer.advanceUntil(s2, pos1)
+					if pos1 == length1 {
+						break main
+					}
+					s1 = rb.highlowcontainer.getKeyAtIndex(pos1)
+				} else { // s1 > s2
+					pos2 = x2.highlowcontainer.advanceUntil(s1, pos2)
+					if pos2 == length2 {
+						break main
+					}
+					s2 = x2.highlowcontainer.getKeyAtIndex(pos2)
+				}
+			}
+		} else {
+			break
+		}
+	}
+	rb.highlowcontainer.resize(intersectionsize)
+}
+
+// OrCardinality returns the cardinality of the union between two bitmaps, bitmaps are not modified
+func (rb *Bitmap) OrCardinality(x2 *Bitmap) uint64 {
+	pos1 := 0
+	pos2 := 0
+	length1 := rb.highlowcontainer.size()
+	length2 := x2.highlowcontainer.size()
+	answer := uint64(0)
+main:
+	for {
+		if (pos1 < length1) && (pos2 < length2) {
+			s1 := rb.highlowcontainer.getKeyAtIndex(pos1)
+			s2 := x2.highlowcontainer.getKeyAtIndex(pos2)
+
+			for {
+				if s1 < s2 {
+					answer += rb.highlowcontainer.getContainerAtIndex(pos1).GetCardinality()
+					pos1++
+					if pos1 == length1 {
+						break main
+					}
+					s1 = rb.highlowcontainer.getKeyAtIndex(pos1)
+				} else if s1 > s2 {
+					answer += x2.highlowcontainer.getContainerAtIndex(pos2).GetCardinality()
+					pos2++
+					if pos2 == length2 {
+						break main
+					}
+					s2 = x2.highlowcontainer.getKeyAtIndex(pos2)
+				} else {
+					// TODO: could be faster if we did not have to materialize the container
+					answer += roaring.Or(rb.highlowcontainer.getContainerAtIndex(pos1), x2.highlowcontainer.getContainerAtIndex(pos2)).GetCardinality()
+					pos1++
+					pos2++
+					if (pos1 == length1) || (pos2 == length2) {
+						break main
+					}
+					s1 = rb.highlowcontainer.getKeyAtIndex(pos1)
+					s2 = x2.highlowcontainer.getKeyAtIndex(pos2)
+				}
+			}
+		} else {
+			break
+		}
+	}
+	for ; pos1 < length1; pos1++ {
+		answer += rb.highlowcontainer.getContainerAtIndex(pos1).GetCardinality()
+	}
+	for ; pos2 < length2; pos2++ {
+		answer += x2.highlowcontainer.getContainerAtIndex(pos2).GetCardinality()
+	}
+	return answer
+}
+
+// AndCardinality returns the cardinality of the intersection between two bitmaps, bitmaps are not modified
+func (rb *Bitmap) AndCardinality(x2 *Bitmap) uint64 {
+	pos1 := 0
+	pos2 := 0
+	answer := uint64(0)
+	length1 := rb.highlowcontainer.size()
+	length2 := x2.highlowcontainer.size()
+
+main:
+	for {
+		if pos1 < length1 && pos2 < length2 {
+			s1 := rb.highlowcontainer.getKeyAtIndex(pos1)
+			s2 := x2.highlowcontainer.getKeyAtIndex(pos2)
+			for {
+				if s1 == s2 {
+					c1 := rb.highlowcontainer.getContainerAtIndex(pos1)
+					c2 := x2.highlowcontainer.getContainerAtIndex(pos2)
+					answer += c1.AndCardinality(c2)
+					pos1++
+					pos2++
+					if (pos1 == length1) || (pos2 == length2) {
+						break main
+					}
+					s1 = rb.highlowcontainer.getKeyAtIndex(pos1)
+					s2 = x2.highlowcontainer.getKeyAtIndex(pos2)
+				} else if s1 < s2 {
+					pos1 = rb.highlowcontainer.advanceUntil(s2, pos1)
+					if pos1 == length1 {
+						break main
+					}
+					s1 = rb.highlowcontainer.getKeyAtIndex(pos1)
+				} else { // s1 > s2
+					pos2 = x2.highlowcontainer.advanceUntil(s1, pos2)
+					if pos2 == length2 {
+						break main
+					}
+					s2 = x2.highlowcontainer.getKeyAtIndex(pos2)
+				}
+			}
+		} else {
+			break
+		}
+	}
+	return answer
+}
+
+// Intersects checks whether two bitmap intersects, bitmaps are not modified
+func (rb *Bitmap) Intersects(x2 *Bitmap) bool {
+	pos1 := 0
+	pos2 := 0
+	length1 := rb.highlowcontainer.size()
+	length2 := x2.highlowcontainer.size()
+
+main:
+	for {
+		if pos1 < length1 && pos2 < length2 {
+			s1 := rb.highlowcontainer.getKeyAtIndex(pos1)
+			s2 := x2.highlowcontainer.getKeyAtIndex(pos2)
+			for {
+				if s1 == s2 {
+					c1 := rb.highlowcontainer.getContainerAtIndex(pos1)
+					c2 := x2.highlowcontainer.getContainerAtIndex(pos2)
+					if c1.Intersects(c2) {
+						return true
+					}
+					pos1++
+					pos2++
+					if (pos1 == length1) || (pos2 == length2) {
+						break main
+					}
+					s1 = rb.highlowcontainer.getKeyAtIndex(pos1)
+					s2 = x2.highlowcontainer.getKeyAtIndex(pos2)
+				} else if s1 < s2 {
+					pos1 = rb.highlowcontainer.advanceUntil(s2, pos1)
+					if pos1 == length1 {
+						break main
+					}
+					s1 = rb.highlowcontainer.getKeyAtIndex(pos1)
+				} else { // s1 > s2
+					pos2 = x2.highlowcontainer.advanceUntil(s1, pos2)
+					if pos2 == length2 {
+						break main
+					}
+					s2 = x2.highlowcontainer.getKeyAtIndex(pos2)
+				}
+			}
+		} else {
+			break
+		}
+	}
+	return false
+}
+
+// Xor computes the symmetric difference between two bitmaps and stores the result in the current bitmap
+func (rb *Bitmap) Xor(x2 *Bitmap) {
+	pos1 := 0
+	pos2 := 0
+	length1 := rb.highlowcontainer.size()
+	length2 := x2.highlowcontainer.size()
+	for {
+		if (pos1 < length1) && (pos2 < length2) {
+			s1 := rb.highlowcontainer.getKeyAtIndex(pos1)
+			s2 := x2.highlowcontainer.getKeyAtIndex(pos2)
+			if s1 < s2 {
+				pos1 = rb.highlowcontainer.advanceUntil(s2, pos1)
+				if pos1 == length1 {
+					break
+				}
+			} else if s1 > s2 {
+				c := x2.highlowcontainer.getWritableContainerAtIndex(pos2)
+				rb.highlowcontainer.insertNewKeyValueAt(pos1, x2.highlowcontainer.getKeyAtIndex(pos2), c)
+				length1++
+				pos1++
+				pos2++
+			} else {
+				// TODO: couple be computed in-place for reduced memory usage
+				c := roaring.Xor(rb.highlowcontainer.getContainerAtIndex(pos1), x2.highlowcontainer.getContainerAtIndex(pos2))
+				if !c.IsEmpty() {
+					rb.highlowcontainer.setContainerAtIndex(pos1, c)
+					pos1++
+				} else {
+					rb.highlowcontainer.removeAtIndex(pos1)
+					length1--
+				}
+				pos2++
+			}
+		} else {
+			break
+		}
+	}
+	if pos1 == length1 {
+		rb.highlowcontainer.appendCopyMany(x2.highlowcontainer, pos2, length2)
+	}
+}
+
+// Or computes the union between two bitmaps and stores the result in the current bitmap
+func (rb *Bitmap) Or(x2 *Bitmap) {
+	pos1 := 0
+	pos2 := 0
+	length1 := rb.highlowcontainer.size()
+	length2 := x2.highlowcontainer.size()
+main:
+	for (pos1 < length1) && (pos2 < length2) {
+		s1 := rb.highlowcontainer.getKeyAtIndex(pos1)
+		s2 := x2.highlowcontainer.getKeyAtIndex(pos2)
+
+		for {
+			if s1 < s2 {
+				pos1++
+				if pos1 == length1 {
+					break main
+				}
+				s1 = rb.highlowcontainer.getKeyAtIndex(pos1)
+			} else if s1 > s2 {
+				rb.highlowcontainer.insertNewKeyValueAt(pos1, s2, x2.highlowcontainer.getContainerAtIndex(pos2).Clone())
+				pos1++
+				length1++
+				pos2++
+				if pos2 == length2 {
+					break main
+				}
+				s2 = x2.highlowcontainer.getKeyAtIndex(pos2)
+			} else {
+				rb.highlowcontainer.getContainerAtIndex(pos1).Or(x2.highlowcontainer.getContainerAtIndex(pos2))
+				pos1++
+				pos2++
+				if (pos1 == length1) || (pos2 == length2) {
+					break main
+				}
+				s1 = rb.highlowcontainer.getKeyAtIndex(pos1)
+				s2 = x2.highlowcontainer.getKeyAtIndex(pos2)
+			}
+		}
+	}
+	if pos1 == length1 {
+		rb.highlowcontainer.appendCopyMany(x2.highlowcontainer, pos2, length2)
+	}
+}
+
+// AndNot computes the difference between two bitmaps and stores the result in the current bitmap
+func (rb *Bitmap) AndNot(x2 *Bitmap) {
+	pos1 := 0
+	pos2 := 0
+	intersectionsize := 0
+	length1 := rb.highlowcontainer.size()
+	length2 := x2.highlowcontainer.size()
+
+main:
+	for {
+		if pos1 < length1 && pos2 < length2 {
+			s1 := rb.highlowcontainer.getKeyAtIndex(pos1)
+			s2 := x2.highlowcontainer.getKeyAtIndex(pos2)
+			for {
+				if s1 == s2 {
+					c1 := rb.highlowcontainer.getWritableContainerAtIndex(pos1)
+					c2 := x2.highlowcontainer.getContainerAtIndex(pos2)
+					c1.AndNot(c2)
+					if !c1.IsEmpty() {
+						rb.highlowcontainer.replaceKeyAndContainerAtIndex(intersectionsize, s1, c1, false)
+						intersectionsize++
+					}
+					pos1++
+					pos2++
+					if (pos1 == length1) || (pos2 == length2) {
+						break main
+					}
+					s1 = rb.highlowcontainer.getKeyAtIndex(pos1)
+					s2 = x2.highlowcontainer.getKeyAtIndex(pos2)
+				} else if s1 < s2 {
+					c1 := rb.highlowcontainer.getContainerAtIndex(pos1)
+					mustCopyOnWrite := rb.highlowcontainer.needsCopyOnWrite(pos1)
+					rb.highlowcontainer.replaceKeyAndContainerAtIndex(intersectionsize, s1, c1, mustCopyOnWrite)
+					intersectionsize++
+					pos1++
+					if pos1 == length1 {
+						break main
+					}
+					s1 = rb.highlowcontainer.getKeyAtIndex(pos1)
+				} else { // s1 > s2
+					pos2 = x2.highlowcontainer.advanceUntil(s1, pos2)
+					if pos2 == length2 {
+						break main
+					}
+					s2 = x2.highlowcontainer.getKeyAtIndex(pos2)
+				}
+			}
+		} else {
+			break
+		}
+	}
+	// TODO:implement as a copy
+	for pos1 < length1 {
+		c1 := rb.highlowcontainer.getContainerAtIndex(pos1)
+		s1 := rb.highlowcontainer.getKeyAtIndex(pos1)
+		mustCopyOnWrite := rb.highlowcontainer.needsCopyOnWrite(pos1)
+		rb.highlowcontainer.replaceKeyAndContainerAtIndex(intersectionsize, s1, c1, mustCopyOnWrite)
+		intersectionsize++
+		pos1++
+	}
+	rb.highlowcontainer.resize(intersectionsize)
+}
+
+// Or computes the union between two bitmaps and returns the result
+func Or(x1, x2 *Bitmap) *Bitmap {
+	answer := NewBitmap()
+	pos1 := 0
+	pos2 := 0
+	length1 := x1.highlowcontainer.size()
+	length2 := x2.highlowcontainer.size()
+main:
+	for (pos1 < length1) && (pos2 < length2) {
+		s1 := x1.highlowcontainer.getKeyAtIndex(pos1)
+		s2 := x2.highlowcontainer.getKeyAtIndex(pos2)
+
+		for {
+			if s1 < s2 {
+				answer.highlowcontainer.appendCopy(x1.highlowcontainer, pos1)
+				pos1++
+				if pos1 == length1 {
+					break main
+				}
+				s1 = x1.highlowcontainer.getKeyAtIndex(pos1)
+			} else if s1 > s2 {
+				answer.highlowcontainer.appendCopy(x2.highlowcontainer, pos2)
+				pos2++
+				if pos2 == length2 {
+					break main
+				}
+				s2 = x2.highlowcontainer.getKeyAtIndex(pos2)
+			} else {
+				answer.highlowcontainer.appendContainer(s1,
+					roaring.Or(x1.highlowcontainer.getContainerAtIndex(pos1), x2.highlowcontainer.getContainerAtIndex(pos2)), false)
+				pos1++
+				pos2++
+				if (pos1 == length1) || (pos2 == length2) {
+					break main
+				}
+				s1 = x1.highlowcontainer.getKeyAtIndex(pos1)
+				s2 = x2.highlowcontainer.getKeyAtIndex(pos2)
+			}
+		}
+	}
+	if pos1 == length1 {
+		answer.highlowcontainer.appendCopyMany(x2.highlowcontainer, pos2, length2)
+	} else if pos2 == length2 {
+		answer.highlowcontainer.appendCopyMany(x1.highlowcontainer, pos1, length1)
+	}
+	return answer
+}
+
+// And computes the intersection between two bitmaps and returns the result
+func And(x1, x2 *Bitmap) *Bitmap {
+	answer := NewBitmap()
+	pos1 := 0
+	pos2 := 0
+	length1 := x1.highlowcontainer.size()
+	length2 := x2.highlowcontainer.size()
+main:
+	for pos1 < length1 && pos2 < length2 {
+		s1 := x1.highlowcontainer.getKeyAtIndex(pos1)
+		s2 := x2.highlowcontainer.getKeyAtIndex(pos2)
+		for {
+			if s1 == s2 {
+				c := roaring.And(x1.highlowcontainer.getContainerAtIndex(pos1), x2.highlowcontainer.getContainerAtIndex(pos2))
+				if !c.IsEmpty() {
+					answer.highlowcontainer.appendContainer(s1, c, false)
+				}
+				pos1++
+				pos2++
+				if (pos1 == length1) || (pos2 == length2) {
+					break main
+				}
+				s1 = x1.highlowcontainer.getKeyAtIndex(pos1)
+				s2 = x2.highlowcontainer.getKeyAtIndex(pos2)
+			} else if s1 < s2 {
+				pos1 = x1.highlowcontainer.advanceUntil(s2, pos1)
+				if pos1 == length1 {
+					break main
+				}
+				s1 = x1.highlowcontainer.getKeyAtIndex(pos1)
+			} else { // s1 > s2
+				pos2 = x2.highlowcontainer.advanceUntil(s1, pos2)
+				if pos2 == length2 {
+					break main
+				}
+				s2 = x2.highlowcontainer.getKeyAtIndex(pos2)
+			}
+		}
+	}
+	return answer
+}
+
+// Xor computes the symmetric difference between two bitmaps and returns the result
+func Xor(x1, x2 *Bitmap) *Bitmap {
+	answer := NewBitmap()
+	pos1 := 0
+	pos2 := 0
+	length1 := x1.highlowcontainer.size()
+	length2 := x2.highlowcontainer.size()
+	for {
+		if (pos1 < length1) && (pos2 < length2) {
+			s1 := x1.highlowcontainer.getKeyAtIndex(pos1)
+			s2 := x2.highlowcontainer.getKeyAtIndex(pos2)
+			if s1 < s2 {
+				answer.highlowcontainer.appendCopy(x1.highlowcontainer, pos1)
+				pos1++
+			} else if s1 > s2 {
+				answer.highlowcontainer.appendCopy(x2.highlowcontainer, pos2)
+				pos2++
+			} else {
+				c := roaring.Xor(x1.highlowcontainer.getContainerAtIndex(pos1), x2.highlowcontainer.getContainerAtIndex(pos2))
+				if !c.IsEmpty() {
+					answer.highlowcontainer.appendContainer(s1, c, false)
+				}
+				pos1++
+				pos2++
+			}
+		} else {
+			break
+		}
+	}
+	if pos1 == length1 {
+		answer.highlowcontainer.appendCopyMany(x2.highlowcontainer, pos2, length2)
+	} else if pos2 == length2 {
+		answer.highlowcontainer.appendCopyMany(x1.highlowcontainer, pos1, length1)
+	}
+	return answer
+}
+
+// AndNot computes the difference between two bitmaps and returns the result
+func AndNot(x1, x2 *Bitmap) *Bitmap {
+	answer := NewBitmap()
+	pos1 := 0
+	pos2 := 0
+	length1 := x1.highlowcontainer.size()
+	length2 := x2.highlowcontainer.size()
+
+main:
+	for {
+		if pos1 < length1 && pos2 < length2 {
+			s1 := x1.highlowcontainer.getKeyAtIndex(pos1)
+			s2 := x2.highlowcontainer.getKeyAtIndex(pos2)
+			for {
+				if s1 < s2 {
+					answer.highlowcontainer.appendCopy(x1.highlowcontainer, pos1)
+					pos1++
+					if pos1 == length1 {
+						break main
+					}
+					s1 = x1.highlowcontainer.getKeyAtIndex(pos1)
+				} else if s1 == s2 {
+					c := roaring.AndNot(x1.highlowcontainer.getContainerAtIndex(pos1), x2.highlowcontainer.getContainerAtIndex(pos2))
+					if !c.IsEmpty() {
+						answer.highlowcontainer.appendContainer(s1, c, false)
+					}
+					pos1++
+					pos2++
+					if (pos1 == length1) || (pos2 == length2) {
+						break main
+					}
+					s1 = x1.highlowcontainer.getKeyAtIndex(pos1)
+					s2 = x2.highlowcontainer.getKeyAtIndex(pos2)
+				} else { // s1 > s2
+					pos2 = x2.highlowcontainer.advanceUntil(s1, pos2)
+					if pos2 == length2 {
+						break main
+					}
+					s2 = x2.highlowcontainer.getKeyAtIndex(pos2)
+				}
+			}
+		} else {
+			break
+		}
+	}
+	if pos2 == length2 {
+		answer.highlowcontainer.appendCopyMany(x1.highlowcontainer, pos1, length1)
+	}
+	return answer
+}
+
+func (rb *Bitmap) AddMany(dat []uint64) {
+	if len(dat) == 0 {
+		return
+	}
+
+	start, batchHighBits := 0, highbits(dat[0])
+	for end := 1; end < len(dat); end++ {
+		hi := highbits(dat[end])
+		if hi != batchHighBits {
+			batch := make([]uint32, end-start)
+			for i := 0; i < end-start; i++ {
+				batch[i] = lowbits(dat[start+i])
+			}
+			rb.getOrCreateContainer(batchHighBits).AddMany(batch)
+
+			batchHighBits = hi
+			start = end
+		}
+	}
+
+	batch := make([]uint32, len(dat)-start)
+	for i := 0; i < len(dat)-start; i++ {
+		batch[i] = lowbits(dat[start+i])
+	}
+	rb.getOrCreateContainer(batchHighBits).AddMany(batch)
+}
+
+// getOrCreateContainer gets the roaring.Bitmap for key hb,
+// or creates an *empty* roaring.Bitmap, inserts it to rb.highlowcontainer, and returns the new roaring.Bitmap.
+func (rb *Bitmap) getOrCreateContainer(hb uint32) *roaring.Bitmap {
+	i := rb.highlowcontainer.getIndex(hb)
+	if i >= 0 {
+		return rb.highlowcontainer.getContainerAtIndex(i)
+	}
+	c := roaring.NewBitmap()
+	rb.highlowcontainer.insertNewKeyValueAt(-i-1, hb, c)
+	return c
+}
+
+// BitmapOf generates a new bitmap filled with the specified integers
+func BitmapOf(dat ...uint64) *Bitmap {
+	ans := NewBitmap()
+	ans.AddMany(dat)
+	return ans
+}
+
+// Flip negates the bits in the given range (i.e., [rangeStart,rangeEnd)), any integer present in this range and in the bitmap is removed,
+// and any integer present in the range and not in the bitmap is added.
+func (rb *Bitmap) Flip(rangeStart, rangeEnd uint64) {
+	if rangeStart >= rangeEnd {
+		return
+	}
+
+	hbStart := uint64(highbits(rangeStart))
+	lbStart := uint64(lowbits(rangeStart))
+	hbLast := uint64(highbits(rangeEnd))
+	lbLast := uint64(lowbits(rangeEnd))
+
+	var max uint64 = maxLowBit
+	for hb := hbStart; hb <= hbLast; hb++ {
+		var containerStart uint64
+		if hb == hbStart {
+			containerStart = lbStart
+		}
+		containerLast := max
+		if hb == hbLast {
+			containerLast = lbLast
+		}
+
+		i := rb.highlowcontainer.getIndex(uint32(hb))
+
+		if i >= 0 {
+			c := rb.highlowcontainer.getWritableContainerAtIndex(i)
+			c.Flip(containerStart, containerLast)
+			if c.IsEmpty() {
+				rb.highlowcontainer.removeAtIndex(i)
+			}
+		} else { // *think* the range of ones must never be empty.
+			c := roaring.NewBitmap()
+			c.Flip(containerStart, containerLast)
+			rb.highlowcontainer.insertNewKeyValueAt(-i-1, uint32(hb), c)
+		}
+	}
+}
+
+// FlipInt calls Flip after casting the parameters  (convenience method)
+func (rb *Bitmap) FlipInt(rangeStart, rangeEnd int) {
+	rb.Flip(uint64(rangeStart), uint64(rangeEnd))
+}
+
+// AddRange adds the integers in [rangeStart, rangeEnd) to the bitmap.
+func (rb *Bitmap) AddRange(rangeStart, rangeEnd uint64) {
+	if rangeStart >= rangeEnd {
+		return
+	}
+	hbStart := uint64(highbits(rangeStart))
+	lbStart := uint64(lowbits(rangeStart))
+	hbLast := uint64(highbits(rangeEnd - 1))
+	lbLast := uint64(lowbits(rangeEnd - 1))
+
+	var max uint64 = maxLowBit
+	for hb := hbStart; hb <= hbLast; hb++ {
+		containerStart := uint64(0)
+		if hb == hbStart {
+			containerStart = lbStart
+		}
+		containerLast := max
+		if hb == hbLast {
+			containerLast = lbLast
+		}
+
+		rb.getOrCreateContainer(uint32(hb)).AddRange(containerStart, containerLast+1)
+	}
+}
+
+// RemoveRange removes the integers in [rangeStart, rangeEnd) from the bitmap.
+func (rb *Bitmap) RemoveRange(rangeStart, rangeEnd uint64) {
+	if rangeStart >= rangeEnd {
+		return
+	}
+	hbStart := uint64(highbits(rangeStart))
+	lbStart := uint64(lowbits(rangeStart))
+	hbLast := uint64(highbits(rangeEnd - 1))
+	lbLast := uint64(lowbits(rangeEnd - 1))
+
+	var max uint64 = maxLowBit
+
+	if hbStart == hbLast {
+		i := rb.highlowcontainer.getIndex(uint32(hbStart))
+		if i < 0 {
+			return
+		}
+		c := rb.highlowcontainer.getWritableContainerAtIndex(i)
+		c.RemoveRange(lbStart, lbLast+1)
+		if c.IsEmpty() {
+			rb.highlowcontainer.removeAtIndex(i)
+		}
+		return
+	}
+	ifirst := rb.highlowcontainer.getIndex(uint32(hbStart))
+	ilast := rb.highlowcontainer.getIndex(uint32(hbLast))
+
+	if ifirst >= 0 {
+		if lbStart != 0 {
+			c := rb.highlowcontainer.getWritableContainerAtIndex(ifirst)
+			c.RemoveRange(lbStart, max+1)
+			if !c.IsEmpty() {
+				ifirst++
+			}
+		}
+	} else {
+		ifirst = -ifirst - 1
+	}
+	if ilast >= 0 {
+		if lbLast != max {
+			c := rb.highlowcontainer.getWritableContainerAtIndex(ilast)
+			c.RemoveRange(0, lbLast+1)
+			if c.IsEmpty() {
+				ilast++
+			}
+		} else {
+			ilast++
+		}
+	} else {
+		ilast = -ilast - 1
+	}
+	rb.highlowcontainer.removeIndexRange(ifirst, ilast)
+}
+
+// Flip negates the bits in the given range  (i.e., [rangeStart,rangeEnd)), any integer present in this range and in the bitmap is removed,
+// and any integer present in the range and not in the bitmap is added, a new bitmap is returned leaving
+// the current bitmap unchanged.
+func Flip(rb *Bitmap, rangeStart, rangeEnd uint64) *Bitmap {
+	if rangeStart >= rangeEnd {
+		return rb.Clone()
+	}
+
+	answer := NewBitmap()
+	hbStart := uint64(highbits(rangeStart))
+	lbStart := uint64(lowbits(rangeStart))
+	hbLast := uint64(highbits(rangeEnd))
+	lbLast := uint64(lowbits(rangeEnd))
+
+	// copy the containers before the active area
+	answer.highlowcontainer.appendCopiesUntil(rb.highlowcontainer, uint32(hbStart))
+
+	var max uint64 = maxLowBit
+	for hb := hbStart; hb <= hbLast; hb++ {
+		var containerStart uint64
+		if hb == hbStart {
+			containerStart = lbStart
+		}
+		containerLast := max
+		if hb == hbLast {
+			containerLast = lbLast
+		}
+
+		i := rb.highlowcontainer.getIndex(uint32(hb))
+		j := answer.highlowcontainer.getIndex(uint32(hb))
+
+		if i >= 0 {
+			c := roaring.Flip(rb.highlowcontainer.getContainerAtIndex(i), containerStart, containerLast)
+			if !c.IsEmpty() {
+				answer.highlowcontainer.insertNewKeyValueAt(-j-1, uint32(hb), c)
+			}
+
+		} else { // *think* the range of ones must never be empty.
+			c := roaring.NewBitmap()
+			c.Flip(containerStart, containerLast)
+			answer.highlowcontainer.insertNewKeyValueAt(-i-1, uint32(hb), c)
+		}
+	}
+	// copy the containers after the active area.
+	answer.highlowcontainer.appendCopiesAfter(rb.highlowcontainer, uint32(hbLast))
+
+	return answer
+}
+
+// SetCopyOnWrite sets this bitmap to use copy-on-write so that copies are fast and memory conscious
+// if the parameter is true, otherwise we leave the default where hard copies are made
+// (copy-on-write requires extra care in a threaded context).
+// Calling SetCopyOnWrite(true) on a bitmap created with FromBuffer is unsafe.
+func (rb *Bitmap) SetCopyOnWrite(val bool) {
+	rb.highlowcontainer.copyOnWrite = val
+}
+
+// GetCopyOnWrite gets this bitmap's copy-on-write property
+func (rb *Bitmap) GetCopyOnWrite() (val bool) {
+	return rb.highlowcontainer.copyOnWrite
+}
+
+// CloneCopyOnWriteContainers clones all containers which have
+// needCopyOnWrite set to true.
+// This can be used to make sure it is safe to munmap a []byte
+// that the roaring array may still have a reference to, after
+// calling FromBuffer.
+// More generally this function is useful if you call FromBuffer
+// to construct a bitmap with a backing array buf
+// and then later discard the buf array. Note that you should call
+// CloneCopyOnWriteContainers on all bitmaps that were derived
+// from the 'FromBuffer' bitmap since they map have dependencies
+// on the buf array as well.
+func (rb *Bitmap) CloneCopyOnWriteContainers() {
+	rb.highlowcontainer.cloneCopyOnWriteContainers()
+}
+
+// FlipInt calls Flip after casting the parameters (convenience method)
+func FlipInt(bm *Bitmap, rangeStart, rangeEnd int) *Bitmap {
+	return Flip(bm, uint64(rangeStart), uint64(rangeEnd))
+}
+
+// Stats returns details on container type usage in a Statistics struct.
+func (rb *Bitmap) Stats() roaring.Statistics {
+	stats := roaring.Statistics{}
+	for _, c := range rb.highlowcontainer.containers {
+		bitmapStats := c.Stats()
+		stats.Cardinality += bitmapStats.Cardinality
+		stats.Containers += bitmapStats.Containers
+		stats.ArrayContainers += bitmapStats.ArrayContainers
+		stats.ArrayContainerBytes += bitmapStats.ArrayContainerBytes
+		stats.ArrayContainerValues += bitmapStats.ArrayContainerValues
+		stats.BitmapContainers += bitmapStats.BitmapContainers
+		stats.BitmapContainerBytes += bitmapStats.BitmapContainerBytes
+		stats.BitmapContainerValues += bitmapStats.BitmapContainerValues
+		stats.RunContainers += bitmapStats.RunContainers
+		stats.RunContainerBytes += bitmapStats.RunContainerBytes
+		stats.RunContainerValues += bitmapStats.RunContainerValues
+	}
+	return stats
+}

--- a/roaring64/roaring64_test.go
+++ b/roaring64/roaring64_test.go
@@ -1895,3 +1895,29 @@ func TestSerialization(t *testing.T) {
         assert.True(t, newBmp.Equals(bmp))
 }
 
+func TestAddCheckedRemove64(t *testing.T) {
+        array := []uint64{123, 0xA00000000A, 0xAFFFFFFF7, 0xFFFFFFFFF}
+        bmp := New()
+        for _, v := range array {
+                assert.True(t, bmp.CheckedAdd(v))
+                assert.False(t, bmp.CheckedAdd(v))
+        }
+        for _, v := range array {
+                assert.True(t, bmp.CheckedRemove(v))
+                assert.False(t, bmp.CheckedRemove(v))
+        }
+        assert.True(t, bmp.IsEmpty())
+}
+
+func TestClear64(t *testing.T) {
+        array := []uint64{123, 0xA00000000A, 0xAFFFFFFF7, 0xFFFFFFFFF}
+        bmp := New()
+        for _, v := range array {
+                bmp.Add(v)
+        }
+        assert.False(t, bmp.IsEmpty())
+        bmp.Clear()
+        assert.True(t, bmp.IsEmpty())
+}
+
+

--- a/roaring64/roaring64_test.go
+++ b/roaring64/roaring64_test.go
@@ -1,0 +1,1877 @@
+package roaring64
+
+import (
+	"log"
+	"math"
+	"math/rand"
+	"strconv"
+	"testing"
+	"unsafe"
+
+	"github.com/RoaringBitmap/roaring"
+	"github.com/stretchr/testify/assert"
+	"github.com/willf/bitset"
+)
+
+func TestRoaringIntervalCheck(t *testing.T) {
+	r := BitmapOf(1, 2, 3, 1000)
+	rangeb := New()
+	rangeb.AddRange(10, 1000+1)
+
+	assert.True(t, r.Intersects(rangeb))
+
+	rangeb2 := New()
+	rangeb2.AddRange(10, 1000)
+
+	assert.False(t, r.Intersects(rangeb2))
+}
+
+func TestRoaringRangeEnd(t *testing.T) {
+	r := New()
+	r.Add(roaring.MaxUint32)
+	assert.EqualValues(t, 1, r.GetCardinality())
+
+	r.RemoveRange(0, roaring.MaxUint32)
+	assert.EqualValues(t, 1, r.GetCardinality())
+
+	r.RemoveRange(0, math.MaxUint64)
+	assert.EqualValues(t, 0, r.GetCardinality())
+
+	r.Add(roaring.MaxUint32)
+	assert.EqualValues(t, 1, r.GetCardinality())
+
+	r.RemoveRange(0, 0x100000001)
+	assert.EqualValues(t, 0, r.GetCardinality())
+
+	r.Add(roaring.MaxUint32)
+	assert.EqualValues(t, 1, r.GetCardinality())
+
+	r.RemoveRange(0, 0x100000000)
+	assert.EqualValues(t, 0, r.GetCardinality())
+}
+
+func TestFirstLast(t *testing.T) {
+	bm := New()
+	bm.AddInt(2)
+	bm.AddInt(4)
+	bm.AddInt(8)
+
+	assert.EqualValues(t, 2, bm.Minimum())
+	assert.EqualValues(t, 8, bm.Maximum())
+
+	i := 1 << 5
+
+	for ; i < (1 << 17); i++ {
+		bm.AddInt(i)
+
+		assert.EqualValues(t, 2, bm.Minimum())
+		assert.EqualValues(t, i, bm.Maximum())
+	}
+
+	bm.RunOptimize()
+
+	assert.EqualValues(t, 2, bm.Minimum())
+	assert.EqualValues(t, i-1, bm.Maximum())
+}
+
+func TestRoaringBitmapBitmapOf(t *testing.T) {
+	array := []uint64{5580, 33722, 44031, 57276, 83097}
+	bmp := BitmapOf(array...)
+
+	assert.EqualValues(t, len(array), bmp.GetCardinality())
+}
+
+func TestRoaringBitmapAdd(t *testing.T) {
+	array := []uint64{5580, 33722, 44031, 57276, 83097}
+	bmp := New()
+	for _, v := range array {
+		bmp.Add(v)
+	}
+
+	assert.EqualValues(t, len(array), bmp.GetCardinality())
+}
+
+func TestRoaringBitmapAddMany(t *testing.T) {
+	array := []uint64{5580, 33722, 44031, 57276, 83097}
+	bmp := NewBitmap()
+	bmp.AddMany(array)
+
+	assert.EqualValues(t, len(array), bmp.GetCardinality())
+}
+
+// https://github.com/RoaringBitmap/roaring/issues/64
+func TestFlip64(t *testing.T) {
+	bm := New()
+	bm.AddInt(0)
+	bm.Flip(1, 2)
+	i := bm.Iterator()
+
+	if assert.True(t, i.HasNext()) {
+		assert.EqualValues(t, 0, i.Next())
+		if assert.True(t, i.HasNext()) {
+			assert.EqualValues(t, 1, i.Next())
+			assert.False(t, i.HasNext())
+		}
+	}
+}
+
+// https://github.com/RoaringBitmap/roaring/issues/64
+func TestFlip64Off(t *testing.T) {
+	bm := New()
+	bm.AddInt(10)
+	bm.Flip(11, 12)
+	i := bm.Iterator()
+
+	assert.False(t, i.Next() != 10 || i.Next() != 11 || i.HasNext())
+}
+
+func TestStringer(t *testing.T) {
+	v := NewBitmap()
+	for i := uint64(0); i < 10; i++ {
+		v.Add(i)
+	}
+
+	assert.Equal(t, "{0,1,2,3,4,5,6,7,8,9}", v.String())
+
+	v.RunOptimize()
+
+	assert.Equal(t, "{0,1,2,3,4,5,6,7,8,9}", v.String())
+}
+
+func TestFastCard(t *testing.T) {
+	bm := NewBitmap()
+	bm.Add(1)
+	bm.AddRange(21, 260000)
+	bm2 := NewBitmap()
+	bm2.Add(25)
+
+	assert.EqualValues(t, 1, bm2.AndCardinality(bm))
+	assert.Equal(t, bm.GetCardinality(), bm2.OrCardinality(bm))
+	assert.EqualValues(t, 1, bm.AndCardinality(bm2))
+	assert.Equal(t, bm.GetCardinality(), bm.OrCardinality(bm2))
+	assert.EqualValues(t, 1, bm2.AndCardinality(bm))
+	assert.Equal(t, bm.GetCardinality(), bm2.OrCardinality(bm))
+
+	bm.RunOptimize()
+
+	assert.EqualValues(t, 1, bm2.AndCardinality(bm))
+	assert.Equal(t, bm.GetCardinality(), bm2.OrCardinality(bm))
+	assert.EqualValues(t, 1, bm.AndCardinality(bm2))
+	assert.Equal(t, bm.GetCardinality(), bm.OrCardinality(bm2))
+	assert.EqualValues(t, 1, bm2.AndCardinality(bm))
+	assert.Equal(t, bm.GetCardinality(), bm2.OrCardinality(bm))
+}
+
+func TestIntersects1(t *testing.T) {
+	bm := NewBitmap()
+	bm.Add(1)
+	bm.AddRange(21, 26)
+	bm2 := NewBitmap()
+	bm2.Add(25)
+
+	assert.True(t, bm2.Intersects(bm))
+
+	bm.Remove(25)
+	assert.Equal(t, false, bm2.Intersects(bm))
+
+	bm.AddRange(1, 100000)
+	assert.True(t, bm2.Intersects(bm))
+}
+
+func TestRangePanic(t *testing.T) {
+	bm := NewBitmap()
+	bm.Add(1)
+	bm.AddRange(21, 26)
+	bm.AddRange(9, 14)
+	bm.AddRange(11, 16)
+}
+
+func TestRangeRemoval(t *testing.T) {
+	bm := NewBitmap()
+	bm.Add(1)
+	bm.AddRange(21, 26)
+	bm.AddRange(9, 14)
+	bm.RemoveRange(11, 16)
+	bm.RemoveRange(1, 26)
+	c := bm.GetCardinality()
+
+	assert.EqualValues(t, 0, c)
+
+	bm.AddRange(1, 10000)
+	c = bm.GetCardinality()
+
+	assert.EqualValues(t, 10000-1, c)
+
+	bm.RemoveRange(1, 10000)
+	c = bm.GetCardinality()
+
+	assert.EqualValues(t, 0, c)
+}
+
+func TestRangeRemovalFromContent(t *testing.T) {
+	bm := NewBitmap()
+	for i := 100; i < 10000; i++ {
+		bm.AddInt(i * 3)
+	}
+	bm.AddRange(21, 26)
+	bm.AddRange(9, 14)
+	bm.RemoveRange(11, 16)
+	bm.RemoveRange(0, 30000)
+	c := bm.GetCardinality()
+
+	assert.EqualValues(t, 00, c)
+}
+
+func TestFlipOnEmpty(t *testing.T) {
+	t.Run("TestFlipOnEmpty in-place", func(t *testing.T) {
+		bm := NewBitmap()
+		bm.Flip(0, 10)
+		c := bm.GetCardinality()
+
+		assert.EqualValues(t, 10, c)
+	})
+
+	t.Run("TestFlipOnEmpty, generating new result", func(t *testing.T) {
+		bm := NewBitmap()
+		bm = Flip(bm, 0, 10)
+		c := bm.GetCardinality()
+
+		assert.EqualValues(t, 10, c)
+	})
+}
+
+func TestBitmapRank2(t *testing.T) {
+	r := NewBitmap()
+	for i := uint64(1); i < 8194; i += 2 {
+		r.Add(i)
+	}
+
+	rank := r.Rank(63)
+	assert.EqualValues(t, 32, rank)
+}
+
+func TestBitmapRank(t *testing.T) {
+	for n := uint64(1); n <= 1048576; n *= 2 {
+		t.Run("rank tests"+strconv.Itoa(int(n)), func(t *testing.T) {
+			for gap := uint64(1); gap <= 65536; gap *= 2 {
+				rb1 := NewBitmap()
+				for x := uint64(0); x <= n; x += gap {
+					rb1.Add(x)
+				}
+				for y := uint64(0); y <= n; y++ {
+					if rb1.Rank(y) != (y+1+gap-1)/gap {
+						assert.Equal(t, (y+1+gap-1)/gap, rb1.Rank(y))
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestBitmapSelect(t *testing.T) {
+	for n := uint64(1); n <= 1048576; n *= 2 {
+		t.Run("rank tests"+strconv.Itoa(int(n)), func(t *testing.T) {
+			for gap := uint64(1); gap <= 65536; gap *= 2 {
+				rb1 := NewBitmap()
+				for x := uint64(0); x <= n; x += gap {
+					rb1.Add(x)
+				}
+				for y := uint64(0); y <= n/gap; y++ {
+					expectedInt := y * gap
+					i, err := rb1.Select(y)
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					if i != expectedInt {
+						assert.Equal(t, expectedInt, i)
+					}
+				}
+			}
+		})
+	}
+}
+
+// some extra tests
+func TestBitmapExtra(t *testing.T) {
+	for n := uint64(1); n <= 65536; n *= 2 {
+		t.Run("extra tests"+strconv.Itoa(int(n)), func(t *testing.T) {
+			for gap := uint64(1); gap <= 65536; gap *= 2 {
+				bs1 := bitset.New(0)
+				rb1 := NewBitmap()
+				for x := uint64(0); x <= n; x += gap {
+					bs1.Set(uint(x))
+					rb1.Add(x)
+				}
+
+				assert.EqualValues(t, rb1.GetCardinality(), bs1.Count())
+				assert.True(t, equalsBitSet(bs1, rb1))
+
+				for offset := uint64(1); offset <= gap; offset *= 2 {
+					bs2 := bitset.New(0)
+					rb2 := NewBitmap()
+					for x := uint64(0); x <= n; x += gap {
+						bs2.Set(uint(x + offset))
+						rb2.Add(x + offset)
+					}
+
+					assert.EqualValues(t, rb2.GetCardinality(), bs2.Count())
+					assert.True(t, equalsBitSet(bs2, rb2))
+
+					clonebs1 := bs1.Clone()
+					clonebs1.InPlaceIntersection(bs2)
+
+					if !equalsBitSet(clonebs1, And(rb1, rb2)) {
+						v := rb1.Clone()
+						v.And(rb2)
+
+						assert.True(t, equalsBitSet(clonebs1, v))
+					}
+
+					// testing OR
+					clonebs1 = bs1.Clone()
+					clonebs1.InPlaceUnion(bs2)
+
+					assert.True(t, equalsBitSet(clonebs1, Or(rb1, rb2)))
+					// testing XOR
+					clonebs1 = bs1.Clone()
+					clonebs1.InPlaceSymmetricDifference(bs2)
+					assert.True(t, equalsBitSet(clonebs1, Xor(rb1, rb2)))
+
+					// testing NOTAND
+					clonebs1 = bs1.Clone()
+					clonebs1.InPlaceDifference(bs2)
+					assert.True(t, equalsBitSet(clonebs1, AndNot(rb1, rb2)))
+				}
+			}
+		})
+	}
+}
+
+func FlipRange(start, end int, bs *bitset.BitSet) {
+	for i := start; i < end; i++ {
+		bs.Flip(uint(i))
+	}
+}
+
+func TestBitmap(t *testing.T) {
+	t.Run("Test Contains", func(t *testing.T) {
+		rbm1 := NewBitmap()
+		for k := 0; k < 1000; k++ {
+			rbm1.AddInt(17 * k)
+		}
+
+		for k := 0; k < 17*1000; k++ {
+			assert.Equal(t, (k/17*17 == k), rbm1.ContainsInt(k))
+		}
+	})
+
+	t.Run("Test Clone", func(t *testing.T) {
+		rb1 := NewBitmap()
+		rb1.Add(10)
+
+		rb2 := rb1.Clone()
+		rb2.Remove(10)
+
+		assert.True(t, rb1.Contains(10))
+	})
+
+	t.Run("Test run array not equal", func(t *testing.T) {
+		rb := NewBitmap()
+		rb2 := NewBitmap()
+		rb.AddRange(0, 1<<16)
+		for i := 0; i < 10; i++ {
+			rb2.AddInt(i)
+		}
+
+		assert.EqualValues(t, 1<<16, rb.GetCardinality())
+		assert.EqualValues(t, 10, rb2.GetCardinality())
+		assert.False(t, rb.Equals(rb2))
+
+		rb.RunOptimize()
+		rb2.RunOptimize()
+
+		assert.EqualValues(t, 1<<16, rb.GetCardinality())
+		assert.EqualValues(t, 10, rb2.GetCardinality())
+		assert.False(t, rb.Equals(rb2))
+	})
+
+	t.Run("Test ANDNOT4", func(t *testing.T) {
+		rb := NewBitmap()
+		rb2 := NewBitmap()
+
+		for i := 0; i < 200000; i += 4 {
+			rb2.AddInt(i)
+		}
+		for i := 200000; i < 400000; i += 14 {
+			rb2.AddInt(i)
+		}
+
+		off := AndNot(rb2, rb)
+		andNotresult := AndNot(rb, rb2)
+
+		assert.True(t, rb.Equals(andNotresult))
+		assert.True(t, rb2.Equals(off))
+
+		rb2.AndNot(rb)
+		assert.True(t, rb2.Equals(off))
+	})
+
+	t.Run("Test AND", func(t *testing.T) {
+		rr := NewBitmap()
+		for k := 0; k < 4000; k++ {
+			rr.AddInt(k)
+		}
+		rr.Add(100000)
+		rr.Add(110000)
+		rr2 := NewBitmap()
+		rr2.Add(13)
+		rrand := And(rr, rr2)
+		array := rrand.ToArray()
+
+		assert.Equal(t, 1, len(array))
+		assert.EqualValues(t, 13, array[0])
+
+		rr.And(rr2)
+		array = rr.ToArray()
+
+		assert.Equal(t, 1, len(array))
+		assert.EqualValues(t, 13, array[0])
+	})
+
+	t.Run("Test AND 2", func(t *testing.T) {
+		rr := NewBitmap()
+		for k := 4000; k < 4256; k++ {
+			rr.AddInt(k)
+		}
+		for k := 65536; k < 65536+4000; k++ {
+			rr.AddInt(k)
+		}
+		for k := 3 * 65536; k < 3*65536+9000; k++ {
+			rr.AddInt(k)
+		}
+		for k := 4 * 65535; k < 4*65535+7000; k++ {
+			rr.AddInt(k)
+		}
+		for k := 6 * 65535; k < 6*65535+10000; k++ {
+			rr.AddInt(k)
+		}
+		for k := 8 * 65535; k < 8*65535+1000; k++ {
+			rr.AddInt(k)
+		}
+		for k := 9 * 65535; k < 9*65535+30000; k++ {
+			rr.AddInt(k)
+		}
+
+		rr2 := NewBitmap()
+		for k := 4000; k < 4256; k++ {
+			rr2.AddInt(k)
+		}
+		for k := 65536; k < 65536+4000; k++ {
+			rr2.AddInt(k)
+		}
+		for k := 3*65536 + 2000; k < 3*65536+6000; k++ {
+			rr2.AddInt(k)
+		}
+		for k := 6 * 65535; k < 6*65535+1000; k++ {
+			rr2.AddInt(k)
+		}
+		for k := 7 * 65535; k < 7*65535+1000; k++ {
+			rr2.AddInt(k)
+		}
+		for k := 10 * 65535; k < 10*65535+5000; k++ {
+			rr2.AddInt(k)
+		}
+		correct := And(rr, rr2)
+		rr.And(rr2)
+
+		assert.True(t, correct.Equals(rr))
+	})
+
+	t.Run("Test AND 2", func(t *testing.T) {
+		rr := NewBitmap()
+		for k := 0; k < 4000; k++ {
+			rr.AddInt(k)
+		}
+		rr.AddInt(100000)
+		rr.AddInt(110000)
+		rr2 := NewBitmap()
+		rr2.AddInt(13)
+
+		rrand := And(rr, rr2)
+		array := rrand.ToArray()
+
+		assert.Equal(t, 1, len(array))
+		assert.EqualValues(t, 13, array[0])
+	})
+
+	t.Run("Test AND 3a", func(t *testing.T) {
+		rr := NewBitmap()
+		rr2 := NewBitmap()
+		for k := 6 * 65536; k < 6*65536+10000; k++ {
+			rr.AddInt(k)
+		}
+		for k := 6 * 65536; k < 6*65536+1000; k++ {
+			rr2.AddInt(k)
+		}
+		result := And(rr, rr2)
+
+		assert.EqualValues(t, 1000, result.GetCardinality())
+	})
+
+	t.Run("Test AND 3", func(t *testing.T) {
+		var arrayand [11256]uint64
+		// 393,216
+		pos := 0
+		rr := NewBitmap()
+		for k := 4000; k < 4256; k++ {
+			rr.AddInt(k)
+		}
+		for k := 65536; k < 65536+4000; k++ {
+			rr.AddInt(k)
+		}
+		for k := 3 * 65536; k < 3*65536+1000; k++ {
+			rr.AddInt(k)
+		}
+		for k := 3*65536 + 1000; k < 3*65536+7000; k++ {
+			rr.AddInt(k)
+		}
+		for k := 3*65536 + 7000; k < 3*65536+9000; k++ {
+			rr.AddInt(k)
+		}
+		for k := 4 * 65536; k < 4*65536+7000; k++ {
+			rr.AddInt(k)
+		}
+		for k := 8 * 65536; k < 8*65536+1000; k++ {
+			rr.AddInt(k)
+		}
+		for k := 9 * 65536; k < 9*65536+30000; k++ {
+			rr.AddInt(k)
+		}
+
+		rr2 := NewBitmap()
+		for k := 4000; k < 4256; k++ {
+			rr2.AddInt(k)
+			arrayand[pos] = uint64(k)
+			pos++
+		}
+		for k := 65536; k < 65536+4000; k++ {
+			rr2.AddInt(k)
+			arrayand[pos] = uint64(k)
+			pos++
+		}
+		for k := 3*65536 + 1000; k < 3*65536+7000; k++ {
+			rr2.AddInt(k)
+			arrayand[pos] = uint64(k)
+			pos++
+		}
+		for k := 6 * 65536; k < 6*65536+10000; k++ {
+			rr.AddInt(k)
+		}
+		for k := 6 * 65536; k < 6*65536+1000; k++ {
+			rr2.AddInt(k)
+			arrayand[pos] = uint64(k)
+			pos++
+		}
+
+		for k := 7 * 65536; k < 7*65536+1000; k++ {
+			rr2.AddInt(k)
+		}
+		for k := 10 * 65536; k < 10*65536+5000; k++ {
+			rr2.AddInt(k)
+		}
+		rrand := And(rr, rr2)
+
+		arrayres := rrand.ToArray()
+		ok := true
+		for i := range arrayres {
+			if i < len(arrayand) {
+				if arrayres[i] != arrayand[i] {
+					log.Println(i, arrayres[i], arrayand[i])
+					ok = false
+				}
+			} else {
+				log.Println('x', arrayres[i])
+				ok = false
+			}
+		}
+
+		assert.Equal(t, len(arrayres), len(arrayand))
+		assert.True(t, ok)
+
+	})
+
+	t.Run("Test AND 4", func(t *testing.T) {
+		rb := NewBitmap()
+		rb2 := NewBitmap()
+
+		for i := 0; i < 200000; i += 4 {
+			rb2.AddInt(i)
+		}
+		for i := 200000; i < 400000; i += 14 {
+			rb2.AddInt(i)
+		}
+		// TODO: Bitmap.And(bm,bm2)
+		andresult := And(rb, rb2)
+		off := And(rb2, rb)
+
+		assert.True(t, andresult.Equals(off))
+		assert.EqualValues(t, 0, andresult.GetCardinality())
+
+		for i := 500000; i < 600000; i += 14 {
+			rb.AddInt(i)
+		}
+		for i := 200000; i < 400000; i += 3 {
+			rb2.AddInt(i)
+		}
+		andresult2 := And(rb, rb2)
+
+		assert.EqualValues(t, 0, andresult.GetCardinality())
+		assert.EqualValues(t, 0, andresult2.GetCardinality())
+
+		for i := 0; i < 200000; i += 4 {
+			rb.AddInt(i)
+		}
+		for i := 200000; i < 400000; i += 14 {
+			rb.AddInt(i)
+		}
+
+		assert.EqualValues(t, 0, andresult.GetCardinality())
+
+		rc := And(rb, rb2)
+		rb.And(rb2)
+
+		assert.Equal(t, rb.GetCardinality(), rc.GetCardinality())
+	})
+
+	t.Run("or test", func(t *testing.T) {
+		rr := NewBitmap()
+		for k := 0; k < 4000; k++ {
+			rr.AddInt(k)
+		}
+		rr2 := NewBitmap()
+		for k := 4000; k < 8000; k++ {
+			rr2.AddInt(k)
+		}
+		result := Or(rr, rr2)
+
+		assert.Equal(t, rr.GetCardinality()+rr2.GetCardinality(), result.GetCardinality())
+	})
+
+	t.Run("basic test", func(t *testing.T) {
+		rr := NewBitmap()
+		var a [4002]uint64
+		pos := 0
+		for k := 0; k < 4000; k++ {
+			rr.AddInt(k)
+			a[pos] = uint64(k)
+			pos++
+		}
+		rr.AddInt(100000)
+		a[pos] = 100000
+		pos++
+		rr.AddInt(110000)
+		a[pos] = 110000
+		pos++
+		array := rr.ToArray()
+		ok := true
+		for i := range a {
+			if array[i] != a[i] {
+				log.Println("rr : ", array[i], " a : ", a[i])
+				ok = false
+			}
+		}
+
+		assert.Equal(t, len(a), len(array))
+		assert.True(t, ok)
+	})
+
+	t.Run("cardinality test", func(t *testing.T) {
+		N := 1024
+		for gap := 7; gap < 100000; gap *= 10 {
+			for offset := 2; offset <= 1024; offset *= 2 {
+				rb := NewBitmap()
+				for k := 0; k < N; k++ {
+					rb.AddInt(k * gap)
+					assert.EqualValues(t, k+1, rb.GetCardinality())
+				}
+
+				assert.EqualValues(t, N, rb.GetCardinality())
+
+				// check the add of existing values
+				for k := 0; k < N; k++ {
+					rb.AddInt(k * gap)
+					assert.EqualValues(t, N, rb.GetCardinality())
+				}
+
+				rb2 := NewBitmap()
+
+				for k := 0; k < N; k++ {
+					rb2.AddInt(k * gap * offset)
+					assert.EqualValues(t, k+1, rb2.GetCardinality())
+				}
+
+				assert.EqualValues(t, N, rb2.GetCardinality())
+
+				for k := 0; k < N; k++ {
+					rb2.AddInt(k * gap * offset)
+					assert.EqualValues(t, N, rb2.GetCardinality())
+				}
+
+				assert.EqualValues(t, N/offset, And(rb, rb2).GetCardinality())
+				assert.EqualValues(t, 2*N-2*N/offset, Xor(rb, rb2).GetCardinality())
+				assert.EqualValues(t, 2*N-N/offset, Or(rb, rb2).GetCardinality())
+			}
+		}
+	})
+
+	t.Run("clear test", func(t *testing.T) {
+		rb := NewBitmap()
+		for i := 0; i < 200000; i += 7 {
+			// dense
+			rb.AddInt(i)
+		}
+		for i := 200000; i < 400000; i += 177 {
+			// sparse
+			rb.AddInt(i)
+		}
+
+		rb2 := NewBitmap()
+		rb3 := NewBitmap()
+		for i := 0; i < 200000; i += 4 {
+			rb2.AddInt(i)
+		}
+		for i := 200000; i < 400000; i += 14 {
+			rb2.AddInt(i)
+		}
+
+		rb.Clear()
+
+		assert.EqualValues(t, 0, rb.GetCardinality())
+		assert.NotEqual(t, 0, rb2.GetCardinality())
+
+		rb.AddInt(4)
+		rb3.AddInt(4)
+		andresult := And(rb, rb2)
+		orresult := Or(rb, rb2)
+
+		assert.EqualValues(t, 1, andresult.GetCardinality())
+		assert.Equal(t, rb2.GetCardinality(), orresult.GetCardinality())
+
+		for i := 0; i < 200000; i += 4 {
+			rb.AddInt(i)
+			rb3.AddInt(i)
+		}
+		for i := 200000; i < 400000; i += 114 {
+			rb.AddInt(i)
+			rb3.AddInt(i)
+		}
+
+		arrayrr := rb.ToArray()
+		arrayrr3 := rb3.ToArray()
+		ok := true
+		for i := range arrayrr {
+			if arrayrr[i] != arrayrr3[i] {
+				ok = false
+			}
+		}
+
+		assert.Equal(t, len(arrayrr3), len(arrayrr))
+		assert.True(t, ok)
+	})
+
+	t.Run("flipTest1 ", func(t *testing.T) {
+		rb := NewBitmap()
+		rb.Flip(100000, 200000) // in-place on empty bitmap
+		rbcard := rb.GetCardinality()
+
+		assert.EqualValues(t, 100000, rbcard)
+
+		bs := bitset.New(20000 - 10000)
+		for i := uint(100000); i < 200000; i++ {
+			bs.Set(i)
+		}
+
+		assert.True(t, equalsBitSet(bs, rb))
+	})
+
+	t.Run("flipTest1A", func(t *testing.T) {
+		rb := NewBitmap()
+		rb1 := Flip(rb, 100000, 200000)
+		rbcard := rb1.GetCardinality()
+
+		assert.EqualValues(t, 100000, rbcard)
+		assert.EqualValues(t, 0, rb.GetCardinality())
+
+		bs := bitset.New(0)
+		assert.True(t, equalsBitSet(bs, rb))
+
+		for i := uint(100000); i < 200000; i++ {
+			bs.Set(i)
+		}
+
+		assert.True(t, equalsBitSet(bs, rb1))
+	})
+
+	t.Run("flipTest2", func(t *testing.T) {
+		rb := NewBitmap()
+		rb.Flip(100000, 100000)
+		rbcard := rb.GetCardinality()
+
+		assert.EqualValues(t, 0, rbcard)
+
+		bs := bitset.New(0)
+		assert.True(t, equalsBitSet(bs, rb))
+	})
+
+	t.Run("flipTest2A", func(t *testing.T) {
+		rb := NewBitmap()
+		rb1 := Flip(rb, 100000, 100000)
+
+		rb.AddInt(1)
+		rbcard := rb1.GetCardinality()
+
+		assert.EqualValues(t, 0, rbcard)
+		assert.EqualValues(t, 1, rb.GetCardinality())
+
+		bs := bitset.New(0)
+		assert.True(t, equalsBitSet(bs, rb1))
+
+		bs.Set(1)
+		assert.True(t, equalsBitSet(bs, rb))
+	})
+
+	t.Run("flipTest3A", func(t *testing.T) {
+		rb := NewBitmap()
+		rb.Flip(100000, 200000) // got 100k-199999
+		rb.Flip(100000, 199991) // give back 100k-199990
+		rbcard := rb.GetCardinality()
+
+		assert.EqualValues(t, 9, rbcard)
+
+		bs := bitset.New(0)
+		for i := uint(199991); i < 200000; i++ {
+			bs.Set(i)
+		}
+
+		assert.True(t, equalsBitSet(bs, rb))
+	})
+
+	t.Run("flipTest4A", func(t *testing.T) {
+		// fits evenly on both ends
+		rb := NewBitmap()
+		rb.Flip(100000, 200000) // got 100k-199999
+		rb.Flip(65536, 4*65536)
+		rbcard := rb.GetCardinality()
+
+		// 65536 to 99999 are 1s
+		// 200000 to 262143 are 1s: total card
+
+		assert.EqualValues(t, 96608, rbcard)
+
+		bs := bitset.New(0)
+		for i := uint(65536); i < 100000; i++ {
+			bs.Set(i)
+		}
+		for i := uint(200000); i < 262144; i++ {
+			bs.Set(i)
+		}
+
+		assert.True(t, equalsBitSet(bs, rb))
+	})
+
+	t.Run("flipTest5", func(t *testing.T) {
+		// fits evenly on small end, multiple
+		// containers
+		rb := NewBitmap()
+		rb.Flip(100000, 132000)
+		rb.Flip(65536, 120000)
+		rbcard := rb.GetCardinality()
+
+		// 65536 to 99999 are 1s
+		// 120000 to 131999
+
+		assert.EqualValues(t, 46464, rbcard)
+
+		bs := bitset.New(0)
+		for i := uint(65536); i < 100000; i++ {
+			bs.Set(i)
+		}
+		for i := uint(120000); i < 132000; i++ {
+			bs.Set(i)
+		}
+
+		assert.True(t, equalsBitSet(bs, rb))
+	})
+
+	t.Run("flipTest6", func(t *testing.T) {
+		rb := NewBitmap()
+		rb1 := Flip(rb, 100000, 132000)
+		rb2 := Flip(rb1, 65536, 120000)
+		// rbcard := rb2.GetCardinality()
+
+		bs := bitset.New(0)
+		for i := uint(65536); i < 100000; i++ {
+			bs.Set(i)
+		}
+		for i := uint(120000); i < 132000; i++ {
+			bs.Set(i)
+		}
+
+		assert.True(t, equalsBitSet(bs, rb2))
+	})
+
+	t.Run("flipTest6A", func(t *testing.T) {
+		rb := NewBitmap()
+		rb1 := Flip(rb, 100000, 132000)
+		rb2 := Flip(rb1, 99000, 2*65536)
+		rbcard := rb2.GetCardinality()
+
+		assert.EqualValues(t, rbcard, 1928)
+
+		bs := bitset.New(0)
+		for i := uint(99000); i < 100000; i++ {
+			bs.Set(i)
+		}
+		for i := uint(2 * 65536); i < 132000; i++ {
+			bs.Set(i)
+		}
+		assert.True(t, equalsBitSet(bs, rb2))
+	})
+
+	t.Run("flipTest7", func(t *testing.T) {
+		// within 1 word, first container
+		rb := NewBitmap()
+		rb.Flip(650, 132000)
+		rb.Flip(648, 651)
+		rbcard := rb.GetCardinality()
+
+		// 648, 649, 651-131999
+
+		assert.EqualValues(t, rbcard, 132000-651+2)
+
+		bs := bitset.New(0)
+		bs.Set(648)
+		bs.Set(649)
+		for i := uint(651); i < 132000; i++ {
+			bs.Set(i)
+		}
+
+		assert.True(t, equalsBitSet(bs, rb))
+	})
+
+	t.Run("flipTestBig", func(t *testing.T) {
+		numCases := 1000
+		rb := NewBitmap()
+		bs := bitset.New(0)
+		// Random r = new Random(3333);
+		checkTime := 2.0
+
+		for i := 0; i < numCases; i++ {
+			start := rand.Intn(65536 * 20)
+			end := rand.Intn(65536 * 20)
+			if rand.Float64() < float64(0.1) {
+				end = start + rand.Intn(100)
+			}
+			rb.Flip(uint64(start), uint64(end))
+			if start < end {
+				FlipRange(start, end, bs) // throws exception
+			}
+			// otherwise
+			// insert some more ANDs to keep things sparser
+			if rand.Float64() < 0.2 {
+				mask := NewBitmap()
+				mask1 := bitset.New(0)
+				startM := rand.Intn(65536 * 20)
+				endM := startM + 100000
+				mask.Flip(uint64(startM), uint64(endM))
+				FlipRange(startM, endM, mask1)
+				mask.Flip(0, 65536*20+100000)
+				FlipRange(0, 65536*20+100000, mask1)
+				rb.And(mask)
+				bs.InPlaceIntersection(mask1)
+			}
+			// see if we can detect incorrectly shared containers
+			if rand.Float64() < 0.1 {
+				irrelevant := Flip(rb, 10, 100000)
+				irrelevant.Flip(5, 200000)
+				irrelevant.Flip(190000, 260000)
+			}
+			if float64(i) > checkTime {
+				assert.True(t, equalsBitSet(bs, rb))
+				checkTime *= 1.5
+			}
+		}
+	})
+
+	t.Run("ortest", func(t *testing.T) {
+		rr := NewBitmap()
+		for k := 0; k < 4000; k++ {
+			rr.AddInt(k)
+		}
+		rr.AddInt(100000)
+		rr.AddInt(110000)
+		rr2 := NewBitmap()
+		for k := 0; k < 4000; k++ {
+			rr2.AddInt(k)
+		}
+
+		rror := Or(rr, rr2)
+
+		array := rror.ToArray()
+
+		rr.Or(rr2)
+		arrayirr := rr.ToArray()
+
+		assert.Equal(t, array, arrayirr)
+	})
+
+	t.Run("ORtest", func(t *testing.T) {
+		rr := NewBitmap()
+		for k := 4000; k < 4256; k++ {
+			rr.AddInt(k)
+		}
+		for k := 65536; k < 65536+4000; k++ {
+			rr.AddInt(k)
+		}
+		for k := 3 * 65536; k < 3*65536+9000; k++ {
+			rr.AddInt(k)
+		}
+		for k := 4 * 65535; k < 4*65535+7000; k++ {
+			rr.AddInt(k)
+		}
+		for k := 6 * 65535; k < 6*65535+10000; k++ {
+			rr.AddInt(k)
+		}
+		for k := 8 * 65535; k < 8*65535+1000; k++ {
+			rr.AddInt(k)
+		}
+		for k := 9 * 65535; k < 9*65535+30000; k++ {
+			rr.AddInt(k)
+		}
+
+		rr2 := NewBitmap()
+		for k := 4000; k < 4256; k++ {
+			rr2.AddInt(k)
+		}
+		for k := 65536; k < 65536+4000; k++ {
+			rr2.AddInt(k)
+		}
+		for k := 3*65536 + 2000; k < 3*65536+6000; k++ {
+			rr2.AddInt(k)
+		}
+		for k := 6 * 65535; k < 6*65535+1000; k++ {
+			rr2.AddInt(k)
+		}
+		for k := 7 * 65535; k < 7*65535+1000; k++ {
+			rr2.AddInt(k)
+		}
+		for k := 10 * 65535; k < 10*65535+5000; k++ {
+			rr2.AddInt(k)
+		}
+		correct := Or(rr, rr2)
+		rr.Or(rr2)
+
+		assert.True(t, correct.Equals(rr))
+	})
+
+	t.Run("ortest2", func(t *testing.T) {
+		arrayrr := make([]uint32, 4000+4000+2)
+		pos := 0
+		rr := NewBitmap()
+		for k := 0; k < 4000; k++ {
+			rr.AddInt(k)
+			arrayrr[pos] = uint32(k)
+			pos++
+		}
+		rr.AddInt(100000)
+		rr.AddInt(110000)
+		rr2 := NewBitmap()
+		for k := 4000; k < 8000; k++ {
+			rr2.AddInt(k)
+			arrayrr[pos] = uint32(k)
+			pos++
+		}
+
+		arrayrr[pos] = 100000
+		pos++
+		arrayrr[pos] = 110000
+		pos++
+
+		rror := Or(rr, rr2)
+
+		arrayor := rror.ToArray()
+
+		assert.Equal(t, arrayor, arrayrr)
+	})
+
+	t.Run("ortest3", func(t *testing.T) {
+		V1 := make(map[int]bool)
+		V2 := make(map[int]bool)
+
+		rr := NewBitmap()
+		rr2 := NewBitmap()
+		for k := 0; k < 4000; k++ {
+			rr2.AddInt(k)
+			V1[k] = true
+		}
+		for k := 3500; k < 4500; k++ {
+			rr.AddInt(k)
+			V1[k] = true
+		}
+		for k := 4000; k < 65000; k++ {
+			rr2.AddInt(k)
+			V1[k] = true
+		}
+
+		// In the second node of each roaring bitmap, we have two bitmap
+		// containers.
+		// So, we will check the union between two BitmapContainers
+		for k := 65536; k < 65536+10000; k++ {
+			rr.AddInt(k)
+			V1[k] = true
+		}
+
+		for k := 65536; k < 65536+14000; k++ {
+			rr2.AddInt(k)
+			V1[k] = true
+		}
+
+		// In the 3rd node of each Roaring Bitmap, we have an
+		// ArrayContainer, so, we will try the union between two
+		// ArrayContainers.
+		for k := 4 * 65535; k < 4*65535+1000; k++ {
+			rr.AddInt(k)
+			V1[k] = true
+		}
+
+		for k := 4 * 65535; k < 4*65535+800; k++ {
+			rr2.AddInt(k)
+			V1[k] = true
+		}
+
+		// For the rest, we will check if the union will take them in
+		// the result
+		for k := 6 * 65535; k < 6*65535+1000; k++ {
+			rr.AddInt(k)
+			V1[k] = true
+		}
+
+		for k := 7 * 65535; k < 7*65535+2000; k++ {
+			rr2.AddInt(k)
+			V1[k] = true
+		}
+
+		rror := Or(rr, rr2)
+		valide := true
+
+		for _, k := range rror.ToArray() {
+			_, found := V1[int(k)]
+			if !found {
+				valide = false
+			}
+			V2[int(k)] = true
+		}
+
+		for k := range V1 {
+			_, found := V2[k]
+			if !found {
+				valide = false
+			}
+		}
+
+		assert.True(t, valide)
+	})
+
+	t.Run("ortest4", func(t *testing.T) {
+		rb := NewBitmap()
+		rb2 := NewBitmap()
+
+		for i := 0; i < 200000; i += 4 {
+			rb2.AddInt(i)
+		}
+		for i := 200000; i < 400000; i += 14 {
+			rb2.AddInt(i)
+		}
+		rb2card := rb2.GetCardinality()
+
+		// check or against an empty bitmap
+		orresult := Or(rb, rb2)
+		off := Or(rb2, rb)
+
+		assert.True(t, orresult.Equals(off))
+		assert.Equal(t, orresult.GetCardinality(), rb2card)
+
+		for i := 500000; i < 600000; i += 14 {
+			rb.AddInt(i)
+		}
+		for i := 200000; i < 400000; i += 3 {
+			rb2.AddInt(i)
+		}
+		// check or against an empty bitmap
+		orresult2 := Or(rb, rb2)
+
+		assert.Equal(t, orresult.GetCardinality(), rb2card)
+		assert.Equal(t, rb2.GetCardinality()+rb.GetCardinality(), orresult2.GetCardinality())
+
+		rb.Or(rb2)
+		assert.True(t, rb.Equals(orresult2))
+	})
+
+	t.Run("randomTest", func(t *testing.T) {
+		rTest(t, 15)
+		rTest(t, 1024)
+		rTest(t, 4096)
+		rTest(t, 65536)
+		rTest(t, 65536*16)
+	})
+
+	t.Run("SimpleCardinality", func(t *testing.T) {
+		N := 512
+		gap := 70
+
+		rb := NewBitmap()
+		for k := 0; k < N; k++ {
+			rb.AddInt(k * gap)
+			assert.EqualValues(t, k+1, rb.GetCardinality())
+		}
+
+		assert.EqualValues(t, N, rb.GetCardinality())
+
+		for k := 0; k < N; k++ {
+			rb.AddInt(k * gap)
+			assert.EqualValues(t, N, rb.GetCardinality())
+		}
+	})
+
+	t.Run("XORtest", func(t *testing.T) {
+		rr := NewBitmap()
+		for k := 4000; k < 4256; k++ {
+			rr.AddInt(k)
+		}
+		for k := 65536; k < 65536+4000; k++ {
+			rr.AddInt(k)
+		}
+		for k := 3 * 65536; k < 3*65536+9000; k++ {
+			rr.AddInt(k)
+		}
+		for k := 4 * 65535; k < 4*65535+7000; k++ {
+			rr.AddInt(k)
+		}
+		for k := 6 * 65535; k < 6*65535+10000; k++ {
+			rr.AddInt(k)
+		}
+		for k := 8 * 65535; k < 8*65535+1000; k++ {
+			rr.AddInt(k)
+		}
+		for k := 9 * 65535; k < 9*65535+30000; k++ {
+			rr.AddInt(k)
+		}
+
+		rr2 := NewBitmap()
+		for k := 4000; k < 4256; k++ {
+			rr2.AddInt(k)
+		}
+		for k := 65536; k < 65536+4000; k++ {
+			rr2.AddInt(k)
+		}
+		for k := 3*65536 + 2000; k < 3*65536+6000; k++ {
+			rr2.AddInt(k)
+		}
+		for k := 6 * 65535; k < 6*65535+1000; k++ {
+			rr2.AddInt(k)
+		}
+		for k := 7 * 65535; k < 7*65535+1000; k++ {
+			rr2.AddInt(k)
+		}
+		for k := 10 * 65535; k < 10*65535+5000; k++ {
+			rr2.AddInt(k)
+		}
+
+		correct := Xor(rr, rr2)
+		rr.Xor(rr2)
+
+		assert.True(t, correct.Equals(rr))
+	})
+
+	t.Run("xortest1", func(t *testing.T) {
+		V1 := make(map[int]bool)
+		V2 := make(map[int]bool)
+
+		rr := NewBitmap()
+		rr2 := NewBitmap()
+		// For the first 65536: rr2 has a bitmap container, and rr has
+		// an array container.
+		// We will check the union between a BitmapCintainer and an
+		// arrayContainer
+		for k := 0; k < 4000; k++ {
+			rr2.AddInt(k)
+			if k < 3500 {
+				V1[k] = true
+			}
+		}
+		for k := 3500; k < 4500; k++ {
+			rr.AddInt(k)
+		}
+		for k := 4000; k < 65000; k++ {
+			rr2.AddInt(k)
+			if k >= 4500 {
+				V1[k] = true
+			}
+		}
+
+		for k := 65536; k < 65536+30000; k++ {
+			rr.AddInt(k)
+		}
+
+		for k := 65536; k < 65536+50000; k++ {
+			rr2.AddInt(k)
+			if k >= 65536+30000 {
+				V1[k] = true
+			}
+		}
+
+		// In the 3rd node of each Roaring Bitmap, we have an
+		// ArrayContainer. So, we will try the union between two
+		// ArrayContainers.
+		for k := 4 * 65535; k < 4*65535+1000; k++ {
+			rr.AddInt(k)
+			if k >= (4*65535 + 800) {
+				V1[k] = true
+			}
+		}
+
+		for k := 4 * 65535; k < 4*65535+800; k++ {
+			rr2.AddInt(k)
+		}
+
+		for k := 6 * 65535; k < 6*65535+1000; k++ {
+			rr.AddInt(k)
+			V1[k] = true
+		}
+
+		for k := 7 * 65535; k < 7*65535+2000; k++ {
+			rr2.AddInt(k)
+			V1[k] = true
+		}
+
+		rrxor := Xor(rr, rr2)
+		valide := true
+
+		for _, i := range rrxor.ToArray() {
+			_, found := V1[int(i)]
+			if !found {
+				valide = false
+			}
+			V2[int(i)] = true
+		}
+		for k := range V1 {
+			_, found := V2[k]
+			if !found {
+				valide = false
+			}
+		}
+
+		assert.True(t, valide)
+	})
+}
+func TestXORtest4(t *testing.T) {
+	t.Run("XORtest 4", func(t *testing.T) {
+		rb := NewBitmap()
+		rb2 := NewBitmap()
+		counter := 0
+
+		for i := 0; i < 200000; i += 4 {
+			rb2.AddInt(i)
+			counter++
+		}
+
+		assert.EqualValues(t, counter, rb2.GetCardinality())
+
+		for i := 200000; i < 400000; i += 14 {
+			rb2.AddInt(i)
+			counter++
+		}
+
+		assert.EqualValues(t, counter, rb2.GetCardinality())
+
+		rb2card := rb2.GetCardinality()
+		assert.EqualValues(t, counter, rb2card)
+
+		// check or against an empty bitmap
+		xorresult := Xor(rb, rb2)
+		assert.EqualValues(t, counter, xorresult.GetCardinality())
+		off := Or(rb2, rb)
+
+		assert.EqualValues(t, counter, off.GetCardinality())
+		assert.True(t, xorresult.Equals(off))
+
+		assert.Equal(t, xorresult.GetCardinality(), rb2card)
+		for i := 500000; i < 600000; i += 14 {
+			rb.AddInt(i)
+		}
+		for i := 200000; i < 400000; i += 3 {
+			rb2.AddInt(i)
+		}
+		// check or against an empty bitmap
+		xorresult2 := Xor(rb, rb2)
+
+		assert.EqualValues(t, xorresult.GetCardinality(), rb2card)
+		assert.Equal(t, xorresult2.GetCardinality(), rb2.GetCardinality()+rb.GetCardinality())
+
+		rb.Xor(rb2)
+		assert.True(t, xorresult2.Equals(rb))
+	})
+	// need to add the massives
+}
+
+func TestNextMany(t *testing.T) {
+	count := 70000
+
+	for _, gap := range []uint64{1, 8, 32, 128} {
+		expected := make([]uint64, count)
+		{
+			v := uint64(0)
+			for i := range expected {
+				expected[i] = v
+				v += gap
+			}
+		}
+		bm := BitmapOf(expected...)
+		for _, bufSize := range []int{1, 64, 4096, count} {
+			buf := make([]uint64, bufSize)
+			it := bm.ManyIterator()
+			cur := 0
+			for n := it.NextMany(buf); n != 0; n = it.NextMany(buf) {
+				// much faster tests... (10s -> 5ms)
+				if cur+n > count {
+					assert.LessOrEqual(t, count, cur+n)
+				}
+
+				for i, v := range buf[:n] {
+					// much faster tests...
+					if v != expected[cur+i] {
+						assert.Equal(t, expected[cur+i], v)
+					}
+				}
+
+				cur += n
+			}
+
+			assert.Equal(t, count, cur)
+		}
+	}
+}
+
+func TestBigRandom(t *testing.T) {
+	rTest(t, 15)
+	rTest(t, 100)
+	rTest(t, 512)
+	rTest(t, 1023)
+	rTest(t, 1025)
+	rTest(t, 4095)
+	rTest(t, 4096)
+	rTest(t, 4097)
+	rTest(t, 65536)
+	rTest(t, 65536*16)
+}
+
+func rTest(t *testing.T, N int) {
+	log.Println("rtest N=", N)
+	for gap := 1; gap <= 65536; gap *= 2 {
+		bs1 := bitset.New(0)
+		rb1 := NewBitmap()
+		for x := 0; x <= N; x += gap {
+			bs1.Set(uint(x))
+			rb1.AddInt(x)
+		}
+
+		assert.EqualValues(t, rb1.GetCardinality(), bs1.Count())
+		assert.True(t, equalsBitSet(bs1, rb1))
+
+		for offset := 1; offset <= gap; offset *= 2 {
+			bs2 := bitset.New(0)
+			rb2 := NewBitmap()
+			for x := 0; x <= N; x += gap {
+				bs2.Set(uint(x + offset))
+				rb2.AddInt(x + offset)
+			}
+
+			assert.EqualValues(t, rb2.GetCardinality(), bs2.Count())
+			assert.True(t, equalsBitSet(bs2, rb2))
+
+			clonebs1 := bs1.Clone()
+			clonebs1.InPlaceIntersection(bs2)
+
+			if !equalsBitSet(clonebs1, And(rb1, rb2)) {
+				v := rb1.Clone()
+				v.And(rb2)
+				assert.True(t, equalsBitSet(clonebs1, v))
+			}
+
+			// testing OR
+			clonebs1 = bs1.Clone()
+			clonebs1.InPlaceUnion(bs2)
+
+			assert.True(t, equalsBitSet(clonebs1, Or(rb1, rb2)))
+
+			// testing XOR
+			clonebs1 = bs1.Clone()
+			clonebs1.InPlaceSymmetricDifference(bs2)
+
+			assert.True(t, equalsBitSet(clonebs1, Xor(rb1, rb2)))
+
+			// testing NOTAND
+			clonebs1 = bs1.Clone()
+			clonebs1.InPlaceDifference(bs2)
+
+			assert.True(t, equalsBitSet(clonebs1, AndNot(rb1, rb2)))
+		}
+	}
+}
+
+func equalsBitSet(a *bitset.BitSet, b *Bitmap) bool {
+	for i, e := a.NextSet(0); e; i, e = a.NextSet(i + 1) {
+		if !b.ContainsInt(int(i)) {
+			return false
+		}
+	}
+	i := b.Iterator()
+	for i.HasNext() {
+		if !a.Test(uint(i.Next())) {
+			return false
+		}
+	}
+	return true
+}
+
+func TestFlipBigA(t *testing.T) {
+	numCases := 1000
+	bs := bitset.New(0)
+	checkTime := 2.0
+	rb1 := NewBitmap()
+	rb2 := NewBitmap()
+
+	for i := 0; i < numCases; i++ {
+		start := rand.Intn(65536 * 20)
+		end := rand.Intn(65536 * 20)
+		if rand.Float64() < 0.1 {
+			end = start + rand.Intn(100)
+		}
+
+		if (i & 1) == 0 {
+			rb2 = FlipInt(rb1, start, end)
+			// tweak the other, catch bad sharing
+			rb1.FlipInt(rand.Intn(65536*20), rand.Intn(65536*20))
+		} else {
+			rb1 = FlipInt(rb2, start, end)
+			rb2.FlipInt(rand.Intn(65536*20), rand.Intn(65536*20))
+		}
+
+		if start < end {
+			FlipRange(start, end, bs) // throws exception
+		}
+		// otherwise
+		// insert some more ANDs to keep things sparser
+		if (rand.Float64() < 0.2) && (i&1) == 0 {
+			mask := NewBitmap()
+			mask1 := bitset.New(0)
+			startM := rand.Intn(65536 * 20)
+			endM := startM + 100000
+			mask.FlipInt(startM, endM)
+			FlipRange(startM, endM, mask1)
+			mask.FlipInt(0, 65536*20+100000)
+			FlipRange(0, 65536*20+100000, mask1)
+			rb2.And(mask)
+			bs.InPlaceIntersection(mask1)
+		}
+
+		if float64(i) > checkTime {
+			var rb *Bitmap
+
+			if (i & 1) == 0 {
+				rb = rb2
+			} else {
+				rb = rb1
+			}
+
+			assert.True(t, equalsBitSet(bs, rb))
+			checkTime *= 1.5
+		}
+	}
+}
+
+func TestNextManyOfAddRangeAcrossContainers(t *testing.T) {
+	rb := NewBitmap()
+	rb.AddRange(65530, 65540)
+	expectedCard := 10
+	expected := []uint64{65530, 65531, 65532, 65533, 65534, 65535, 65536, 65537, 65538, 65539, 0}
+
+	// test where all values can be returned in a single buffer
+	it := rb.ManyIterator()
+	buf := make([]uint64, 11)
+	n := it.NextMany(buf)
+
+	assert.Equal(t, expectedCard, n)
+
+	for i, e := range expected {
+		assert.Equal(t, e, buf[i])
+	}
+
+	// test where buf is size 1, so many iterations
+	it = rb.ManyIterator()
+	n = 0
+	buf = make([]uint64, 1)
+
+	for i := 0; i < expectedCard; i++ {
+		n = it.NextMany(buf)
+
+		assert.Equal(t, 1, n)
+		assert.Equal(t, expected[i], buf[0])
+	}
+
+	n = it.NextMany(buf)
+	assert.Equal(t, 0, n)
+}
+
+func TestDoubleAdd(t *testing.T) {
+	t.Run("doubleadd ", func(t *testing.T) {
+		rb := NewBitmap()
+		rb.AddRange(65533, 65536)
+		rb.AddRange(65530, 65536)
+		rb2 := NewBitmap()
+		rb2.AddRange(65530, 65536)
+
+		assert.True(t, rb.Equals(rb2))
+
+		rb2.RemoveRange(65530, 65536)
+
+		assert.EqualValues(t, 0, rb2.GetCardinality())
+	})
+
+	t.Run("doubleadd2 ", func(t *testing.T) {
+		rb := NewBitmap()
+		rb.AddRange(65533, 65536*20)
+		rb.AddRange(65530, 65536*20)
+		rb2 := NewBitmap()
+		rb2.AddRange(65530, 65536*20)
+
+		assert.True(t, rb.Equals(rb2))
+
+		rb2.RemoveRange(65530, 65536*20)
+
+		assert.EqualValues(t, 0, rb2.GetCardinality())
+	})
+
+	t.Run("doubleadd3 ", func(t *testing.T) {
+		rb := NewBitmap()
+		rb.AddRange(65533, 65536*20+10)
+		rb.AddRange(65530, 65536*20+10)
+		rb2 := NewBitmap()
+		rb2.AddRange(65530, 65536*20+10)
+
+		assert.True(t, rb.Equals(rb2))
+
+		rb2.RemoveRange(65530, 65536*20+1)
+
+		assert.EqualValues(t, 9, rb2.GetCardinality())
+	})
+
+	t.Run("doubleadd4 ", func(t *testing.T) {
+		rb := NewBitmap()
+		rb.AddRange(65533, 65536*20)
+		rb.RemoveRange(65533+5, 65536*20)
+
+		assert.EqualValues(t, 5, rb.GetCardinality())
+	})
+
+	t.Run("doubleadd5 ", func(t *testing.T) {
+		rb := NewBitmap()
+		rb.AddRange(65533, 65536*20)
+		rb.RemoveRange(65533+5, 65536*20-5)
+
+		assert.EqualValues(t, 10, rb.GetCardinality())
+	})
+
+	t.Run("doubleadd6 ", func(t *testing.T) {
+		rb := NewBitmap()
+		rb.AddRange(65533, 65536*20-5)
+		rb.RemoveRange(65533+5, 65536*20-10)
+
+		assert.EqualValues(t, 10, rb.GetCardinality())
+	})
+
+	t.Run("doubleadd7 ", func(t *testing.T) {
+		rb := NewBitmap()
+		rb.AddRange(65533, 65536*20+1)
+		rb.RemoveRange(65533+1, 65536*20)
+
+		assert.EqualValues(t, 2, rb.GetCardinality())
+	})
+
+	t.Run("AndNotBug01 ", func(t *testing.T) {
+		rb1 := NewBitmap()
+		rb1.AddRange(0, 60000)
+		rb2 := NewBitmap()
+		rb2.AddRange(60000-10, 60000+10)
+		rb2.AndNot(rb1)
+		rb3 := NewBitmap()
+		rb3.AddRange(60000, 60000+10)
+
+		assert.True(t, rb2.Equals(rb3))
+	})
+}
+
+func TestAndNot(t *testing.T) {
+	rr := NewBitmap()
+
+	for k := 4000; k < 4256; k++ {
+		rr.AddInt(k)
+	}
+	for k := 65536; k < 65536+4000; k++ {
+		rr.AddInt(k)
+	}
+	for k := 3 * 65536; k < 3*65536+9000; k++ {
+		rr.AddInt(k)
+	}
+	for k := 4 * 65535; k < 4*65535+7000; k++ {
+		rr.AddInt(k)
+	}
+	for k := 6 * 65535; k < 6*65535+10000; k++ {
+		rr.AddInt(k)
+	}
+	for k := 8 * 65535; k < 8*65535+1000; k++ {
+		rr.AddInt(k)
+	}
+	for k := 9 * 65535; k < 9*65535+30000; k++ {
+		rr.AddInt(k)
+	}
+
+	rr2 := NewBitmap()
+
+	for k := 4000; k < 4256; k++ {
+		rr2.AddInt(k)
+	}
+	for k := 65536; k < 65536+4000; k++ {
+		rr2.AddInt(k)
+	}
+	for k := 3*65536 + 2000; k < 3*65536+6000; k++ {
+		rr2.AddInt(k)
+	}
+	for k := 6 * 65535; k < 6*65535+1000; k++ {
+		rr2.AddInt(k)
+	}
+	for k := 7 * 65535; k < 7*65535+1000; k++ {
+		rr2.AddInt(k)
+	}
+	for k := 10 * 65535; k < 10*65535+5000; k++ {
+		rr2.AddInt(k)
+	}
+
+	correct := AndNot(rr, rr2)
+	rr.AndNot(rr2)
+
+	assert.True(t, correct.Equals(rr))
+}
+
+func TestStats(t *testing.T) {
+	t.Run("Test Stats with empty bitmap", func(t *testing.T) {
+		expectedStats := roaring.Statistics{}
+		rr := NewBitmap()
+
+		assert.EqualValues(t, expectedStats, rr.Stats())
+	})
+
+	t.Run("Test Stats with bitmap Container", func(t *testing.T) {
+		// Given a bitmap that should have a single bitmap container
+		expectedStats := roaring.Statistics{
+			Cardinality: 60000,
+			Containers:  1,
+
+			BitmapContainers:      1,
+			BitmapContainerValues: 60000,
+			BitmapContainerBytes:  8192,
+
+			RunContainers:      0,
+			RunContainerBytes:  0,
+			RunContainerValues: 0,
+		}
+
+		rr := NewBitmap()
+
+		for i := uint64(0); i < 60000; i++ {
+			rr.Add(i)
+		}
+
+		assert.EqualValues(t, expectedStats, rr.Stats())
+	})
+
+	t.Run("Test Stats with run Container", func(t *testing.T) {
+		// Given that we should have a single run container
+		intSize := int(unsafe.Sizeof(int(0)))
+		var runContainerBytes uint64
+		if intSize == 4 {
+			runContainerBytes = 40
+		} else {
+			runContainerBytes = 52
+		}
+
+		expectedStats := roaring.Statistics{
+			Cardinality: 60000,
+			Containers:  1,
+
+			BitmapContainers:      0,
+			BitmapContainerValues: 0,
+			BitmapContainerBytes:  0,
+
+			RunContainers:      1,
+			RunContainerBytes:  runContainerBytes,
+			RunContainerValues: 60000,
+		}
+
+		rr := NewBitmap()
+		rr.AddRange(0, 60000)
+
+		assert.EqualValues(t, expectedStats, rr.Stats())
+	})
+
+	t.Run("Test Stats with Array Container", func(t *testing.T) {
+		// Given a bitmap that should have a single array container
+		expectedStats := roaring.Statistics{
+			Cardinality: 2,
+			Containers:  1,
+
+			ArrayContainers:      1,
+			ArrayContainerValues: 2,
+			ArrayContainerBytes:  4,
+		}
+		rr := NewBitmap()
+		rr.Add(2)
+		rr.Add(4)
+
+		assert.EqualValues(t, expectedStats, rr.Stats())
+	})
+}
+
+func TestFlipVerySmall(t *testing.T) {
+	rb := NewBitmap()
+	rb.Flip(0, 10) // got [0,9], card is 10
+	rb.Flip(0, 1)  // give back the number 0, card goes to 9
+	rbcard := rb.GetCardinality()
+
+	assert.EqualValues(t, 9, rbcard)
+}
+
+func TestPackageFlipMaxRangeEnd(t *testing.T) {
+	var empty Bitmap
+	flipped := Flip(&empty, 0, roaring.MaxRange)
+
+	assert.EqualValues(t, roaring.MaxRange, flipped.GetCardinality())
+}
+
+func TestBitmapFlipMaxRangeEnd(t *testing.T) {
+	var bm Bitmap
+	bm.Flip(0, roaring.MaxRange)
+
+	assert.EqualValues(t, roaring.MaxRange, bm.GetCardinality())
+}

--- a/roaring64/roaring64_test.go
+++ b/roaring64/roaring64_test.go
@@ -1875,3 +1875,23 @@ func TestBitmapFlipMaxRangeEnd(t *testing.T) {
 
 	assert.EqualValues(t, roaring.MaxRange, bm.GetCardinality())
 }
+
+func TestSerialization(t *testing.T) {
+        array := []uint64{123, 0xA00000000A, 0xAFFFFFFF7, 0xFFFFFFFFF}
+        bmp := New()
+        for _, v := range array {
+                bmp.Add(v)
+        }
+        assert.False(t, bmp.IsEmpty())
+
+        buf, err := bmp.MarshalBinary()
+        assert.Nil(t, err)
+        assert.NotNil(t, buf)
+
+        newBmp := New()
+        err = newBmp.UnmarshalBinary(buf)
+        assert.Nil(t, err)
+
+        assert.True(t, newBmp.Equals(bmp))
+}
+

--- a/roaring64/roaring64_test.go
+++ b/roaring64/roaring64_test.go
@@ -1076,12 +1076,12 @@ func TestBitmap(t *testing.T) {
 	})
 
 	t.Run("ortest2", func(t *testing.T) {
-		arrayrr := make([]uint32, 4000+4000+2)
+		arrayrr := make([]uint64, 4000+4000+2)
 		pos := 0
 		rr := NewBitmap()
 		for k := 0; k < 4000; k++ {
 			rr.AddInt(k)
-			arrayrr[pos] = uint32(k)
+			arrayrr[pos] = uint64(k)
 			pos++
 		}
 		rr.AddInt(100000)
@@ -1089,7 +1089,7 @@ func TestBitmap(t *testing.T) {
 		rr2 := NewBitmap()
 		for k := 4000; k < 8000; k++ {
 			rr2.AddInt(k)
-			arrayrr[pos] = uint32(k)
+			arrayrr[pos] = uint64(k)
 			pos++
 		}
 

--- a/roaring64/roaring64cow_test.go
+++ b/roaring64/roaring64cow_test.go
@@ -58,7 +58,7 @@ func TestCloneOfCOWRange(t *testing.T) {
 }
 
 func TestRoaringBitmapBitmapOfCOW(t *testing.T) {
-	array := []uint64{5580, 33722, 44031, 57276, 83097}
+	array := []uint64{5580, 33722, 44031, 57276, 83097, 234294967296, 195839473298, 14000000000000000100}
 	bmp := BitmapOf(array...)
 	bmp.SetCopyOnWrite(true)
 
@@ -66,7 +66,7 @@ func TestRoaringBitmapBitmapOfCOW(t *testing.T) {
 }
 
 func TestRoaringBitmapAddCOW(t *testing.T) {
-	array := []uint64{5580, 33722, 44031, 57276, 83097}
+	array := []uint64{5580, 33722, 44031, 57276, 83097, 234294967296, 195839473298, 14000000000000000100}
 	bmp := New()
 	bmp.SetCopyOnWrite(true)
 	for _, v := range array {

--- a/roaring64/roaring64cow_test.go
+++ b/roaring64/roaring64cow_test.go
@@ -1,89 +1,74 @@
 package roaring64
 
 import (
+	"bytes"
 	"log"
-	"math"
 	"math/rand"
 	"strconv"
 	"testing"
-	"unsafe"
 
-	"github.com/RoaringBitmap/roaring"
 	"github.com/stretchr/testify/assert"
 	"github.com/willf/bitset"
 )
 
-func TestRoaringIntervalCheck(t *testing.T) {
-	r := BitmapOf(1, 2, 3, 1000)
-	rangeb := New()
-	rangeb.AddRange(10, 1000+1)
+func TestCloneOfCOW(t *testing.T) {
+	rb1 := NewBitmap()
+	rb1.SetCopyOnWrite(true)
+	rb1.Add(uint64(10))
+	rb1.Add(uint64(12))
+	rb1.Remove(uint64(12))
 
-	assert.True(t, r.Intersects(rangeb))
+	rb2 := rb1.Clone()
 
-	rangeb2 := New()
-	rangeb2.AddRange(10, 1000)
+	rb3 := rb1.Clone()
 
-	assert.False(t, r.Intersects(rangeb2))
+	rb2.Remove(uint64(10))
+
+        for i := uint64(100); i < 200; i++ {
+	    rb3.Add(i)
+        }
+
+	assert.True(t, rb2.IsEmpty())
+	assert.False(t, rb1.IsEmpty())
+	assert.EqualValues(t, 100+1, rb3.GetCardinality())
+	assert.True(t, rb1.Contains(uint64(10)))
+	assert.EqualValues(t, 1, rb1.GetCardinality())
 }
 
-func TestRoaringRangeEnd(t *testing.T) {
-	r := New()
-	r.Add(roaring.MaxUint32)
-	assert.EqualValues(t, 1, r.GetCardinality())
+func TestCloneOfCOWRange(t *testing.T) {
+	rb1 := NewBitmap()
+	rb1.SetCopyOnWrite(true)
+	rb1.Add(uint64(10))
+	rb1.Add(uint64(12))
+	rb1.Remove(uint64(12))
 
-	r.RemoveRange(0, roaring.MaxUint32)
-	assert.EqualValues(t, 1, r.GetCardinality())
+	rb2 := rb1.Clone()
 
-	r.RemoveRange(0, math.MaxUint64)
-	assert.EqualValues(t, 0, r.GetCardinality())
+	rb3 := rb1.Clone()
 
-	r.Add(roaring.MaxUint32)
-	assert.EqualValues(t, 1, r.GetCardinality())
+	rb2.Remove(uint64(10))
 
-	r.RemoveRange(0, 0x100000001)
-	assert.EqualValues(t, 0, r.GetCardinality())
+	rb3.AddRange(uint64(100), uint64(200))
 
-	r.Add(roaring.MaxUint32)
-	assert.EqualValues(t, 1, r.GetCardinality())
-
-	r.RemoveRange(0, 0x100000000)
-	assert.EqualValues(t, 0, r.GetCardinality())
+	assert.True(t, rb2.IsEmpty())
+	assert.False(t, rb1.IsEmpty())
+	assert.EqualValues(t, 100+1, rb3.GetCardinality())
+	assert.True(t, rb1.Contains(uint64(10)))
+	assert.EqualValues(t, 1, rb1.GetCardinality())
 }
 
-func TestFirstLast(t *testing.T) {
-	bm := New()
-	bm.AddInt(2)
-	bm.AddInt(4)
-	bm.AddInt(8)
-
-	assert.EqualValues(t, 2, bm.Minimum())
-	assert.EqualValues(t, 8, bm.Maximum())
-
-	i := 1 << 5
-
-	for ; i < (1 << 17); i++ {
-		bm.AddInt(i)
-
-		assert.EqualValues(t, 2, bm.Minimum())
-		assert.EqualValues(t, i, bm.Maximum())
-	}
-
-	bm.RunOptimize()
-
-	assert.EqualValues(t, 2, bm.Minimum())
-	assert.EqualValues(t, i-1, bm.Maximum())
-}
-
-func TestRoaringBitmapBitmapOf(t *testing.T) {
+func TestRoaringBitmapBitmapOfCOW(t *testing.T) {
 	array := []uint64{5580, 33722, 44031, 57276, 83097}
 	bmp := BitmapOf(array...)
+	bmp.SetCopyOnWrite(true)
 
 	assert.EqualValues(t, len(array), bmp.GetCardinality())
 }
 
-func TestRoaringBitmapAdd(t *testing.T) {
+func TestRoaringBitmapAddCOW(t *testing.T) {
 	array := []uint64{5580, 33722, 44031, 57276, 83097}
 	bmp := New()
+	bmp.SetCopyOnWrite(true)
 	for _, v := range array {
 		bmp.Add(v)
 	}
@@ -91,42 +76,43 @@ func TestRoaringBitmapAdd(t *testing.T) {
 	assert.EqualValues(t, len(array), bmp.GetCardinality())
 }
 
-func TestRoaringBitmapAddMany(t *testing.T) {
+func TestRoaringBitmapAddManyCOW(t *testing.T) {
 	array := []uint64{5580, 33722, 44031, 57276, 83097}
 	bmp := NewBitmap()
+	bmp.SetCopyOnWrite(true)
+
 	bmp.AddMany(array)
 
 	assert.EqualValues(t, len(array), bmp.GetCardinality())
 }
 
 // https://github.com/RoaringBitmap/roaring/issues/64
-func TestFlip64(t *testing.T) {
+func TestFlip64COW(t *testing.T) {
 	bm := New()
+	bm.SetCopyOnWrite(true)
+
 	bm.AddInt(0)
-	bm.Flip(1, 2)
+	bm.Flip(uint64(1), uint64(2))
 	i := bm.Iterator()
 
-	if assert.True(t, i.HasNext()) {
-		assert.EqualValues(t, 0, i.Next())
-		if assert.True(t, i.HasNext()) {
-			assert.EqualValues(t, 1, i.Next())
-			assert.False(t, i.HasNext())
-		}
-	}
+	assert.False(t, i.Next() != 0 || i.Next() != 1 || i.HasNext())
 }
 
 // https://github.com/RoaringBitmap/roaring/issues/64
-func TestFlip64Off(t *testing.T) {
+func TestFlip64OffCOW(t *testing.T) {
 	bm := New()
+	bm.SetCopyOnWrite(true)
+
 	bm.AddInt(10)
-	bm.Flip(11, 12)
+	bm.Flip(uint64(11), uint64(12))
 	i := bm.Iterator()
 
 	assert.False(t, i.Next() != 10 || i.Next() != 11 || i.HasNext())
 }
 
-func TestStringer(t *testing.T) {
+func TestStringerCOW(t *testing.T) {
 	v := NewBitmap()
+	v.SetCopyOnWrite(true)
 	for i := uint64(0); i < 10; i++ {
 		v.Add(i)
 	}
@@ -138,12 +124,15 @@ func TestStringer(t *testing.T) {
 	assert.Equal(t, "{0,1,2,3,4,5,6,7,8,9}", v.String())
 }
 
-func TestFastCard(t *testing.T) {
+func TestFastCardCOW(t *testing.T) {
 	bm := NewBitmap()
-	bm.Add(1)
-	bm.AddRange(21, 260000)
+	bm.SetCopyOnWrite(true)
+	bm.Add(uint64(1))
+	bm.AddRange(uint64(21), uint64(260000))
+
 	bm2 := NewBitmap()
-	bm2.Add(25)
+	bm2.SetCopyOnWrite(true)
+	bm2.Add(uint64(25))
 
 	assert.EqualValues(t, 1, bm2.AndCardinality(bm))
 	assert.Equal(t, bm.GetCardinality(), bm2.OrCardinality(bm))
@@ -162,70 +151,71 @@ func TestFastCard(t *testing.T) {
 	assert.Equal(t, bm.GetCardinality(), bm2.OrCardinality(bm))
 }
 
-func TestIntersects1(t *testing.T) {
+func TestIntersects1COW(t *testing.T) {
 	bm := NewBitmap()
-	bm.Add(1)
-	bm.AddRange(21, 26)
+	bm.SetCopyOnWrite(true)
+	bm.Add(uint64(1))
+	bm.AddRange(uint64(21), uint64(26))
+
 	bm2 := NewBitmap()
-	bm2.Add(25)
+	bm2.SetCopyOnWrite(true)
+	bm2.Add(uint64(25))
 
 	assert.True(t, bm2.Intersects(bm))
 
-	bm.Remove(25)
-	assert.Equal(t, false, bm2.Intersects(bm))
+	bm.Remove(uint64(25))
+	assert.False(t, bm2.Intersects(bm))
 
-	bm.AddRange(1, 100000)
+	bm.AddRange(uint64(1), uint64(100000))
 	assert.True(t, bm2.Intersects(bm))
 }
 
-func TestRangePanic(t *testing.T) {
+func TestRangePanicCOW(t *testing.T) {
 	bm := NewBitmap()
-	bm.Add(1)
-	bm.AddRange(21, 26)
-	bm.AddRange(9, 14)
-	bm.AddRange(11, 16)
+	bm.SetCopyOnWrite(true)
+	bm.Add(uint64(1))
+	bm.AddRange(uint64(21), uint64(26))
+	bm.AddRange(uint64(9), uint64(14))
+	bm.AddRange(uint64(11), uint64(16))
 }
 
-func TestRangeRemoval(t *testing.T) {
+func TestRangeRemovalCOW(t *testing.T) {
 	bm := NewBitmap()
-	bm.Add(1)
-	bm.AddRange(21, 26)
-	bm.AddRange(9, 14)
-	bm.RemoveRange(11, 16)
-	bm.RemoveRange(1, 26)
-	c := bm.GetCardinality()
+	bm.SetCopyOnWrite(true)
+	bm.Add(uint64(1))
+	bm.AddRange(uint64(21), uint64(26))
+	bm.AddRange(uint64(9), uint64(14))
+	bm.RemoveRange(uint64(11), uint64(16))
+	bm.RemoveRange(uint64(1), uint64(26))
 
-	assert.EqualValues(t, 0, c)
+	assert.EqualValues(t, 0, bm.GetCardinality())
 
-	bm.AddRange(1, 10000)
-	c = bm.GetCardinality()
+	bm.AddRange(uint64(1), uint64(10000))
+	assert.EqualValues(t, 10000-1, bm.GetCardinality())
 
-	assert.EqualValues(t, 10000-1, c)
-
-	bm.RemoveRange(1, 10000)
-	c = bm.GetCardinality()
-
-	assert.EqualValues(t, 0, c)
+	bm.RemoveRange(uint64(1), uint64(10000))
+	assert.EqualValues(t, 0, bm.GetCardinality())
 }
 
-func TestRangeRemovalFromContent(t *testing.T) {
+func TestRangeRemovalFromContentCOW(t *testing.T) {
 	bm := NewBitmap()
+	bm.SetCopyOnWrite(true)
 	for i := 100; i < 10000; i++ {
 		bm.AddInt(i * 3)
 	}
-	bm.AddRange(21, 26)
-	bm.AddRange(9, 14)
-	bm.RemoveRange(11, 16)
-	bm.RemoveRange(0, 30000)
-	c := bm.GetCardinality()
+	bm.AddRange(uint64(21), uint64(26))
+	bm.AddRange(uint64(9), uint64(14))
+	bm.RemoveRange(uint64(11), uint64(16))
+	bm.RemoveRange(uint64(0), uint64(30000))
 
-	assert.EqualValues(t, 00, c)
+	assert.EqualValues(t, 0, bm.GetCardinality())
 }
 
-func TestFlipOnEmpty(t *testing.T) {
+func TestFlipOnEmptyCOW(t *testing.T) {
 	t.Run("TestFlipOnEmpty in-place", func(t *testing.T) {
 		bm := NewBitmap()
-		bm.Flip(0, 10)
+		bm.SetCopyOnWrite(true)
+		bm.Flip(uint64(0), uint64(10))
 		c := bm.GetCardinality()
 
 		assert.EqualValues(t, 10, c)
@@ -233,6 +223,7 @@ func TestFlipOnEmpty(t *testing.T) {
 
 	t.Run("TestFlipOnEmpty, generating new result", func(t *testing.T) {
 		bm := NewBitmap()
+		bm.SetCopyOnWrite(true)
 		bm = Flip(bm, 0, 10)
 		c := bm.GetCardinality()
 
@@ -240,26 +231,17 @@ func TestFlipOnEmpty(t *testing.T) {
 	})
 }
 
-func TestBitmapRank2(t *testing.T) {
-	r := NewBitmap()
-	for i := uint64(1); i < 8194; i += 2 {
-		r.Add(i)
-	}
-
-	rank := r.Rank(63)
-	assert.EqualValues(t, 32, rank)
-}
-
-func TestBitmapRank(t *testing.T) {
-	for n := uint64(1); n <= 1048576; n *= 2 {
-		t.Run("rank tests"+strconv.Itoa(int(n)), func(t *testing.T) {
+func TestBitmapRankCOW(t *testing.T) {
+	for N := uint64(1); N <= 1048576; N *= 2 {
+		t.Run("rank tests"+strconv.Itoa(int(N)), func(t *testing.T) {
 			for gap := uint64(1); gap <= 65536; gap *= 2 {
 				rb1 := NewBitmap()
-				for x := uint64(0); x <= n; x += gap {
+				rb1.SetCopyOnWrite(true)
+				for x := uint64(0); x <= N; x += gap {
 					rb1.Add(x)
 				}
-				for y := uint64(0); y <= n; y++ {
-					if rb1.Rank(y) != (y+1+gap-1)/gap {
+				for y := uint64(0); y <= N; y++ {
+					if rb1.Rank(y) != uint64((y+1+gap-1)/gap) {
 						assert.Equal(t, (y+1+gap-1)/gap, rb1.Rank(y))
 					}
 				}
@@ -268,15 +250,16 @@ func TestBitmapRank(t *testing.T) {
 	}
 }
 
-func TestBitmapSelect(t *testing.T) {
-	for n := uint64(1); n <= 1048576; n *= 2 {
-		t.Run("rank tests"+strconv.Itoa(int(n)), func(t *testing.T) {
+func TestBitmapSelectCOW(t *testing.T) {
+	for N := uint64(1); N <= 1048576; N *= 2 {
+		t.Run("rank tests"+strconv.Itoa(int(N)), func(t *testing.T) {
 			for gap := uint64(1); gap <= 65536; gap *= 2 {
 				rb1 := NewBitmap()
-				for x := uint64(0); x <= n; x += gap {
+				rb1.SetCopyOnWrite(true)
+				for x := uint64(0); x <= N; x += gap {
 					rb1.Add(x)
 				}
-				for y := uint64(0); y <= n/gap; y++ {
+				for y := uint64(0); y <= N/gap; y++ {
 					expectedInt := y * gap
 					i, err := rb1.Select(y)
 					if err != nil {
@@ -293,13 +276,15 @@ func TestBitmapSelect(t *testing.T) {
 }
 
 // some extra tests
-func TestBitmapExtra(t *testing.T) {
-	for n := uint64(1); n <= 65536; n *= 2 {
-		t.Run("extra tests"+strconv.Itoa(int(n)), func(t *testing.T) {
+func TestBitmapExtraCOW(t *testing.T) {
+	for N := uint64(1); N <= 65536; N *= 2 {
+		t.Run("extra tests"+strconv.Itoa(int(N)), func(t *testing.T) {
 			for gap := uint64(1); gap <= 65536; gap *= 2 {
 				bs1 := bitset.New(0)
 				rb1 := NewBitmap()
-				for x := uint64(0); x <= n; x += gap {
+				rb1.SetCopyOnWrite(true)
+
+				for x := uint64(0); x <= N; x += gap {
 					bs1.Set(uint(x))
 					rb1.Add(x)
 				}
@@ -310,7 +295,9 @@ func TestBitmapExtra(t *testing.T) {
 				for offset := uint64(1); offset <= gap; offset *= 2 {
 					bs2 := bitset.New(0)
 					rb2 := NewBitmap()
-					for x := uint64(0); x <= n; x += gap {
+					rb2.SetCopyOnWrite(true)
+
+					for x := uint64(0); x <= N; x += gap {
 						bs2.Set(uint(x + offset))
 						rb2.Add(x + offset)
 					}
@@ -320,7 +307,6 @@ func TestBitmapExtra(t *testing.T) {
 
 					clonebs1 := bs1.Clone()
 					clonebs1.InPlaceIntersection(bs2)
-
 					if !equalsBitSet(clonebs1, And(rb1, rb2)) {
 						v := rb1.Clone()
 						v.And(rb2)
@@ -333,14 +319,17 @@ func TestBitmapExtra(t *testing.T) {
 					clonebs1.InPlaceUnion(bs2)
 
 					assert.True(t, equalsBitSet(clonebs1, Or(rb1, rb2)))
+
 					// testing XOR
 					clonebs1 = bs1.Clone()
 					clonebs1.InPlaceSymmetricDifference(bs2)
+
 					assert.True(t, equalsBitSet(clonebs1, Xor(rb1, rb2)))
 
-					// testing NOTAND
+					//testing NOTAND
 					clonebs1 = bs1.Clone()
 					clonebs1.InPlaceDifference(bs2)
+
 					assert.True(t, equalsBitSet(clonebs1, AndNot(rb1, rb2)))
 				}
 			}
@@ -348,57 +337,34 @@ func TestBitmapExtra(t *testing.T) {
 	}
 }
 
-func FlipRange(start, end int, bs *bitset.BitSet) {
-	for i := start; i < end; i++ {
-		bs.Flip(uint(i))
-	}
-}
-
-func TestBitmap(t *testing.T) {
+func TestBitmapCOW(t *testing.T) {
 	t.Run("Test Contains", func(t *testing.T) {
 		rbm1 := NewBitmap()
+		rbm1.SetCopyOnWrite(true)
 		for k := 0; k < 1000; k++ {
 			rbm1.AddInt(17 * k)
 		}
-
 		for k := 0; k < 17*1000; k++ {
-			assert.Equal(t, (k/17*17 == k), rbm1.ContainsInt(k))
+			assert.Equal(t, k/17*17 == k, rbm1.ContainsInt(k))
 		}
 	})
 
 	t.Run("Test Clone", func(t *testing.T) {
 		rb1 := NewBitmap()
-		rb1.Add(10)
+		rb1.SetCopyOnWrite(true)
+		rb1.Add(uint64(10))
 
 		rb2 := rb1.Clone()
-		rb2.Remove(10)
+		rb2.Remove(uint64(10))
 
-		assert.True(t, rb1.Contains(10))
-	})
-
-	t.Run("Test run array not equal", func(t *testing.T) {
-		rb := NewBitmap()
-		rb2 := NewBitmap()
-		rb.AddRange(0, 1<<16)
-		for i := 0; i < 10; i++ {
-			rb2.AddInt(i)
-		}
-
-		assert.EqualValues(t, 1<<16, rb.GetCardinality())
-		assert.EqualValues(t, 10, rb2.GetCardinality())
-		assert.False(t, rb.Equals(rb2))
-
-		rb.RunOptimize()
-		rb2.RunOptimize()
-
-		assert.EqualValues(t, 1<<16, rb.GetCardinality())
-		assert.EqualValues(t, 10, rb2.GetCardinality())
-		assert.False(t, rb.Equals(rb2))
+		assert.True(t, rb1.Contains(uint64(10)))
 	})
 
 	t.Run("Test ANDNOT4", func(t *testing.T) {
 		rb := NewBitmap()
+		rb.SetCopyOnWrite(true)
 		rb2 := NewBitmap()
+		rb2.SetCopyOnWrite(true)
 
 		for i := 0; i < 200000; i += 4 {
 			rb2.AddInt(i)
@@ -419,13 +385,15 @@ func TestBitmap(t *testing.T) {
 
 	t.Run("Test AND", func(t *testing.T) {
 		rr := NewBitmap()
+		rr.SetCopyOnWrite(true)
 		for k := 0; k < 4000; k++ {
 			rr.AddInt(k)
 		}
-		rr.Add(100000)
-		rr.Add(110000)
+		rr.Add(uint64(100000))
+		rr.Add(uint64(110000))
 		rr2 := NewBitmap()
-		rr2.Add(13)
+		rr2.SetCopyOnWrite(true)
+		rr2.Add(uint64(13))
 		rrand := And(rr, rr2)
 		array := rrand.ToArray()
 
@@ -441,6 +409,7 @@ func TestBitmap(t *testing.T) {
 
 	t.Run("Test AND 2", func(t *testing.T) {
 		rr := NewBitmap()
+		rr.SetCopyOnWrite(true)
 		for k := 4000; k < 4256; k++ {
 			rr.AddInt(k)
 		}
@@ -464,6 +433,7 @@ func TestBitmap(t *testing.T) {
 		}
 
 		rr2 := NewBitmap()
+		rr2.SetCopyOnWrite(true)
 		for k := 4000; k < 4256; k++ {
 			rr2.AddInt(k)
 		}
@@ -490,12 +460,14 @@ func TestBitmap(t *testing.T) {
 
 	t.Run("Test AND 2", func(t *testing.T) {
 		rr := NewBitmap()
+		rr.SetCopyOnWrite(true)
 		for k := 0; k < 4000; k++ {
 			rr.AddInt(k)
 		}
 		rr.AddInt(100000)
 		rr.AddInt(110000)
 		rr2 := NewBitmap()
+		rr2.SetCopyOnWrite(true)
 		rr2.AddInt(13)
 
 		rrand := And(rr, rr2)
@@ -507,7 +479,9 @@ func TestBitmap(t *testing.T) {
 
 	t.Run("Test AND 3a", func(t *testing.T) {
 		rr := NewBitmap()
+		rr.SetCopyOnWrite(true)
 		rr2 := NewBitmap()
+		rr2.SetCopyOnWrite(true)
 		for k := 6 * 65536; k < 6*65536+10000; k++ {
 			rr.AddInt(k)
 		}
@@ -521,9 +495,10 @@ func TestBitmap(t *testing.T) {
 
 	t.Run("Test AND 3", func(t *testing.T) {
 		var arrayand [11256]uint64
-		// 393,216
+		//393,216
 		pos := 0
 		rr := NewBitmap()
+		rr.SetCopyOnWrite(true)
 		for k := 4000; k < 4256; k++ {
 			rr.AddInt(k)
 		}
@@ -550,6 +525,7 @@ func TestBitmap(t *testing.T) {
 		}
 
 		rr2 := NewBitmap()
+		rr2.SetCopyOnWrite(true)
 		for k := 4000; k < 4256; k++ {
 			rr2.AddInt(k)
 			arrayand[pos] = uint64(k)
@@ -598,12 +574,13 @@ func TestBitmap(t *testing.T) {
 
 		assert.Equal(t, len(arrayres), len(arrayand))
 		assert.True(t, ok)
-
 	})
 
 	t.Run("Test AND 4", func(t *testing.T) {
 		rb := NewBitmap()
+		rb.SetCopyOnWrite(true)
 		rb2 := NewBitmap()
+		rb2.SetCopyOnWrite(true)
 
 		for i := 0; i < 200000; i += 4 {
 			rb2.AddInt(i)
@@ -611,7 +588,7 @@ func TestBitmap(t *testing.T) {
 		for i := 200000; i < 400000; i += 14 {
 			rb2.AddInt(i)
 		}
-		// TODO: Bitmap.And(bm,bm2)
+		//TODO: Bitmap.And(bm,bm2)
 		andresult := And(rb, rb2)
 		off := And(rb2, rb)
 
@@ -644,22 +621,25 @@ func TestBitmap(t *testing.T) {
 		assert.Equal(t, rb.GetCardinality(), rc.GetCardinality())
 	})
 
+
 	t.Run("or test", func(t *testing.T) {
 		rr := NewBitmap()
+		rr.SetCopyOnWrite(true)
 		for k := 0; k < 4000; k++ {
 			rr.AddInt(k)
 		}
 		rr2 := NewBitmap()
+		rr2.SetCopyOnWrite(true)
 		for k := 4000; k < 8000; k++ {
 			rr2.AddInt(k)
 		}
 		result := Or(rr, rr2)
-
 		assert.Equal(t, rr.GetCardinality()+rr2.GetCardinality(), result.GetCardinality())
 	})
 
 	t.Run("basic test", func(t *testing.T) {
 		rr := NewBitmap()
+		rr.SetCopyOnWrite(true)
 		var a [4002]uint64
 		pos := 0
 		for k := 0; k < 4000; k++ {
@@ -686,11 +666,13 @@ func TestBitmap(t *testing.T) {
 		assert.True(t, ok)
 	})
 
+
 	t.Run("cardinality test", func(t *testing.T) {
 		N := 1024
 		for gap := 7; gap < 100000; gap *= 10 {
 			for offset := 2; offset <= 1024; offset *= 2 {
 				rb := NewBitmap()
+				rb.SetCopyOnWrite(true)
 				for k := 0; k < N; k++ {
 					rb.AddInt(k * gap)
 					assert.EqualValues(t, k+1, rb.GetCardinality())
@@ -705,6 +687,7 @@ func TestBitmap(t *testing.T) {
 				}
 
 				rb2 := NewBitmap()
+				rb2.SetCopyOnWrite(true)
 
 				for k := 0; k < N; k++ {
 					rb2.AddInt(k * gap * offset)
@@ -717,7 +700,6 @@ func TestBitmap(t *testing.T) {
 					rb2.AddInt(k * gap * offset)
 					assert.EqualValues(t, N, rb2.GetCardinality())
 				}
-
 				assert.EqualValues(t, N/offset, And(rb, rb2).GetCardinality())
 				assert.EqualValues(t, 2*N-2*N/offset, Xor(rb, rb2).GetCardinality())
 				assert.EqualValues(t, 2*N-N/offset, Or(rb, rb2).GetCardinality())
@@ -727,6 +709,7 @@ func TestBitmap(t *testing.T) {
 
 	t.Run("clear test", func(t *testing.T) {
 		rb := NewBitmap()
+		rb.SetCopyOnWrite(true)
 		for i := 0; i < 200000; i += 7 {
 			// dense
 			rb.AddInt(i)
@@ -737,7 +720,9 @@ func TestBitmap(t *testing.T) {
 		}
 
 		rb2 := NewBitmap()
+		rb2.SetCopyOnWrite(true)
 		rb3 := NewBitmap()
+		rb3.SetCopyOnWrite(true)
 		for i := 0; i < 200000; i += 4 {
 			rb2.AddInt(i)
 		}
@@ -780,12 +765,14 @@ func TestBitmap(t *testing.T) {
 		assert.True(t, ok)
 	})
 
+
 	t.Run("flipTest1 ", func(t *testing.T) {
 		rb := NewBitmap()
-		rb.Flip(100000, 200000) // in-place on empty bitmap
+		rb.SetCopyOnWrite(true)
+		rb.Flip(uint64(100000), uint64(200000)) // in-place on empty bitmap
 		rbcard := rb.GetCardinality()
 
-		assert.EqualValues(t, 100000, rbcard)
+		assert.EqualValues(t, rbcard, 100000)
 
 		bs := bitset.New(20000 - 10000)
 		for i := uint(100000); i < 200000; i++ {
@@ -797,11 +784,12 @@ func TestBitmap(t *testing.T) {
 
 	t.Run("flipTest1A", func(t *testing.T) {
 		rb := NewBitmap()
+		rb.SetCopyOnWrite(true)
 		rb1 := Flip(rb, 100000, 200000)
 		rbcard := rb1.GetCardinality()
 
-		assert.EqualValues(t, 100000, rbcard)
-		assert.EqualValues(t, 0, rb.GetCardinality())
+		assert.EqualValues(t, rbcard, 100000)
+		assert.EqualValues(t, rb.GetCardinality(), 0)
 
 		bs := bitset.New(0)
 		assert.True(t, equalsBitSet(bs, rb))
@@ -815,10 +803,11 @@ func TestBitmap(t *testing.T) {
 
 	t.Run("flipTest2", func(t *testing.T) {
 		rb := NewBitmap()
-		rb.Flip(100000, 100000)
+		rb.SetCopyOnWrite(true)
+		rb.Flip(uint64(100000), uint64(100000))
 		rbcard := rb.GetCardinality()
 
-		assert.EqualValues(t, 0, rbcard)
+		assert.EqualValues(t, rbcard, 0)
 
 		bs := bitset.New(0)
 		assert.True(t, equalsBitSet(bs, rb))
@@ -826,13 +815,14 @@ func TestBitmap(t *testing.T) {
 
 	t.Run("flipTest2A", func(t *testing.T) {
 		rb := NewBitmap()
+		rb.SetCopyOnWrite(true)
 		rb1 := Flip(rb, 100000, 100000)
 
 		rb.AddInt(1)
 		rbcard := rb1.GetCardinality()
 
 		assert.EqualValues(t, 0, rbcard)
-		assert.EqualValues(t, 1, rb.GetCardinality())
+		assert.EqualValues(t, rb.GetCardinality(), 1)
 
 		bs := bitset.New(0)
 		assert.True(t, equalsBitSet(bs, rb1))
@@ -843,8 +833,9 @@ func TestBitmap(t *testing.T) {
 
 	t.Run("flipTest3A", func(t *testing.T) {
 		rb := NewBitmap()
-		rb.Flip(100000, 200000) // got 100k-199999
-		rb.Flip(100000, 199991) // give back 100k-199990
+		rb.SetCopyOnWrite(true)
+		rb.Flip(uint64(100000), uint64(200000)) // got 100k-199999
+		rb.Flip(uint64(100000), uint64(199991)) // give back 100k-199990
 		rbcard := rb.GetCardinality()
 
 		assert.EqualValues(t, 9, rbcard)
@@ -860,8 +851,9 @@ func TestBitmap(t *testing.T) {
 	t.Run("flipTest4A", func(t *testing.T) {
 		// fits evenly on both ends
 		rb := NewBitmap()
-		rb.Flip(100000, 200000) // got 100k-199999
-		rb.Flip(65536, 4*65536)
+		rb.SetCopyOnWrite(true)
+		rb.Flip(uint64(100000), uint64(200000)) // got 100k-199999
+		rb.Flip(uint64(65536), uint64(4*65536))
 		rbcard := rb.GetCardinality()
 
 		// 65536 to 99999 are 1s
@@ -884,8 +876,9 @@ func TestBitmap(t *testing.T) {
 		// fits evenly on small end, multiple
 		// containers
 		rb := NewBitmap()
-		rb.Flip(100000, 132000)
-		rb.Flip(65536, 120000)
+		rb.SetCopyOnWrite(true)
+		rb.Flip(uint64(100000), uint64(132000))
+		rb.Flip(uint64(65536), uint64(120000))
 		rbcard := rb.GetCardinality()
 
 		// 65536 to 99999 are 1s
@@ -906,9 +899,10 @@ func TestBitmap(t *testing.T) {
 
 	t.Run("flipTest6", func(t *testing.T) {
 		rb := NewBitmap()
+		rb.SetCopyOnWrite(true)
 		rb1 := Flip(rb, 100000, 132000)
 		rb2 := Flip(rb1, 65536, 120000)
-		// rbcard := rb2.GetCardinality()
+		//rbcard := rb2.GetCardinality()
 
 		bs := bitset.New(0)
 		for i := uint(65536); i < 100000; i++ {
@@ -923,11 +917,12 @@ func TestBitmap(t *testing.T) {
 
 	t.Run("flipTest6A", func(t *testing.T) {
 		rb := NewBitmap()
+		rb.SetCopyOnWrite(true)
 		rb1 := Flip(rb, 100000, 132000)
 		rb2 := Flip(rb1, 99000, 2*65536)
 		rbcard := rb2.GetCardinality()
 
-		assert.EqualValues(t, rbcard, 1928)
+		assert.EqualValues(t, 1928, rbcard)
 
 		bs := bitset.New(0)
 		for i := uint(99000); i < 100000; i++ {
@@ -936,19 +931,20 @@ func TestBitmap(t *testing.T) {
 		for i := uint(2 * 65536); i < 132000; i++ {
 			bs.Set(i)
 		}
+
 		assert.True(t, equalsBitSet(bs, rb2))
 	})
 
 	t.Run("flipTest7", func(t *testing.T) {
 		// within 1 word, first container
 		rb := NewBitmap()
-		rb.Flip(650, 132000)
-		rb.Flip(648, 651)
+		rb.SetCopyOnWrite(true)
+		rb.Flip(uint64(650), uint64(132000))
+		rb.Flip(uint64(648), uint64(651))
 		rbcard := rb.GetCardinality()
 
 		// 648, 649, 651-131999
-
-		assert.EqualValues(t, rbcard, 132000-651+2)
+		assert.EqualValues(t, 132000-651+2, rbcard)
 
 		bs := bitset.New(0)
 		bs.Set(648)
@@ -963,8 +959,9 @@ func TestBitmap(t *testing.T) {
 	t.Run("flipTestBig", func(t *testing.T) {
 		numCases := 1000
 		rb := NewBitmap()
+		rb.SetCopyOnWrite(true)
 		bs := bitset.New(0)
-		// Random r = new Random(3333);
+		//Random r = new Random(3333);
 		checkTime := 2.0
 
 		for i := 0; i < numCases; i++ {
@@ -981,12 +978,13 @@ func TestBitmap(t *testing.T) {
 			// insert some more ANDs to keep things sparser
 			if rand.Float64() < 0.2 {
 				mask := NewBitmap()
+				mask.SetCopyOnWrite(true)
 				mask1 := bitset.New(0)
 				startM := rand.Intn(65536 * 20)
 				endM := startM + 100000
 				mask.Flip(uint64(startM), uint64(endM))
 				FlipRange(startM, endM, mask1)
-				mask.Flip(0, 65536*20+100000)
+				mask.Flip(uint64(0), uint64(65536*20+100000))
 				FlipRange(0, 65536*20+100000, mask1)
 				rb.And(mask)
 				bs.InPlaceIntersection(mask1)
@@ -994,8 +992,8 @@ func TestBitmap(t *testing.T) {
 			// see if we can detect incorrectly shared containers
 			if rand.Float64() < 0.1 {
 				irrelevant := Flip(rb, 10, 100000)
-				irrelevant.Flip(5, 200000)
-				irrelevant.Flip(190000, 260000)
+				irrelevant.Flip(uint64(5), uint64(200000))
+				irrelevant.Flip(uint64(190000), uint64(260000))
 			}
 			if float64(i) > checkTime {
 				assert.True(t, equalsBitSet(bs, rb))
@@ -1006,12 +1004,14 @@ func TestBitmap(t *testing.T) {
 
 	t.Run("ortest", func(t *testing.T) {
 		rr := NewBitmap()
+		rr.SetCopyOnWrite(true)
 		for k := 0; k < 4000; k++ {
 			rr.AddInt(k)
 		}
 		rr.AddInt(100000)
 		rr.AddInt(110000)
 		rr2 := NewBitmap()
+		rr2.SetCopyOnWrite(true)
 		for k := 0; k < 4000; k++ {
 			rr2.AddInt(k)
 		}
@@ -1023,11 +1023,12 @@ func TestBitmap(t *testing.T) {
 		rr.Or(rr2)
 		arrayirr := rr.ToArray()
 
-		assert.Equal(t, array, arrayirr)
+		assert.True(t, IntsEquals(array, arrayirr))
 	})
 
 	t.Run("ORtest", func(t *testing.T) {
 		rr := NewBitmap()
+		rr.SetCopyOnWrite(true)
 		for k := 4000; k < 4256; k++ {
 			rr.AddInt(k)
 		}
@@ -1051,6 +1052,7 @@ func TestBitmap(t *testing.T) {
 		}
 
 		rr2 := NewBitmap()
+		rr2.SetCopyOnWrite(true)
 		for k := 4000; k < 4256; k++ {
 			rr2.AddInt(k)
 		}
@@ -1069,6 +1071,7 @@ func TestBitmap(t *testing.T) {
 		for k := 10 * 65535; k < 10*65535+5000; k++ {
 			rr2.AddInt(k)
 		}
+
 		correct := Or(rr, rr2)
 		rr.Or(rr2)
 
@@ -1079,6 +1082,7 @@ func TestBitmap(t *testing.T) {
 		arrayrr := make([]uint64, 4000+4000+2)
 		pos := 0
 		rr := NewBitmap()
+		rr.SetCopyOnWrite(true)
 		for k := 0; k < 4000; k++ {
 			rr.AddInt(k)
 			arrayrr[pos] = uint64(k)
@@ -1087,6 +1091,7 @@ func TestBitmap(t *testing.T) {
 		rr.AddInt(100000)
 		rr.AddInt(110000)
 		rr2 := NewBitmap()
+		rr2.SetCopyOnWrite(true)
 		for k := 4000; k < 8000; k++ {
 			rr2.AddInt(k)
 			arrayrr[pos] = uint64(k)
@@ -1099,10 +1104,9 @@ func TestBitmap(t *testing.T) {
 		pos++
 
 		rror := Or(rr, rr2)
-
 		arrayor := rror.ToArray()
 
-		assert.Equal(t, arrayor, arrayrr)
+		assert.True(t, IntsEquals(arrayor, arrayrr))
 	})
 
 	t.Run("ortest3", func(t *testing.T) {
@@ -1110,7 +1114,9 @@ func TestBitmap(t *testing.T) {
 		V2 := make(map[int]bool)
 
 		rr := NewBitmap()
+		rr.SetCopyOnWrite(true)
 		rr2 := NewBitmap()
+		rr2.SetCopyOnWrite(true)
 		for k := 0; k < 4000; k++ {
 			rr2.AddInt(k)
 			V1[k] = true
@@ -1185,7 +1191,9 @@ func TestBitmap(t *testing.T) {
 
 	t.Run("ortest4", func(t *testing.T) {
 		rb := NewBitmap()
+		rb.SetCopyOnWrite(true)
 		rb2 := NewBitmap()
+		rb2.SetCopyOnWrite(true)
 
 		for i := 0; i < 200000; i += 4 {
 			rb2.AddInt(i)
@@ -1219,11 +1227,11 @@ func TestBitmap(t *testing.T) {
 	})
 
 	t.Run("randomTest", func(t *testing.T) {
-		rTest(t, 15)
-		rTest(t, 1024)
-		rTest(t, 4096)
-		rTest(t, 65536)
-		rTest(t, 65536*16)
+		rTestCOW(t, 15)
+		rTestCOW(t, 1024)
+		rTestCOW(t, 4096)
+		rTestCOW(t, 65536)
+		rTestCOW(t, 65536*16)
 	})
 
 	t.Run("SimpleCardinality", func(t *testing.T) {
@@ -1231,6 +1239,7 @@ func TestBitmap(t *testing.T) {
 		gap := 70
 
 		rb := NewBitmap()
+		rb.SetCopyOnWrite(true)
 		for k := 0; k < N; k++ {
 			rb.AddInt(k * gap)
 			assert.EqualValues(t, k+1, rb.GetCardinality())
@@ -1246,6 +1255,7 @@ func TestBitmap(t *testing.T) {
 
 	t.Run("XORtest", func(t *testing.T) {
 		rr := NewBitmap()
+		rr.SetCopyOnWrite(true)
 		for k := 4000; k < 4256; k++ {
 			rr.AddInt(k)
 		}
@@ -1269,6 +1279,7 @@ func TestBitmap(t *testing.T) {
 		}
 
 		rr2 := NewBitmap()
+		rr2.SetCopyOnWrite(true)
 		for k := 4000; k < 4256; k++ {
 			rr2.AddInt(k)
 		}
@@ -1287,7 +1298,6 @@ func TestBitmap(t *testing.T) {
 		for k := 10 * 65535; k < 10*65535+5000; k++ {
 			rr2.AddInt(k)
 		}
-
 		correct := Xor(rr, rr2)
 		rr.Xor(rr2)
 
@@ -1299,7 +1309,9 @@ func TestBitmap(t *testing.T) {
 		V2 := make(map[int]bool)
 
 		rr := NewBitmap()
+		rr.SetCopyOnWrite(true)
 		rr2 := NewBitmap()
+		rr2.SetCopyOnWrite(true)
 		// For the first 65536: rr2 has a bitmap container, and rr has
 		// an array container.
 		// We will check the union between a BitmapCintainer and an
@@ -1375,112 +1387,79 @@ func TestBitmap(t *testing.T) {
 		assert.True(t, valide)
 	})
 }
-func TestXORtest4(t *testing.T) {
-	t.Run("XORtest 4", func(t *testing.T) {
-		rb := NewBitmap()
-		rb2 := NewBitmap()
-		counter := 0
 
-		for i := 0; i < 200000; i += 4 {
-			rb2.AddInt(i)
-			counter++
-		}
+func TestXORtest4COW(t *testing.T) {
+	rb := NewBitmap()
+	rb.SetCopyOnWrite(true)
+	rb2 := NewBitmap()
+	rb2.SetCopyOnWrite(true)
+	counter := 0
 
-		assert.EqualValues(t, counter, rb2.GetCardinality())
-
-		for i := 200000; i < 400000; i += 14 {
-			rb2.AddInt(i)
-			counter++
-		}
-
-		assert.EqualValues(t, counter, rb2.GetCardinality())
-
-		rb2card := rb2.GetCardinality()
-		assert.EqualValues(t, counter, rb2card)
-
-		// check or against an empty bitmap
-		xorresult := Xor(rb, rb2)
-		assert.EqualValues(t, counter, xorresult.GetCardinality())
-		off := Or(rb2, rb)
-
-		assert.EqualValues(t, counter, off.GetCardinality())
-		assert.True(t, xorresult.Equals(off))
-
-		assert.Equal(t, xorresult.GetCardinality(), rb2card)
-		for i := 500000; i < 600000; i += 14 {
-			rb.AddInt(i)
-		}
-		for i := 200000; i < 400000; i += 3 {
-			rb2.AddInt(i)
-		}
-		// check or against an empty bitmap
-		xorresult2 := Xor(rb, rb2)
-
-		assert.EqualValues(t, xorresult.GetCardinality(), rb2card)
-		assert.Equal(t, xorresult2.GetCardinality(), rb2.GetCardinality()+rb.GetCardinality())
-
-		rb.Xor(rb2)
-		assert.True(t, xorresult2.Equals(rb))
-	})
-	// need to add the massives
-}
-
-func TestNextMany(t *testing.T) {
-	count := 70000
-
-	for _, gap := range []uint64{1, 8, 32, 128} {
-		expected := make([]uint64, count)
-		{
-			v := uint64(0)
-			for i := range expected {
-				expected[i] = v
-				v += gap
-			}
-		}
-		bm := BitmapOf(expected...)
-		for _, bufSize := range []int{1, 64, 4096, count} {
-			buf := make([]uint64, bufSize)
-			it := bm.ManyIterator()
-			cur := 0
-			for n := it.NextMany(buf); n != 0; n = it.NextMany(buf) {
-				// much faster tests... (10s -> 5ms)
-				if cur+n > count {
-					assert.LessOrEqual(t, count, cur+n)
-				}
-
-				for i, v := range buf[:n] {
-					// much faster tests...
-					if v != expected[cur+i] {
-						assert.Equal(t, expected[cur+i], v)
-					}
-				}
-
-				cur += n
-			}
-
-			assert.Equal(t, count, cur)
-		}
+	for i := 0; i < 200000; i += 4 {
+		rb2.AddInt(i)
+		counter++
 	}
+
+	assert.EqualValues(t, counter, rb2.GetCardinality())
+
+	for i := 200000; i < 400000; i += 14 {
+		rb2.AddInt(i)
+		counter++
+	}
+
+	assert.EqualValues(t, counter, rb2.GetCardinality())
+
+	rb2card := rb2.GetCardinality()
+	assert.EqualValues(t, counter, rb2card)
+
+	// check or against an empty bitmap
+	xorresult := Xor(rb, rb2)
+	assert.EqualValues(t, counter, xorresult.GetCardinality())
+
+	off := Or(rb2, rb)
+
+	assert.EqualValues(t, counter, off.GetCardinality())
+	assert.True(t, xorresult.Equals(off))
+
+	assert.Equal(t, xorresult.GetCardinality(), rb2card)
+	for i := 500000; i < 600000; i += 14 {
+		rb.AddInt(i)
+	}
+	for i := 200000; i < 400000; i += 3 {
+		rb2.AddInt(i)
+	}
+	// check or against an empty bitmap
+	xorresult2 := Xor(rb, rb2)
+
+	assert.Equal(t, xorresult.GetCardinality(), rb2card)
+	assert.Equal(t, xorresult2.GetCardinality(), rb2.GetCardinality()+rb.GetCardinality())
+
+	rb.Xor(rb2)
+	assert.True(t, xorresult2.Equals(rb))
+	//need to add the massives
 }
 
-func TestBigRandom(t *testing.T) {
-	rTest(t, 15)
-	rTest(t, 100)
-	rTest(t, 512)
-	rTest(t, 1023)
-	rTest(t, 1025)
-	rTest(t, 4095)
-	rTest(t, 4096)
-	rTest(t, 4097)
-	rTest(t, 65536)
-	rTest(t, 65536*16)
+func TestBigRandomCOW(t *testing.T) {
+	t.Run("randomTest", func(t *testing.T) {
+		rTestCOW(t, 15)
+		rTestCOW(t, 100)
+		rTestCOW(t, 512)
+		rTestCOW(t, 1023)
+		rTestCOW(t, 1025)
+		rTestCOW(t, 4095)
+		rTestCOW(t, 4096)
+		rTestCOW(t, 4097)
+		rTestCOW(t, 65536)
+		rTestCOW(t, 65536*16)
+	})
 }
 
-func rTest(t *testing.T, N int) {
+func rTestCOW(t *testing.T, N int) {
 	log.Println("rtest N=", N)
 	for gap := 1; gap <= 65536; gap *= 2 {
 		bs1 := bitset.New(0)
 		rb1 := NewBitmap()
+		rb1.SetCopyOnWrite(true)
 		for x := 0; x <= N; x += gap {
 			bs1.Set(uint(x))
 			rb1.AddInt(x)
@@ -1492,6 +1471,7 @@ func rTest(t *testing.T, N int) {
 		for offset := 1; offset <= gap; offset *= 2 {
 			bs2 := bitset.New(0)
 			rb2 := NewBitmap()
+			rb2.SetCopyOnWrite(true)
 			for x := 0; x <= N; x += gap {
 				bs2.Set(uint(x + offset))
 				rb2.AddInt(x + offset)
@@ -1502,7 +1482,6 @@ func rTest(t *testing.T, N int) {
 
 			clonebs1 := bs1.Clone()
 			clonebs1.InPlaceIntersection(bs2)
-
 			if !equalsBitSet(clonebs1, And(rb1, rb2)) {
 				v := rb1.Clone()
 				v.And(rb2)
@@ -1521,7 +1500,7 @@ func rTest(t *testing.T, N int) {
 
 			assert.True(t, equalsBitSet(clonebs1, Xor(rb1, rb2)))
 
-			// testing NOTAND
+			//testing NOTAND
 			clonebs1 = bs1.Clone()
 			clonebs1.InPlaceDifference(bs2)
 
@@ -1530,27 +1509,15 @@ func rTest(t *testing.T, N int) {
 	}
 }
 
-func equalsBitSet(a *bitset.BitSet, b *Bitmap) bool {
-	for i, e := a.NextSet(0); e; i, e = a.NextSet(i + 1) {
-		if !b.ContainsInt(int(i)) {
-			return false
-		}
-	}
-	i := b.Iterator()
-	for i.HasNext() {
-		if !a.Test(uint(i.Next())) {
-			return false
-		}
-	}
-	return true
-}
 
-func TestFlipBigA(t *testing.T) {
+func TestFlipBigACOW(t *testing.T) {
 	numCases := 1000
 	bs := bitset.New(0)
 	checkTime := 2.0
 	rb1 := NewBitmap()
+	rb1.SetCopyOnWrite(true)
 	rb2 := NewBitmap()
+	rb2.SetCopyOnWrite(true)
 
 	for i := 0; i < numCases; i++ {
 		start := rand.Intn(65536 * 20)
@@ -1575,6 +1542,7 @@ func TestFlipBigA(t *testing.T) {
 		// insert some more ANDs to keep things sparser
 		if (rand.Float64() < 0.2) && (i&1) == 0 {
 			mask := NewBitmap()
+			mask.SetCopyOnWrite(true)
 			mask1 := bitset.New(0)
 			startM := rand.Intn(65536 * 20)
 			endM := startM + 100000
@@ -1594,137 +1562,113 @@ func TestFlipBigA(t *testing.T) {
 			} else {
 				rb = rb1
 			}
-
 			assert.True(t, equalsBitSet(bs, rb))
 			checkTime *= 1.5
 		}
 	}
 }
 
-func TestNextManyOfAddRangeAcrossContainers(t *testing.T) {
-	rb := NewBitmap()
-	rb.AddRange(65530, 65540)
-	expectedCard := 10
-	expected := []uint64{65530, 65531, 65532, 65533, 65534, 65535, 65536, 65537, 65538, 65539, 0}
-
-	// test where all values can be returned in a single buffer
-	it := rb.ManyIterator()
-	buf := make([]uint64, 11)
-	n := it.NextMany(buf)
-
-	assert.Equal(t, expectedCard, n)
-
-	for i, e := range expected {
-		assert.Equal(t, e, buf[i])
-	}
-
-	// test where buf is size 1, so many iterations
-	it = rb.ManyIterator()
-	n = 0
-	buf = make([]uint64, 1)
-
-	for i := 0; i < expectedCard; i++ {
-		n = it.NextMany(buf)
-
-		assert.Equal(t, 1, n)
-		assert.Equal(t, expected[i], buf[0])
-	}
-
-	n = it.NextMany(buf)
-	assert.Equal(t, 0, n)
-}
-
-func TestDoubleAdd(t *testing.T) {
+func TestDoubleAddCOW(t *testing.T) {
 	t.Run("doubleadd ", func(t *testing.T) {
 		rb := NewBitmap()
-		rb.AddRange(65533, 65536)
-		rb.AddRange(65530, 65536)
+		rb.SetCopyOnWrite(true)
+		rb.AddRange(uint64(65533), uint64(65536))
+		rb.AddRange(uint64(65530), uint64(65536))
 		rb2 := NewBitmap()
-		rb2.AddRange(65530, 65536)
+		rb2.SetCopyOnWrite(true)
+		rb2.AddRange(uint64(65530), uint64(65536))
 
 		assert.True(t, rb.Equals(rb2))
 
-		rb2.RemoveRange(65530, 65536)
-
+		rb2.RemoveRange(uint64(65530), uint64(65536))
 		assert.EqualValues(t, 0, rb2.GetCardinality())
 	})
 
 	t.Run("doubleadd2 ", func(t *testing.T) {
 		rb := NewBitmap()
-		rb.AddRange(65533, 65536*20)
-		rb.AddRange(65530, 65536*20)
+		rb.SetCopyOnWrite(true)
+		rb.AddRange(uint64(65533), uint64(65536*20))
+		rb.AddRange(uint64(65530), uint64(65536*20))
 		rb2 := NewBitmap()
-		rb2.AddRange(65530, 65536*20)
+		rb2.SetCopyOnWrite(true)
+		rb2.AddRange(uint64(65530), uint64(65536*20))
 
 		assert.True(t, rb.Equals(rb2))
 
-		rb2.RemoveRange(65530, 65536*20)
-
+		rb2.RemoveRange(uint64(65530), uint64(65536*20))
 		assert.EqualValues(t, 0, rb2.GetCardinality())
 	})
 
 	t.Run("doubleadd3 ", func(t *testing.T) {
 		rb := NewBitmap()
-		rb.AddRange(65533, 65536*20+10)
-		rb.AddRange(65530, 65536*20+10)
+		rb.SetCopyOnWrite(true)
+		rb.AddRange(uint64(65533), uint64(65536*20+10))
+		rb.AddRange(uint64(65530), uint64(65536*20+10))
+
 		rb2 := NewBitmap()
-		rb2.AddRange(65530, 65536*20+10)
-
+		rb2.SetCopyOnWrite(true)
+		rb2.AddRange(uint64(65530), uint64(65536*20+10))
 		assert.True(t, rb.Equals(rb2))
-
-		rb2.RemoveRange(65530, 65536*20+1)
+		rb2.RemoveRange(uint64(65530), uint64(65536*20+1))
 
 		assert.EqualValues(t, 9, rb2.GetCardinality())
 	})
 
 	t.Run("doubleadd4 ", func(t *testing.T) {
 		rb := NewBitmap()
-		rb.AddRange(65533, 65536*20)
-		rb.RemoveRange(65533+5, 65536*20)
+		rb.SetCopyOnWrite(true)
+		rb.AddRange(uint64(65533), uint64(65536*20))
+		rb.RemoveRange(uint64(65533+5), uint64(65536*20))
 
 		assert.EqualValues(t, 5, rb.GetCardinality())
 	})
 
 	t.Run("doubleadd5 ", func(t *testing.T) {
 		rb := NewBitmap()
-		rb.AddRange(65533, 65536*20)
-		rb.RemoveRange(65533+5, 65536*20-5)
+		rb.SetCopyOnWrite(true)
+		rb.AddRange(uint64(65533), uint64(65536*20))
+		rb.RemoveRange(uint64(65533+5), uint64(65536*20-5))
 
 		assert.EqualValues(t, 10, rb.GetCardinality())
 	})
 
 	t.Run("doubleadd6 ", func(t *testing.T) {
 		rb := NewBitmap()
-		rb.AddRange(65533, 65536*20-5)
-		rb.RemoveRange(65533+5, 65536*20-10)
+		rb.SetCopyOnWrite(true)
+		rb.AddRange(uint64(65533), uint64(65536*20-5))
+		rb.RemoveRange(uint64(65533+5), uint64(65536*20-10))
 
 		assert.EqualValues(t, 10, rb.GetCardinality())
 	})
 
 	t.Run("doubleadd7 ", func(t *testing.T) {
 		rb := NewBitmap()
-		rb.AddRange(65533, 65536*20+1)
-		rb.RemoveRange(65533+1, 65536*20)
+		rb.SetCopyOnWrite(true)
+		rb.AddRange(uint64(65533), uint64(65536*20+1))
+		rb.RemoveRange(uint64(65533+1), uint64(65536*20))
 
 		assert.EqualValues(t, 2, rb.GetCardinality())
 	})
 
 	t.Run("AndNotBug01 ", func(t *testing.T) {
 		rb1 := NewBitmap()
-		rb1.AddRange(0, 60000)
+		rb1.SetCopyOnWrite(true)
+		rb1.AddRange(uint64(0), uint64(60000))
 		rb2 := NewBitmap()
-		rb2.AddRange(60000-10, 60000+10)
+		rb2.SetCopyOnWrite(true)
+		rb2.AddRange(uint64(60000-10), uint64(60000+10))
 		rb2.AndNot(rb1)
 		rb3 := NewBitmap()
-		rb3.AddRange(60000, 60000+10)
+		rb3.SetCopyOnWrite(true)
+		rb3.AddRange(uint64(60000), uint64(60000+10))
 
 		assert.True(t, rb2.Equals(rb3))
 	})
 }
 
-func TestAndNot(t *testing.T) {
+func TestAndNotCOW(t *testing.T) {
 	rr := NewBitmap()
-
+	rr.SetCopyOnWrite(true)
 	for k := 4000; k < 4256; k++ {
 		rr.AddInt(k)
 	}
@@ -1748,7 +1692,7 @@ func TestAndNot(t *testing.T) {
 	}
 
 	rr2 := NewBitmap()
-
+	rr2.SetCopyOnWrite(true)
 	for k := 4000; k < 4256; k++ {
 		rr2.AddInt(k)
 	}
@@ -1767,222 +1711,36 @@ func TestAndNot(t *testing.T) {
 	for k := 10 * 65535; k < 10*65535+5000; k++ {
 		rr2.AddInt(k)
 	}
-
 	correct := AndNot(rr, rr2)
 	rr.AndNot(rr2)
 
 	assert.True(t, correct.Equals(rr))
 }
 
-func TestStats(t *testing.T) {
-	t.Run("Test Stats with empty bitmap", func(t *testing.T) {
-		expectedStats := roaring.Statistics{}
-		rr := NewBitmap()
-
-		assert.EqualValues(t, expectedStats, rr.Stats())
-	})
-
-	t.Run("Test Stats with bitmap Container", func(t *testing.T) {
-		// Given a bitmap that should have a single bitmap container
-		expectedStats := roaring.Statistics{
-			Cardinality: 60000,
-			Containers:  1,
-
-			BitmapContainers:      1,
-			BitmapContainerValues: 60000,
-			BitmapContainerBytes:  8192,
-
-			RunContainers:      0,
-			RunContainerBytes:  0,
-			RunContainerValues: 0,
-		}
-
-		rr := NewBitmap()
-
-		for i := uint64(0); i < 60000; i++ {
-			rr.Add(i)
-		}
-
-		assert.EqualValues(t, expectedStats, rr.Stats())
-	})
-
-	t.Run("Test Stats with run Container", func(t *testing.T) {
-		// Given that we should have a single run container
-		intSize := int(unsafe.Sizeof(int(0)))
-		var runContainerBytes uint64
-		if intSize == 4 {
-			runContainerBytes = 40
-		} else {
-			runContainerBytes = 52
-		}
-
-		expectedStats := roaring.Statistics{
-			Cardinality: 60000,
-			Containers:  1,
-
-			BitmapContainers:      0,
-			BitmapContainerValues: 0,
-			BitmapContainerBytes:  0,
-
-			RunContainers:      1,
-			RunContainerBytes:  runContainerBytes,
-			RunContainerValues: 60000,
-		}
-
-		rr := NewBitmap()
-		rr.AddRange(0, 60000)
-
-		assert.EqualValues(t, expectedStats, rr.Stats())
-	})
-
-	t.Run("Test Stats with Array Container", func(t *testing.T) {
-		// Given a bitmap that should have a single array container
-		expectedStats := roaring.Statistics{
-			Cardinality: 2,
-			Containers:  1,
-
-			ArrayContainers:      1,
-			ArrayContainerValues: 2,
-			ArrayContainerBytes:  4,
-		}
-		rr := NewBitmap()
-		rr.Add(2)
-		rr.Add(4)
-
-		assert.EqualValues(t, expectedStats, rr.Stats())
-	})
-}
-
-func TestFlipVerySmall(t *testing.T) {
+func TestFlipVerySmallCOW(t *testing.T) {
 	rb := NewBitmap()
-	rb.Flip(0, 10) // got [0,9], card is 10
-	rb.Flip(0, 1)  // give back the number 0, card goes to 9
+	rb.SetCopyOnWrite(true)
+	rb.Flip(uint64(0), uint64(10)) // got [0,9], card is 10
+	rb.Flip(uint64(0), uint64(1))  // give back the number 0, card goes to 9
 	rbcard := rb.GetCardinality()
 
 	assert.EqualValues(t, 9, rbcard)
 }
 
-func TestPackageFlipMaxRangeEnd(t *testing.T) {
-	var empty Bitmap
-	flipped := Flip(&empty, 0, roaring.MaxRange)
+func TestCloneCOWContainers(t *testing.T) {
+	rb := NewBitmap()
+	rb.AddRange(uint64(0), uint64(3000))
+	buf := &bytes.Buffer{}
+	rb.WriteTo(buf)
 
-	assert.EqualValues(t, roaring.MaxRange, flipped.GetCardinality())
-}
+	newRb1 := NewBitmap()
+	newRb1.FromBuffer(buf.Bytes())
+	newRb1.CloneCopyOnWriteContainers()
 
-func TestBitmapFlipMaxRangeEnd(t *testing.T) {
-	var bm Bitmap
-	bm.Flip(0, roaring.MaxRange)
+	rb2 := NewBitmap()
+	rb2.AddRange(uint64(3000), uint64(6000))
+	buf.Reset()
+	rb2.WriteTo(buf)
 
-	assert.EqualValues(t, roaring.MaxRange, bm.GetCardinality())
-}
-
-func TestSerialization(t *testing.T) {
-        array := []uint64{123, 0xA00000000A, 0xAFFFFFFF7, 0xFFFFFFFFF}
-        bmp := New()
-        for _, v := range array {
-                bmp.Add(v)
-        }
-        assert.False(t, bmp.IsEmpty())
-
-        buf, err := bmp.MarshalBinary()
-        assert.Nil(t, err)
-        assert.NotNil(t, buf)
-
-        newBmp := New()
-        err = newBmp.UnmarshalBinary(buf)
-        assert.Nil(t, err)
-        assert.True(t, newBmp.Equals(bmp))
-
-        bufBmp := New()
-        _, err = bufBmp.FromBuffer(buf)
-        assert.Nil(t, err)
-        assert.True(t, bufBmp.Equals(bmp))
-
-	var base64 string
-        base64, err = bufBmp.ToBase64()
-        assert.Nil(t, err)
-        
-        base64Bmp := New()
-        _, err = base64Bmp.FromBase64(base64)
-        assert.Nil(t, err)
-        assert.True(t, base64Bmp.Equals(bmp))
-}
-
-func TestAddCheckedRemove64(t *testing.T) {
-        array := []uint64{123, 0xA00000000A, 0xAFFFFFFF7, 0xFFFFFFFFF}
-        bmp := New()
-        for _, v := range array {
-                assert.True(t, bmp.CheckedAdd(v))
-                assert.False(t, bmp.CheckedAdd(v))
-        }
-        for _, v := range array {
-                assert.True(t, bmp.CheckedRemove(v))
-                assert.False(t, bmp.CheckedRemove(v))
-        }
-        assert.True(t, bmp.IsEmpty())
-}
-
-func TestClear64(t *testing.T) {
-        array := []uint64{123, 0xA00000000A, 0xAFFFFFFF7, 0xFFFFFFFFF}
-        bmp := New()
-        for _, v := range array {
-                bmp.Add(v)
-        }
-        assert.False(t, bmp.IsEmpty())
-        bmp.Clear()
-        assert.True(t, bmp.IsEmpty())
-}
-
-
-func TestRunCompression(t *testing.T) {
-        bmp := New()
-	bmp.SetCopyOnWrite(true)
-	for i := 100; i < 10000; i++ {
-		bmp.Add(uint64(i))
-	}
-	var j uint64
-    	for j = 14000000000000000100; j < 14000000000000001000; j++ {
-		bmp.Add(j)
-	}
-	sizeOrigin := bmp.GetSizeInBytes()
-        bmp.RunOptimize()
-        assert.True(t, bmp.HasRunCompression())
-        assert.True(t, sizeOrigin > bmp.GetSizeInBytes())
-        assert.True(t, bmp.GetCopyOnWrite())
-}
-
-
-func Test64BitValues(t *testing.T) {
-        bmp := New()
-	bmp.SetCopyOnWrite(true)
-	for i := 100; i < 1000; i++ {
-		bmp.Add(uint64(i))
-        }
-	var i uint64
-    	for i = 14000000000000000100; i < 14000000000000001000; i++ {
-		bmp.Add(i)
-	}
-	assert.True(t, bmp.Contains(uint64(14000000000000000500)))
-        array := []uint64{5, 1, 2, 234294967296, 195839473298, 14000000000000000100};
-        bmp2 := New()
-	bmp2.AddMany(array)
-        v, err := bmp2.Select(uint64(5))
-        assert.Nil(t, err)
-	assert.True(t, v == uint64(14000000000000000100))
-	assert.True(t, bmp2.Minimum() == uint64(1))
-	assert.True(t, bmp2.Maximum() == uint64(14000000000000000100))
-	assert.True(t, bmp2.Rank(uint64(195839473298)) == uint64(4))
-}
-
-
-func IntsEquals(a, b []uint64) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i, v := range a {
-		if v != b[i] {
-			return false
-		}
-	}
-	return true
+	assert.EqualValues(t, rb.ToArray(), newRb1.ToArray())
 }

--- a/roaring64/roaringarray64.go
+++ b/roaring64/roaringarray64.go
@@ -1,0 +1,388 @@
+package roaring64
+
+import "github.com/RoaringBitmap/roaring"
+
+type roaringArray64 struct {
+	keys            []uint32
+	containers      []*roaring.Bitmap
+	needCopyOnWrite []bool
+	copyOnWrite     bool
+}
+
+// runOptimize compresses the element containers to minimize space consumed.
+// Q: how does this interact with copyOnWrite and needCopyOnWrite?
+// A: since we aren't changing the logical content, just the representation,
+//    we don't bother to check the needCopyOnWrite bits. We replace
+//    (possibly all) elements of ra.containers in-place with space
+//    optimized versions.
+func (ra *roaringArray64) runOptimize() {
+	for i := range ra.containers {
+		ra.containers[i].RunOptimize()
+	}
+}
+
+func (ra *roaringArray64) appendContainer(key uint32, value *roaring.Bitmap, mustCopyOnWrite bool) {
+	ra.keys = append(ra.keys, key)
+	ra.containers = append(ra.containers, value)
+	ra.needCopyOnWrite = append(ra.needCopyOnWrite, mustCopyOnWrite)
+}
+
+func (ra *roaringArray64) appendWithoutCopy(sa roaringArray64, startingindex int) {
+	mustCopyOnWrite := sa.needCopyOnWrite[startingindex]
+	ra.appendContainer(sa.keys[startingindex], sa.containers[startingindex], mustCopyOnWrite)
+}
+
+func (ra *roaringArray64) appendCopy(sa roaringArray64, startingindex int) {
+	// cow only if the two request it, or if we already have a lightweight copy
+	copyonwrite := (ra.copyOnWrite && sa.copyOnWrite) || sa.needsCopyOnWrite(startingindex)
+	if !copyonwrite {
+		// since there is no copy-on-write, we need to clone the container (this is important)
+		ra.appendContainer(sa.keys[startingindex], sa.containers[startingindex].Clone(), copyonwrite)
+	} else {
+		ra.appendContainer(sa.keys[startingindex], sa.containers[startingindex], copyonwrite)
+		if !sa.needsCopyOnWrite(startingindex) {
+			sa.setNeedsCopyOnWrite(startingindex)
+		}
+	}
+}
+
+func (ra *roaringArray64) appendWithoutCopyMany(sa roaringArray64, startingindex, end int) {
+	for i := startingindex; i < end; i++ {
+		ra.appendWithoutCopy(sa, i)
+	}
+}
+
+func (ra *roaringArray64) appendCopyMany(sa roaringArray64, startingindex, end int) {
+	for i := startingindex; i < end; i++ {
+		ra.appendCopy(sa, i)
+	}
+}
+
+func (ra *roaringArray64) appendCopiesUntil(sa roaringArray64, stoppingKey uint32) {
+	// cow only if the two request it, or if we already have a lightweight copy
+	copyonwrite := ra.copyOnWrite && sa.copyOnWrite
+
+	for i := 0; i < sa.size(); i++ {
+		if sa.keys[i] >= stoppingKey {
+			break
+		}
+		thiscopyonewrite := copyonwrite || sa.needsCopyOnWrite(i)
+		if thiscopyonewrite {
+			ra.appendContainer(sa.keys[i], sa.containers[i], thiscopyonewrite)
+			if !sa.needsCopyOnWrite(i) {
+				sa.setNeedsCopyOnWrite(i)
+			}
+
+		} else {
+			// since there is no copy-on-write, we need to clone the container (this is important)
+			ra.appendContainer(sa.keys[i], sa.containers[i].Clone(), thiscopyonewrite)
+		}
+	}
+}
+
+func (ra *roaringArray64) appendCopiesAfter(sa roaringArray64, beforeStart uint32) {
+	// cow only if the two request it, or if we already have a lightweight copy
+	copyonwrite := ra.copyOnWrite && sa.copyOnWrite
+
+	startLocation := sa.getIndex(beforeStart)
+	if startLocation >= 0 {
+		startLocation++
+	} else {
+		startLocation = -startLocation - 1
+	}
+
+	for i := startLocation; i < sa.size(); i++ {
+		thiscopyonewrite := copyonwrite || sa.needsCopyOnWrite(i)
+		if thiscopyonewrite {
+			ra.appendContainer(sa.keys[i], sa.containers[i], thiscopyonewrite)
+			if !sa.needsCopyOnWrite(i) {
+				sa.setNeedsCopyOnWrite(i)
+			}
+		} else {
+			// since there is no copy-on-write, we need to clone the container (this is important)
+			ra.appendContainer(sa.keys[i], sa.containers[i].Clone(), thiscopyonewrite)
+		}
+	}
+}
+
+func (ra *roaringArray64) removeIndexRange(begin, end int) {
+	if end <= begin {
+		return
+	}
+
+	r := end - begin
+
+	copy(ra.keys[begin:], ra.keys[end:])
+	copy(ra.containers[begin:], ra.containers[end:])
+	copy(ra.needCopyOnWrite[begin:], ra.needCopyOnWrite[end:])
+
+	ra.resize(len(ra.keys) - r)
+}
+
+func (ra *roaringArray64) resize(newsize int) {
+	for k := newsize; k < len(ra.containers); k++ {
+		ra.containers[k] = nil
+	}
+
+	ra.keys = ra.keys[:newsize]
+	ra.containers = ra.containers[:newsize]
+	ra.needCopyOnWrite = ra.needCopyOnWrite[:newsize]
+}
+
+func (ra *roaringArray64) clear() {
+	ra.resize(0)
+	ra.copyOnWrite = false
+}
+
+func (ra *roaringArray64) clone() *roaringArray64 {
+
+	sa := roaringArray64{}
+	sa.copyOnWrite = ra.copyOnWrite
+
+	// this is where copyOnWrite is used.
+	if ra.copyOnWrite {
+		sa.keys = make([]uint32, len(ra.keys))
+		copy(sa.keys, ra.keys)
+		sa.containers = make([]*roaring.Bitmap, len(ra.containers))
+		copy(sa.containers, ra.containers)
+		sa.needCopyOnWrite = make([]bool, len(ra.needCopyOnWrite))
+
+		ra.markAllAsNeedingCopyOnWrite()
+		sa.markAllAsNeedingCopyOnWrite()
+
+		// sa.needCopyOnWrite is shared
+	} else {
+		// make a full copy
+
+		sa.keys = make([]uint32, len(ra.keys))
+		copy(sa.keys, ra.keys)
+
+		sa.containers = make([]*roaring.Bitmap, len(ra.containers))
+		for i := range sa.containers {
+			sa.containers[i] = ra.containers[i].Clone()
+		}
+
+		sa.needCopyOnWrite = make([]bool, len(ra.needCopyOnWrite))
+	}
+	return &sa
+}
+
+// clone all containers which have needCopyOnWrite set to true
+// This can be used to make sure it is safe to munmap a []byte
+// that the roaring array may still have a reference to.
+func (ra *roaringArray64) cloneCopyOnWriteContainers() {
+	for i, needCopyOnWrite := range ra.needCopyOnWrite {
+		if needCopyOnWrite {
+			ra.containers[i] = ra.containers[i].Clone()
+			ra.needCopyOnWrite[i] = false
+		}
+	}
+}
+
+// unused function:
+// func (ra *roaringArray64) containsKey(x uint32) bool {
+//	return (ra.binarySearch(0, int64(len(ra.keys)), x) >= 0)
+// }
+
+func (ra *roaringArray64) getContainer(x uint32) *roaring.Bitmap {
+	i := ra.binarySearch(0, int64(len(ra.keys)), x)
+	if i < 0 {
+		return nil
+	}
+	return ra.containers[i]
+}
+
+func (ra *roaringArray64) getContainerAtIndex(i int) *roaring.Bitmap {
+	return ra.containers[i]
+}
+
+func (ra *roaringArray64) getWritableContainerAtIndex(i int) *roaring.Bitmap {
+	if ra.needCopyOnWrite[i] {
+		ra.containers[i] = ra.containers[i].Clone()
+		ra.needCopyOnWrite[i] = false
+	}
+	return ra.containers[i]
+}
+
+func (ra *roaringArray64) getIndex(x uint32) int {
+	// before the binary search, we optimize for frequent cases
+	size := len(ra.keys)
+	if (size == 0) || (ra.keys[size-1] == x) {
+		return size - 1
+	}
+	return ra.binarySearch(0, int64(size), x)
+}
+
+func (ra *roaringArray64) getKeyAtIndex(i int) uint32 {
+	return ra.keys[i]
+}
+
+func (ra *roaringArray64) insertNewKeyValueAt(i int, key uint32, value *roaring.Bitmap) {
+	ra.keys = append(ra.keys, 0)
+	ra.containers = append(ra.containers, nil)
+
+	copy(ra.keys[i+1:], ra.keys[i:])
+	copy(ra.containers[i+1:], ra.containers[i:])
+
+	ra.keys[i] = key
+	ra.containers[i] = value
+
+	ra.needCopyOnWrite = append(ra.needCopyOnWrite, false)
+	copy(ra.needCopyOnWrite[i+1:], ra.needCopyOnWrite[i:])
+	ra.needCopyOnWrite[i] = false
+}
+
+func (ra *roaringArray64) remove(key uint32) bool {
+	i := ra.binarySearch(0, int64(len(ra.keys)), key)
+	if i >= 0 { // if a new key
+		ra.removeAtIndex(i)
+		return true
+	}
+	return false
+}
+
+func (ra *roaringArray64) removeAtIndex(i int) {
+	copy(ra.keys[i:], ra.keys[i+1:])
+	copy(ra.containers[i:], ra.containers[i+1:])
+
+	copy(ra.needCopyOnWrite[i:], ra.needCopyOnWrite[i+1:])
+
+	ra.resize(len(ra.keys) - 1)
+}
+
+func (ra *roaringArray64) setContainerAtIndex(i int, c *roaring.Bitmap) {
+	ra.containers[i] = c
+}
+
+func (ra *roaringArray64) replaceKeyAndContainerAtIndex(i int, key uint32, c *roaring.Bitmap, mustCopyOnWrite bool) {
+	ra.keys[i] = key
+	ra.containers[i] = c
+	ra.needCopyOnWrite[i] = mustCopyOnWrite
+}
+
+func (ra *roaringArray64) size() int {
+	return len(ra.keys)
+}
+
+func (ra *roaringArray64) binarySearch(begin, end int64, ikey uint32) int {
+	low := begin
+	high := end - 1
+	for low+16 <= high {
+		middleIndex := low + (high-low)/2 // avoid overflow
+		middleValue := ra.keys[middleIndex]
+
+		if middleValue < ikey {
+			low = middleIndex + 1
+		} else if middleValue > ikey {
+			high = middleIndex - 1
+		} else {
+			return int(middleIndex)
+		}
+	}
+	for ; low <= high; low++ {
+		val := ra.keys[low]
+		if val >= ikey {
+			if val == ikey {
+				return int(low)
+			}
+			break
+		}
+	}
+	return -int(low + 1)
+}
+
+func (ra *roaringArray64) equals(o interface{}) bool {
+	srb, ok := o.(roaringArray64)
+	if ok {
+
+		if srb.size() != ra.size() {
+			return false
+		}
+		for i, k := range ra.keys {
+			if k != srb.keys[i] {
+				return false
+			}
+		}
+
+		for i, c := range ra.containers {
+			if !c.Equals(srb.containers[i]) {
+				return false
+			}
+		}
+		return true
+	}
+	return false
+}
+
+func (ra *roaringArray64) hasRunCompression() bool {
+	for _, c := range ra.containers {
+		if c.HasRunCompression() {
+			return true
+		}
+	}
+	return false
+}
+
+func (ra *roaringArray64) advanceUntil(min uint32, pos int) int {
+	lower := pos + 1
+
+	if lower >= len(ra.keys) || ra.keys[lower] >= min {
+		return lower
+	}
+
+	spansize := 1
+
+	for lower+spansize < len(ra.keys) && ra.keys[lower+spansize] < min {
+		spansize *= 2
+	}
+	var upper int
+	if lower+spansize < len(ra.keys) {
+		upper = lower + spansize
+	} else {
+		upper = len(ra.keys) - 1
+	}
+
+	if ra.keys[upper] == min {
+		return upper
+	}
+
+	if ra.keys[upper] < min {
+		// means
+		// array
+		// has no
+		// item
+		// >= min
+		// pos = array.length;
+		return len(ra.keys)
+	}
+
+	// we know that the next-smallest span was too small
+	lower += (spansize >> 1)
+
+	mid := 0
+	for lower+1 != upper {
+		mid = (lower + upper) >> 1
+		if ra.keys[mid] == min {
+			return mid
+		} else if ra.keys[mid] < min {
+			lower = mid
+		} else {
+			upper = mid
+		}
+	}
+	return upper
+}
+
+func (ra *roaringArray64) markAllAsNeedingCopyOnWrite() {
+	for i := range ra.needCopyOnWrite {
+		ra.needCopyOnWrite[i] = true
+	}
+}
+
+func (ra *roaringArray64) needsCopyOnWrite(i int) bool {
+	return ra.needCopyOnWrite[i]
+}
+
+func (ra *roaringArray64) setNeedsCopyOnWrite(i int) {
+	ra.needCopyOnWrite[i] = true
+}

--- a/roaring64/util.go
+++ b/roaring64/util.go
@@ -1,0 +1,13 @@
+package roaring64
+
+import "github.com/RoaringBitmap/roaring"
+
+func highbits(x uint64) uint32 {
+	return uint32(x >> 32)
+}
+
+func lowbits(x uint64) uint32 {
+	return uint32(x & maxLowBit)
+}
+
+const maxLowBit = roaring.MaxUint32

--- a/roaring64/util.go
+++ b/roaring64/util.go
@@ -11,3 +11,32 @@ func lowbits(x uint64) uint32 {
 }
 
 const maxLowBit = roaring.MaxUint32
+const MaxUint32 = roaring.MaxUint32
+
+func minOfInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func maxOfInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func maxOfUint32(a, b uint32) uint32 {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func minOfUint32(a, b uint32) uint32 {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/runcontainer.go
+++ b/runcontainer.go
@@ -1309,6 +1309,47 @@ func (ri *runIterator16) nextMany(hs uint32, buf []uint32) int {
 	return n
 }
 
+func (ri *runIterator16) nextMany64(hs uint64, buf []uint64) int {
+	n := 0
+
+	if !ri.hasNext() {
+		return n
+	}
+
+	// start and end are inclusive
+	for n < len(buf) {
+		moreVals := 0
+
+		if ri.rc.iv[ri.curIndex].length >= ri.curPosInIndex {
+			// add as many as you can from this seq
+			moreVals = minOfInt(int(ri.rc.iv[ri.curIndex].length-ri.curPosInIndex)+1, len(buf)-n)
+			base := uint64(ri.rc.iv[ri.curIndex].start+ri.curPosInIndex) | hs
+
+			// allows BCE
+			buf2 := buf[n : n+moreVals]
+			for i := range buf2 {
+				buf2[i] = base + uint64(i)
+			}
+
+			// update values
+			n += moreVals
+		}
+
+		if moreVals+int(ri.curPosInIndex) > int(ri.rc.iv[ri.curIndex].length) {
+			ri.curPosInIndex = 0
+			ri.curIndex++
+
+			if ri.curIndex == int64(len(ri.rc.iv)) {
+				break
+			}
+		} else {
+			ri.curPosInIndex += uint16(moreVals) //moreVals always fits in uint16
+		}
+	}
+
+	return n
+}
+
 // remove removes key from the container.
 func (rc *runContainer16) removeKey(key uint16) (wasPresent bool) {
 

--- a/util.go
+++ b/util.go
@@ -1,6 +1,7 @@
 package roaring
 
 import (
+	"math"
 	"math/rand"
 	"sort"
 )
@@ -15,7 +16,7 @@ const (
 	noOffsetThreshold          = 4
 
 	// MaxUint32 is the largest uint32 value.
-	MaxUint32 = 4294967295
+	MaxUint32 = math.MaxUint32
 
 	// MaxRange is One more than the maximum allowed bitmap bit index. For use as an upper
 	// bound for ranges.
@@ -23,7 +24,7 @@ const (
 
 	// MaxUint16 is the largest 16 bit unsigned int.
 	// This is the largest value an interval16 can store.
-	MaxUint16 = 65535
+	MaxUint16 = math.MaxUint16
 
 	// Compute wordSizeInBytes, the size of a word in bytes.
 	_m              = ^uint64(0)


### PR DESCRIPTION
Fixes #136

This PR is very much a work-in-progress. I've tried to stay with the original 32 bit method signatures as much as possible. Serialization is explicitly not part of this PR.

- [x] fix failing tests
- [x] augment tests with 64 bit values
- [x] verify copy-on-write