### PR TITLE
Use a sync.Pool for bitmapContainers used in ToBytes()

### DIFF
--- a/bitmapcontainer.go
+++ b/bitmapcontainer.go
@@ -47,6 +47,13 @@ func newBitmapContainerwithRange(firstOfRun, lastOfRun int) *bitmapContainer {
 	return bc
 }
 
+func (bc *bitmapContainer) clear() {
+	bc.cardinality = 0
+	for i := 0; i < len(bc.bitmap); i++ {
+		bc.bitmap[i] = 0
+	}
+}
+
 func (bc *bitmapContainer) minimum() uint16 {
 	for i := 0; i < len(bc.bitmap); i++ {
 		w := bc.bitmap[i]


### PR DESCRIPTION
One of our applications maintains a lot of small compressed bitmaps in memory and occasionally serializes them  to disk.  When they are serialized, we notice a large bump in memory allocations (and accompanying cpu/gc activity) due to creating a new `*bitmapContainer` each time.

This commit modifies roaringArray to use a `sync.Pool` of `*bitmapContainer` in writeTo() instead of creating a new one each time.  Since the bitmapContainers can now be reused, a clear() method is also added to reset its state

@lemire please let me know if you have alternative thoughts here. The goal is to avoid allocating a new `*bitmapContainer` (which is really a `[1024]uint64` and an `int`) every time we call `ToBytes()` on a compressed bit map