### PR TITLE
unsafe extraction.

### DIFF
--- a/byte_input.go
+++ b/byte_input.go
@@ -1,8 +1,8 @@
 package roaring
 
 import (
-	"encoding/binary"
 	"io"
+	"unsafe"
 )
 
 type byteInput interface {
@@ -59,7 +59,7 @@ func (b *byteBuffer) readUInt32() (uint32, error) {
 		return 0, io.ErrUnexpectedEOF
 	}
 
-	v := binary.LittleEndian.Uint32(b.buf[b.off:])
+	v := *(*uint32)(unsafe.Pointer(&b.buf[b.off]))
 	b.off += 4
 
 	return v, nil
@@ -71,7 +71,7 @@ func (b *byteBuffer) readUInt16() (uint16, error) {
 		return 0, io.ErrUnexpectedEOF
 	}
 
-	v := binary.LittleEndian.Uint16(b.buf[b.off:])
+	v := *(*uint16)(unsafe.Pointer(&b.buf[b.off]))
 	b.off += 2
 
 	return v, nil
@@ -128,7 +128,7 @@ func (b *byteInputAdapter) readUInt32() (uint32, error) {
 		return 0, err
 	}
 
-	return binary.LittleEndian.Uint32(buf), nil
+	return *(*uint32)(unsafe.Pointer(&buf[0])), nil
 }
 
 // readUInt16 reads uint16 with LittleEndian order
@@ -139,7 +139,7 @@ func (b *byteInputAdapter) readUInt16() (uint16, error) {
 		return 0, err
 	}
 
-	return binary.LittleEndian.Uint16(buf), nil
+	return *(*uint16)(unsafe.Pointer(&buf[0])), nil
 }
 
 // getReadBytes returns read bytes

--- a/serialization_test.go
+++ b/serialization_test.go
@@ -771,3 +771,36 @@ func BenchmarkUnserializeFromBuffer(b *testing.B) {
 		})
 	}
 }
+
+func BenchmarkUnserializeFromBufferSparse(b *testing.B) {
+	for _, size := range []uint32{650, 6500, 65000} {
+		rb := New()
+		buf := &bytes.Buffer{}
+
+		for i := uint32(0); i < size; i++ {
+			rb.Add(i << 14)
+		}
+
+		_, err := rb.WriteTo(buf)
+
+		if err != nil {
+			b.Fatalf("Unexpected error occurs: %v", err)
+		}
+		b.N = 50
+
+		b.Run(fmt.Sprintf("FromBuffer-%d", size), func(b *testing.B) {
+			b.ReportAllocs()
+			b.StartTimer()
+
+			for n := 0; n < b.N; n++ {
+				nb := New()
+
+				if _, err := nb.FromBuffer(buf.Bytes()); err != nil {
+					b.Fatalf("Unexpected error occurs: %v", err)
+				}
+			}
+
+			b.StopTimer()
+		})
+	}
+}


### PR DESCRIPTION
Unsafe read performance benchmark.

 Should we be using this unsafe operation for the byte_input.go read operations? It relies on the underlying system being little endian, but I believe that this is already a requirement for the other uses of unsafe on arrays.

My results on OS X give

goos: darwin
goarch: amd64
pkg: github.com/RoaringBitmap/roaring
BenchmarkUint32SafeReading-12      	1000000000	         0.000764 ns/op
BenchmarkUint32UnsafeReading-12    	1000000000	         0.000417 ns/op
