### PR TITLE
No longer allocate temporary memory when serializing

### DIFF
--- a/roaringarray.go
+++ b/roaringarray.go
@@ -488,20 +488,15 @@ func (ra *roaringArray) writeTo(w io.Writer) (n int64, err error) {
 		nw += 2
 		binary.LittleEndian.PutUint16(buf[2:], uint16(len(ra.keys)-1))
 		nw += 2
-
-		// compute isRun bitmap
-		var ir []byte
-
-		isRun := newBitmapContainer()
+		// compute isRun bitmap without temporary allocation
+		var runbitmapslice = buf[nw:nw+isRunSizeInBytes]
 		for i, c := range ra.containers {
 			switch c.(type) {
 			case *runContainer16:
-				isRun.iadd(uint16(i))
+				runbitmapslice[i / 8] |= 1<<(uint(i)%8)
 			}
 		}
-		// convert to little endian
-		ir = isRun.asLittleEndianByteSlice()[:isRunSizeInBytes]
-		nw += copy(buf[nw:], ir)
+		nw += isRunSizeInBytes
 	} else {
 		binary.LittleEndian.PutUint32(buf[0:], uint32(serialCookieNoRunContainer))
 		nw += 4


### PR DESCRIPTION
This might be faster than another PR:

https://github.com/RoaringBitmap/roaring/pull/246