### PR TITLE
make arrayContainer's iorArray optimistic.

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -12,6 +12,36 @@ import (
 
 // BENCHMARKS, to run them type "go test -bench Benchmark -run -"
 
+// BenchmarkArrayIorMergeThreshold tests performance
+// when unioning two array containers when the cardinality sum is over 4096
+func BenchmarkArrayIorMergeThreshold(b *testing.B) {
+	testOddPoint := map[string]int{
+		"mostly-overlap": 4900,
+		"little-overlap": 2000,
+		"no-overlap":     0,
+	}
+	for name, oddPoint := range testOddPoint {
+		b.Run(name, func(b *testing.B) {
+			left := newArrayContainer()
+			right := newArrayContainer()
+			for i := 0; i < 5000; i++ {
+				if i%2 == 0 {
+					left.iadd(uint16(i))
+				}
+				if i%2 == 0 && i < oddPoint {
+					right.iadd(uint16(i))
+				} else if i%2 == 1 && i >= oddPoint {
+					right.iadd(uint16(i))
+				}
+			}
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				right.clone().ior(left)
+			}
+		})
+	}
+}
+
 // go test -bench BenchmarkOrs -benchmem -run -
 func BenchmarkOrs(b *testing.B) {
 


### PR DESCRIPTION
The current code for arraycontainers' iorArray method is pessimistic about the likelihood of the union staying under 4096. If the sum of cardinalities is greater than 4096 it creates a bitmap container, iterates over each container, flipping bits as appropriate. Then, if the final size is <=4096, it converts it back to an array container.

This change makes this operation optimistic, checking only after taking the union to see if it should be a bitmap. As you can see from the benchmarks, neither approach is dominant. If you need a bitmap, better to just convert to start with. However, if the result is still an array, you save a bunch of time by never involving bitmaps. 

I think this change is preferable for two reasons. First, if you are repeatedly ORing containers together, you'll only trigger the slow mode at most once. The current code can repeatedly take the bitmap path and then convert back to arrays. Secondly, the new code is somewhat simpler.

It does make some things slower, so I'm curious to hear if people are comfortable with that change.

current:
```
BenchmarkArrayIorMergeThreshold/mostly-overlap-12	71218	16349 ns/op
BenchmarkArrayIorMergeThreshold/little-overlap-12	75625	16343 ns/op
BenchmarkArrayIorMergeThreshold/no-overlap-12		110556	11090 ns/op
```
with change 
```
BenchmarkArrayIorMergeThreshold/mostly-overlap-12	138745	7968 ns/op
BenchmarkArrayIorMergeThreshold/little-overlap-12	122030	10970 ns/op
BenchmarkArrayIorMergeThreshold/no-overlap-12		67244	20027 ns/op
```