### PR TITLE
Add Iterate() method for iterating the bitmap without an iterator

### DIFF
--- a/arraycontainer.go
+++ b/arraycontainer.go
@@ -24,6 +24,12 @@ func (ac *arrayContainer) fillLeastSignificant16bits(x []uint32, i int, mask uin
 	}
 }
 
+func (ac *arrayContainer) iterate(cb func(x uint16)) {
+	for i := 0; i < len(ac.content); i++ {
+		cb(ac.content[i])
+	}
+}
+
 func (ac *arrayContainer) getShortIterator() shortPeekable {
 	return &shortIterator{ac.content, 0}
 }

--- a/arraycontainer.go
+++ b/arraycontainer.go
@@ -25,8 +25,10 @@ func (ac *arrayContainer) fillLeastSignificant16bits(x []uint32, i int, mask uin
 }
 
 func (ac *arrayContainer) iterate(cb func(x uint16) bool) bool {
-	for i := 0; i < len(ac.content); i++ {
-		if !cb(ac.content[i]) {
+	iterator := shortIterator{ac.content, 0}
+
+	for iterator.hasNext() {
+		if !cb(iterator.next()) {
 			return false
 		}
 	}

--- a/arraycontainer.go
+++ b/arraycontainer.go
@@ -24,10 +24,14 @@ func (ac *arrayContainer) fillLeastSignificant16bits(x []uint32, i int, mask uin
 	}
 }
 
-func (ac *arrayContainer) iterate(cb func(x uint16)) {
+func (ac *arrayContainer) iterate(cb func(x uint16) bool) bool {
 	for i := 0; i < len(ac.content); i++ {
-		cb(ac.content[i])
+		if !cb(ac.content[i]) {
+			return false
+		}
 	}
+
+	return true
 }
 
 func (ac *arrayContainer) getShortIterator() shortPeekable {

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -419,8 +419,9 @@ func BenchmarkIterateRoaring(b *testing.B) {
 
 		for j := 0; j < b.N; j++ {
 			c9 = uint(0)
-			s.Iterate(func(x uint32) {
+			s.Iterate(func(x uint32) bool {
 				c9++
+				return true
 			})
 		}
 	})
@@ -434,8 +435,9 @@ func BenchmarkIterateRoaring(b *testing.B) {
 
 		for j := 0; j < b.N; j++ {
 			c9 = uint(0)
-			s.Iterate(func(x uint32) {
+			s.Iterate(func(x uint32) bool {
 				c9++
+				return true
 			})
 		}
 	})

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -363,23 +363,82 @@ func BenchmarkCountBitset(b *testing.B) {
 
 // go test -bench BenchmarkIterate -run -
 func BenchmarkIterateRoaring(b *testing.B) {
-	b.StopTimer()
-	r := rand.New(rand.NewSource(0))
-	s := NewBitmap()
-	sz := 150000
-	initsize := 65000
-	for i := 0; i < initsize; i++ {
-		s.Add(uint32(r.Int31n(int32(sz))))
-	}
-	b.StartTimer()
-	for j := 0; j < b.N; j++ {
-		c9 = uint(0)
-		i := s.Iterator()
-		for i.HasNext() {
-			i.Next()
-			c9++
+	newBitmap := func() *Bitmap {
+		r := rand.New(rand.NewSource(0))
+		s := NewBitmap()
+		sz := 150000
+		initsize := 65000
+		for i := 0; i < initsize; i++ {
+			s.Add(uint32(r.Int31n(int32(sz))))
 		}
+		return s
 	}
+
+	b.Run("iterator-compressed", func(b *testing.B) {
+		b.ReportAllocs()
+
+		s := newBitmap()
+		s.RunOptimize()
+
+		b.ResetTimer()
+
+		for j := 0; j < b.N; j++ {
+			c9 = uint(0)
+			i := s.Iterator()
+			for i.HasNext() {
+				i.Next()
+				c9++
+			}
+		}
+	})
+
+	b.Run("iterator", func(b *testing.B) {
+		b.ReportAllocs()
+
+		s := newBitmap()
+
+		b.ResetTimer()
+
+		for j := 0; j < b.N; j++ {
+			c9 = uint(0)
+			i := s.Iterator()
+			for i.HasNext() {
+				i.Next()
+				c9++
+			}
+		}
+	})
+
+	b.Run("iterate-compressed", func(b *testing.B) {
+		b.ReportAllocs()
+
+		s := newBitmap()
+		s.RunOptimize()
+
+		b.ResetTimer()
+
+		for j := 0; j < b.N; j++ {
+			c9 = uint(0)
+			s.Iterate(func(x uint32) {
+				c9++
+			})
+		}
+	})
+
+	b.Run("iterate", func(b *testing.B) {
+		b.ReportAllocs()
+
+		s := newBitmap()
+
+		b.ResetTimer()
+
+		for j := 0; j < b.N; j++ {
+			c9 = uint(0)
+			s.Iterate(func(x uint32) {
+				c9++
+			})
+		}
+	})
 }
 
 // go test -bench BenchmarkSparseIterate -run -

--- a/bitmapcontainer.go
+++ b/bitmapcontainer.go
@@ -96,12 +96,15 @@ func (bc *bitmapContainer) maximum() uint16 {
 	return uint16(0)
 }
 
-func (bc *bitmapContainer) iterate(cb func(x uint16)) {
+func (bc *bitmapContainer) iterate(cb func(x uint16) bool) bool {
 	for i := bc.NextSetBit(0); i >= 0; {
 		j := i
 		i = bc.NextSetBit(i + 1)
-		cb(uint16(j))
+		if !cb(uint16(j)) {
+			return false
+		}
 	}
+	return true
 }
 
 type bitmapContainerShortIterator struct {

--- a/bitmapcontainer.go
+++ b/bitmapcontainer.go
@@ -96,6 +96,14 @@ func (bc *bitmapContainer) maximum() uint16 {
 	return uint16(0)
 }
 
+func (bc *bitmapContainer) iterate(cb func(x uint16)) {
+	for i := bc.NextSetBit(0); i >= 0; {
+		j := i
+		i = bc.NextSetBit(i + 1)
+		cb(uint16(j))
+	}
+}
+
 type bitmapContainerShortIterator struct {
 	ptr *bitmapContainer
 	i   int

--- a/bitmapcontainer.go
+++ b/bitmapcontainer.go
@@ -97,13 +97,14 @@ func (bc *bitmapContainer) maximum() uint16 {
 }
 
 func (bc *bitmapContainer) iterate(cb func(x uint16) bool) bool {
-	for i := bc.NextSetBit(0); i >= 0; {
-		j := i
-		i = bc.NextSetBit(i + 1)
-		if !cb(uint16(j)) {
+	iterator := bitmapContainerShortIterator{bc, bc.NextSetBit(0)}
+
+	for iterator.hasNext() {
+		if !cb(iterator.next()) {
 			return false
 		}
 	}
+
 	return true
 }
 

--- a/roaring.go
+++ b/roaring.go
@@ -421,10 +421,8 @@ func (rb *Bitmap) String() string {
 // The iteration results are undefined if the bitmap is modified (e.g., with Add or Remove).
 // There is no guarantee as to what order the values will be iterated
 func (rb *Bitmap) Iterate(cb func(x uint32) bool) {
-	var hs uint32
 	for i := 0; i < rb.highlowcontainer.size(); i++ {
-		hs = uint32(rb.highlowcontainer.getKeyAtIndex(i)) << 16
-
+		hs := uint32(rb.highlowcontainer.getKeyAtIndex(i)) << 16
 		c := rb.highlowcontainer.getContainerAtIndex(i)
 
 		var shouldContinue bool
@@ -443,8 +441,9 @@ func (rb *Bitmap) Iterate(cb func(x uint32) bool) {
 				return cb(uint32(x) | hs)
 			})
 		}
+
 		if !shouldContinue {
-			return
+			break
 		}
 	}
 }

--- a/roaring_test.go
+++ b/roaring_test.go
@@ -2308,3 +2308,51 @@ func TestBitmapFlipMaxRangeEnd(t *testing.T) {
 
 	assert.EqualValues(t, MaxRange, bm.GetCardinality())
 }
+
+func TestIterate(t *testing.T) {
+	rb := NewBitmap()
+
+	for i := 0; i < 300; i++ {
+		rb.Add(uint32(i))
+	}
+
+	var values []uint32
+	rb.Iterate(func(x uint32) {
+		values = append(values, x)
+	})
+
+	assert.Equal(t, rb.ToArray(), values)
+}
+
+func TestIterateCompressed(t *testing.T) {
+	rb := NewBitmap()
+
+	for i := 0; i < 300; i++ {
+		rb.Add(uint32(i))
+	}
+
+	rb.RunOptimize()
+
+	var values []uint32
+	rb.Iterate(func(x uint32) {
+		values = append(values, x)
+	})
+
+	assert.Equal(t, rb.ToArray(), values)
+}
+
+func TestIterateLargeValues(t *testing.T) {
+	rb := NewBitmap()
+
+	// This range of values ensures that all different types of containers will be used
+	for i := 150000; i < 450000; i++ {
+		rb.Add(uint32(i))
+	}
+
+	var values []uint32
+	rb.Iterate(func(x uint32) {
+		values = append(values, x)
+	})
+
+	assert.Equal(t, rb.ToArray(), values)
+}

--- a/roaringarray.go
+++ b/roaringarray.go
@@ -4,9 +4,10 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+	"io"
+
 	snappy "github.com/glycerine/go-unsnap-stream"
 	"github.com/tinylib/msgp/msgp"
-	"io"
 )
 
 //go:generate msgp -unexported
@@ -38,6 +39,7 @@ type container interface {
 	inot(firstOfRange, endx int) container // i stands for inplace, range is [firstOfRange,endx)
 	xor(r container) container
 	getShortIterator() shortPeekable
+	iterate(cb func(x uint16))
 	getReverseIterator() shortIterable
 	getManyIterator() manyIterable
 	contains(i uint16) bool

--- a/roaringarray.go
+++ b/roaringarray.go
@@ -39,7 +39,7 @@ type container interface {
 	inot(firstOfRange, endx int) container // i stands for inplace, range is [firstOfRange,endx)
 	xor(r container) container
 	getShortIterator() shortPeekable
-	iterate(cb func(x uint16))
+	iterate(cb func(x uint16) bool) bool
 	getReverseIterator() shortIterable
 	getManyIterator() manyIterable
 	contains(i uint16) bool

--- a/runcontainer.go
+++ b/runcontainer.go
@@ -1162,6 +1162,30 @@ func (rc *runContainer16) newRunIterator16() *runIterator16 {
 	return &runIterator16{rc: rc, curIndex: 0, curPosInIndex: 0}
 }
 
+func (rc *runContainer16) iterate(cb func(x uint16)) {
+	curIndex := int64(0)
+	curPosInIndex := uint16(0)
+
+	hasNext := func() bool {
+		return int64(len(rc.iv)) > curIndex+1 ||
+			(int64(len(rc.iv)) == curIndex+1 && rc.iv[curIndex].length >= curPosInIndex)
+	}
+
+	for hasNext() {
+		next := rc.iv[curIndex].start + curPosInIndex
+
+		if curPosInIndex == rc.iv[curIndex].length {
+			curPosInIndex = 0
+			curIndex++
+		} else {
+			curPosInIndex++
+		}
+
+		cb(next)
+	}
+
+}
+
 // hasNext returns false if calling next will panic. It
 // returns true when there is at least one more value
 // available in the iteration sequence.

--- a/runcontainer.go
+++ b/runcontainer.go
@@ -1162,7 +1162,7 @@ func (rc *runContainer16) newRunIterator16() *runIterator16 {
 	return &runIterator16{rc: rc, curIndex: 0, curPosInIndex: 0}
 }
 
-func (rc *runContainer16) iterate(cb func(x uint16)) {
+func (rc *runContainer16) iterate(cb func(x uint16) bool) bool {
 	curIndex := int64(0)
 	curPosInIndex := uint16(0)
 
@@ -1181,9 +1181,12 @@ func (rc *runContainer16) iterate(cb func(x uint16)) {
 			curPosInIndex++
 		}
 
-		cb(next)
+		if !cb(next) {
+			return false
+		}
 	}
 
+	return true
 }
 
 // hasNext returns false if calling next will panic. It

--- a/runcontainer.go
+++ b/runcontainer.go
@@ -1163,25 +1163,10 @@ func (rc *runContainer16) newRunIterator16() *runIterator16 {
 }
 
 func (rc *runContainer16) iterate(cb func(x uint16) bool) bool {
-	curIndex := int64(0)
-	curPosInIndex := uint16(0)
+	iterator := runIterator16{rc, 0, 0}
 
-	hasNext := func() bool {
-		return int64(len(rc.iv)) > curIndex+1 ||
-			(int64(len(rc.iv)) == curIndex+1 && rc.iv[curIndex].length >= curPosInIndex)
-	}
-
-	for hasNext() {
-		next := rc.iv[curIndex].start + curPosInIndex
-
-		if curPosInIndex == rc.iv[curIndex].length {
-			curPosInIndex = 0
-			curIndex++
-		} else {
-			curPosInIndex++
-		}
-
-		if !cb(next) {
+	for iterator.hasNext() {
+		if !cb(iterator.next()) {
 			return false
 		}
 	}


### PR DESCRIPTION
One of our applications currently makes heavy use of Iterators.  We noticed that they are a minor but noticeable source of allocations (along with the associated cpu & gc cost) in our application due to each Iterator being heap allocated along with the internal iterators each container creates.

This commit provides an alternate Iterate() method with a callback that iterates the bitmap in place, invoking the callback for each value.  This avoids allocations entirely at the cost of some code duplication

Below are benchmarks, you can see that `iterate` doesn't allocate and is slightly faster.

```
$ go test -run=none -bench=BenchmarkIterateRoaring -count 25

$ benchstat
name                                  time/op
IterateRoaring/iterator-compressed-8  519µs ± 3%
IterateRoaring/iterator-8             517µs ± 4%
IterateRoaring/iterate-compressed-8   349µs ± 4%
IterateRoaring/iterate-8              347µs ± 3%

name                                  alloc/op
IterateRoaring/iterator-compressed-8  96.0B ± 0%
IterateRoaring/iterator-8             96.0B ± 0%
IterateRoaring/iterate-compressed-8   0.00B
IterateRoaring/iterate-8              0.00B

name                                  allocs/op
IterateRoaring/iterator-compressed-8   4.00 ± 0%
IterateRoaring/iterator-8              4.00 ± 0%
IterateRoaring/iterate-compressed-8    0.00
IterateRoaring/iterate-8               0.00
```

@lemire please let me know your thoughts, I'm open to alternatives as well.