### PR TITLE
add AndAny method

### DIFF
--- a/arraycontainer.go
+++ b/arraycontainer.go
@@ -892,7 +892,7 @@ func (ac *arrayContainer) resetTo(a container) {
 		ac.realloc(card)
 		cur := 0
 		for _, r := range x.iv {
-			for val := r.start; val <= r.start+r.length; val++ {
+			for val := r.start; val <= r.last(); val++ {
 				ac.content[cur] = val
 				cur++
 			}

--- a/arraycontainer.go
+++ b/arraycontainer.go
@@ -876,6 +876,41 @@ func (ac *arrayContainer) loadData(bitmapContainer *bitmapContainer) {
 	ac.content = make([]uint16, bitmapContainer.cardinality, bitmapContainer.cardinality)
 	bitmapContainer.fillArray(ac.content)
 }
+
+func (ac *arrayContainer) resetTo(a container) {
+	switch x := a.(type) {
+	case *arrayContainer:
+		ac.realloc(len(x.content))
+		copy(ac.content, x.content)
+
+	case *bitmapContainer:
+		ac.realloc(x.cardinality)
+		x.fillArray(ac.content)
+
+	case *runContainer16:
+		card := int(x.cardinality())
+		ac.realloc(card)
+		cur := 0
+		for _, r := range x.iv {
+			for val := r.start; val < r.start+r.length; val++ {
+				ac.content[cur] = val
+				cur++
+			}
+		}
+
+	default:
+		panic("unsupported container type")
+	}
+}
+
+func (ac *arrayContainer) realloc(size int) {
+	if cap(ac.content) < size {
+		ac.content = make([]uint16, size)
+	} else {
+		ac.content = ac.content[:size]
+	}
+}
+
 func newArrayContainer() *arrayContainer {
 	p := new(arrayContainer)
 	return p

--- a/arraycontainer.go
+++ b/arraycontainer.go
@@ -892,7 +892,7 @@ func (ac *arrayContainer) resetTo(a container) {
 		ac.realloc(card)
 		cur := 0
 		for _, r := range x.iv {
-			for val := r.start; val < r.start+r.length; val++ {
+			for val := r.start; val <= r.start+r.length; val++ {
 				ac.content[cur] = val
 				cur++
 			}

--- a/bitmapcontainer.go
+++ b/bitmapcontainer.go
@@ -945,7 +945,7 @@ func (bc *bitmapContainer) resetTo(a container) {
 		copy(bc.bitmap, x.bitmap)
 
 	case *runContainer16:
-		bc.cardinality = 0
+		bc.cardinality = len(x.iv)
 		lastEnd := 0
 		for _, r := range x.iv {
 			bc.cardinality += int(r.length)

--- a/bitmapcontainer.go
+++ b/bitmapcontainer.go
@@ -934,6 +934,31 @@ func (bc *bitmapContainer) loadData(arrayContainer *arrayContainer) {
 	}
 }
 
+func (bc *bitmapContainer) resetTo(a container) {
+	switch x := a.(type) {
+	case *arrayContainer:
+		fill(bc.bitmap, 0)
+		bc.loadData(x)
+
+	case *bitmapContainer:
+		bc.cardinality = x.cardinality
+		copy(bc.bitmap, x.bitmap)
+
+	case *runContainer16:
+		bc.cardinality = 0
+		lastEnd := 0
+		for _, r := range x.iv {
+			bc.cardinality += int(r.length)
+			resetBitmapRange(bc.bitmap, lastEnd, int(r.start))
+			setBitmapRange(bc.bitmap, int(r.start), int(r.start+r.length))
+			lastEnd = int(r.start + r.length)
+		}
+
+	default:
+		panic("unsupported container type")
+	}
+}
+
 func (bc *bitmapContainer) toArrayContainer() *arrayContainer {
 	ac := &arrayContainer{}
 	ac.loadData(bc)

--- a/bitmapcontainer.go
+++ b/bitmapcontainer.go
@@ -950,9 +950,10 @@ func (bc *bitmapContainer) resetTo(a container) {
 		for _, r := range x.iv {
 			bc.cardinality += int(r.length)
 			resetBitmapRange(bc.bitmap, lastEnd, int(r.start))
-			setBitmapRange(bc.bitmap, int(r.start), int(r.start+r.length))
-			lastEnd = int(r.start + r.length)
+			lastEnd = int(r.start+r.length) + 1
+			setBitmapRange(bc.bitmap, int(r.start), lastEnd)
 		}
+		resetBitmapRange(bc.bitmap, lastEnd, maxCapacity)
 
 	default:
 		panic("unsupported container type")

--- a/bitmapcontainer_test.go
+++ b/bitmapcontainer_test.go
@@ -238,3 +238,59 @@ func TestBitmapOffset(t *testing.T) {
 		assert.Equal(t, expected[i], x)
 	}
 }
+
+func TestBitmapContainerResetTo(t *testing.T) {
+	array := newArrayContainer()
+	for i := 0; i < 1000; i++ {
+		array.iadd(uint16(i*1000 + i + 50))
+	}
+
+	bitmap := newBitmapContainer()
+	for i := 0; i < 10000; i++ {
+		bitmap.iadd(uint16(i*1000 + i + 50))
+	}
+
+	run := newRunContainer16()
+	for i := 0; i < 10; i++ {
+		start := i*1000 + i + 50
+		run.iaddRange(start, start+100+i)
+	}
+
+	makeDirty := func() *bitmapContainer {
+		ret := newBitmapContainer()
+		for i := 0; i < maxCapacity; i += 42 {
+			ret.iadd(uint16(i))
+		}
+		return ret
+	}
+
+	t.Run("to array container", func(t *testing.T) {
+		clean := newBitmapContainer()
+		clean.resetTo(array)
+		assert.True(t, clean.toArrayContainer().equals(array))
+
+		dirty := makeDirty()
+		dirty.resetTo(array)
+		assert.True(t, dirty.toArrayContainer().equals(array))
+	})
+
+	t.Run("to bitmap container", func(t *testing.T) {
+		clean := newBitmapContainer()
+		clean.resetTo(bitmap)
+		assert.True(t, clean.equals(bitmap))
+
+		dirty := makeDirty()
+		dirty.resetTo(bitmap)
+		assert.True(t, dirty.equals(bitmap))
+	})
+
+	t.Run("to run container", func(t *testing.T) {
+		clean := newBitmapContainer()
+		clean.resetTo(run)
+		assert.True(t, clean.toEfficientContainer().equals(run))
+
+		dirty := makeDirty()
+		dirty.resetTo(run)
+		assert.True(t, dirty.toEfficientContainer().equals(run))
+	})
+}

--- a/bitmapcontainer_test.go
+++ b/bitmapcontainer_test.go
@@ -287,10 +287,12 @@ func TestBitmapContainerResetTo(t *testing.T) {
 	t.Run("to run container", func(t *testing.T) {
 		clean := newBitmapContainer()
 		clean.resetTo(run)
+		assert.EqualValues(t, clean.cardinality, run.cardinality())
 		assert.True(t, clean.toEfficientContainer().equals(run))
 
 		dirty := makeDirty()
 		dirty.resetTo(run)
+		assert.EqualValues(t, dirty.cardinality, run.cardinality())
 		assert.True(t, dirty.toEfficientContainer().equals(run))
 	})
 }

--- a/fastaggregation.go
+++ b/fastaggregation.go
@@ -224,9 +224,6 @@ func (rb *Bitmap) AndAny(bitmaps ...*Bitmap) {
 		return
 	}
 
-	basePos := 0
-	intersections := 0
-
 	type withPos struct {
 		bitmap *roaringArray
 		pos    int
@@ -244,8 +241,9 @@ func (rb *Bitmap) AndAny(bitmaps ...*Bitmap) {
 		}
 	}
 
+	basePos := 0
+	intersections := 0
 	keyContainers := make([]container, 0, len(filters))
-
 	var (
 		tmpArray  *arrayContainer
 		tmpBitmap *bitmapContainer
@@ -282,8 +280,6 @@ func (rb *Bitmap) AndAny(bitmaps ...*Bitmap) {
 			continue
 		}
 
-		baseContainer := rb.highlowcontainer.getWritableContainerAtIndex(basePos)
-
 		var ored container
 
 		if len(keyContainers) == 1 {
@@ -312,9 +308,9 @@ func (rb *Bitmap) AndAny(bitmaps ...*Bitmap) {
 			}
 		}
 
-		baseContainer.iand(ored)
-		if baseContainer.getCardinality() > 0 {
-			rb.highlowcontainer.replaceKeyAndContainerAtIndex(intersections, baseKey, baseContainer, false)
+		result := rb.highlowcontainer.getWritableContainerAtIndex(basePos).iand(ored)
+		if result.getCardinality() > 0 {
+			rb.highlowcontainer.replaceKeyAndContainerAtIndex(intersections, baseKey, result, false)
 			intersections++
 		}
 

--- a/fastaggregation_test.go
+++ b/fastaggregation_test.go
@@ -191,3 +191,40 @@ func TestFastAggregationsXOR_run(t *testing.T) {
 
 	assert.True(t, HeapXor(rb1, rb2, rb3).Equals(bigxor))
 }
+
+func TestFastAggregationsAndAny(t *testing.T) {
+	rb1 := NewBitmap()
+	rb2 := NewBitmap()
+	rb3 := NewBitmap()
+	rb4 := NewBitmap()
+	for i := uint32(500); i < 75000; i++ {
+		rb1.Add(i)
+	}
+	for i := uint32(0); i < 1000000; i += 7 {
+		rb2.Add(i)
+	}
+	for i := uint32(0); i < 1000000; i += 1001 {
+		rb3.Add(i)
+	}
+	for i := uint32(1000000); i < 2000000; i += 1001 {
+		rb1.Add(i)
+	}
+	for i := uint32(1000000); i < 2000000; i += 3 {
+		rb2.Add(i)
+	}
+	for i := uint32(1000000); i < 2000000; i += 7 {
+		rb3.Add(i)
+	}
+
+	rb4.Add(1001001)
+
+	rb1.RunOptimize()
+
+	base := rb1.Clone()
+	base.And(FastOr(rb2, rb3, rb4))
+
+	fast := rb1.Clone()
+	fast.AndAny(rb2, rb3, rb4)
+
+	assert.True(t, fast.Equals(base))
+}

--- a/roaringarray.go
+++ b/roaringarray.go
@@ -491,11 +491,11 @@ func (ra *roaringArray) writeTo(w io.Writer) (n int64, err error) {
 		binary.LittleEndian.PutUint16(buf[2:], uint16(len(ra.keys)-1))
 		nw += 2
 		// compute isRun bitmap without temporary allocation
-		var runbitmapslice = buf[nw:nw+isRunSizeInBytes]
+		var runbitmapslice = buf[nw : nw+isRunSizeInBytes]
 		for i, c := range ra.containers {
 			switch c.(type) {
 			case *runContainer16:
-				runbitmapslice[i / 8] |= 1<<(uint(i)%8)
+				runbitmapslice[i/8] |= 1 << (uint(i) % 8)
 			}
 		}
 		nw += isRunSizeInBytes


### PR DESCRIPTION
This method provides shortcut for `rb.And(FastOr(bitmaps...))`.
I tried mainly to minimize allocations, as huge amounts of garbage are a major concern in my current workflow.

Benchmark results:
```
$ go test -v -bench AndAny -benchmem -run=^$
goos: linux
goarch: amd64
pkg: github.com/RoaringBitmap/roaring
BenchmarkAndAny
BenchmarkAndAny/small-base_or-first
BenchmarkAndAny/small-base_or-first-4                 24          46254232 ns/op        35107140 B/op       9197 allocs/op
BenchmarkAndAny/small-base_and-first
BenchmarkAndAny/small-base_and-first-4              7383            148264 ns/op           26448 B/op       1485 allocs/op
BenchmarkAndAny/small-base_AndAny
BenchmarkAndAny/small-base_AndAny-4                  318           3369823 ns/op           46909 B/op         10 allocs/op
BenchmarkAndAny/small-filters_or-first
BenchmarkAndAny/small-filters_or-first-4            1364            851162 ns/op          784129 B/op       1417 allocs/op
BenchmarkAndAny/small-filters_and-first
BenchmarkAndAny/small-filters_and-first-4           9811            122298 ns/op           22560 B/op       1262 allocs/op
BenchmarkAndAny/small-filters_AndAny
BenchmarkAndAny/small-filters_AndAny-4              6522            210888 ns/op             565 B/op          5 allocs/op
BenchmarkAndAny/equal_or-first
BenchmarkAndAny/equal_or-first-4                      45          43176037 ns/op        26469836 B/op       9259 allocs/op
BenchmarkAndAny/equal_and-first
BenchmarkAndAny/equal_and-first-4                    130          11011968 ns/op         2213365 B/op      31790 allocs/op
BenchmarkAndAny/equal_AndAny
BenchmarkAndAny/equal_AndAny-4                        82          12343330 ns/op            8093 B/op         45 allocs/op
PASS
ok      github.com/RoaringBitmap/roaring        27.690s
```

It's still WIP but seems to perform reasonably well.