### PR TITLE
Minimize clones (WIP)

### DIFF
--- a/roaring.go
+++ b/roaring.go
@@ -1006,7 +1006,7 @@ main:
 				}
 				s2 = x2.highlowcontainer.getKeyAtIndex(pos2)
 			} else {
-				rb.highlowcontainer.replaceKeyAndContainerAtIndex(pos1, s1, rb.highlowcontainer.getWritableContainerAtIndex(pos1).ior(x2.highlowcontainer.getContainerAtIndex(pos2)), false)
+				rb.highlowcontainer.replaceKeyAndContainerAtIndex(pos1, s1, rb.highlowcontainer.getUnionedWritableContainer(pos1, x2.highlowcontainer.getContainerAtIndex(pos2)), false)
 				pos1++
 				pos2++
 				if (pos1 == length1) || (pos2 == length2) {

--- a/roaringarray.go
+++ b/roaringarray.go
@@ -328,6 +328,17 @@ func (ra *roaringArray) getFastContainerAtIndex(i int, needsWriteable bool) cont
 	return c
 }
 
+// getUnionedWritableContainer switches behavior for in-place Or
+// depending on whether the container requires a copy on write.
+// If it does using the non-inplace or() method leads to fewer allocations.
+func (ra *roaringArray) getUnionedWritableContainer(pos int, other container) container {
+	if ra.needCopyOnWrite[pos] {
+		return ra.getContainerAtIndex(pos).or(other)
+	}
+	return ra.getContainerAtIndex(pos).ior(other)
+
+}
+
 func (ra *roaringArray) getWritableContainerAtIndex(i int) container {
 	if ra.needCopyOnWrite[i] {
 		ra.containers[i] = ra.containers[i].clone()

--- a/roaringcow_test.go
+++ b/roaringcow_test.go
@@ -1939,3 +1939,38 @@ func TestCloneCOWContainers(t *testing.T) {
 
 	assert.EqualValues(t, rb.ToArray(), newRb1.ToArray())
 }
+
+func TestInPlaceCOWContainers(t *testing.T) {
+	// write bitmap
+	wb1 := NewBitmap()
+	wb2 := NewBitmap()
+
+	wb1.AddRange(0, 3000)
+	wb2.AddRange(2000, 5000)
+
+	buf1 := &bytes.Buffer{}
+	buf2 := &bytes.Buffer{}
+
+	wb1.WriteTo(buf1)
+	wb2.WriteTo(buf2)
+
+	// read bitmaps
+	rb1 := NewBitmap()
+	rb2 := NewBitmap()
+
+	rb1.FromBuffer(buf1.Bytes())
+	rb2.FromBuffer(buf2.Bytes())
+
+	assert.True(t, wb1.Equals(rb1))
+	assert.True(t, wb2.Equals(rb2))
+
+	rb1.Or(rb2)
+
+	assert.True(t, Or(wb1, wb2).Equals(rb1))
+	assert.True(t, wb2.Equals(rb2))
+
+	rb3 := NewBitmap()
+	rb3.FromBuffer(buf1.Bytes())
+
+	assert.True(t, rb3.Equals(wb1))
+}


### PR DESCRIPTION
This is a change for #265, with a benchmark that demonstrates the effect that it has. The actual change is good to go, although I'm not certain if it is in the most elegant manner.

The benchmark is kinda hideous, but gets at the target of this change: If the receiving bitmap's containers are COW, as they tend to be if deserialized from bytes, then you end up doing allocations both within `getWritableContainerAtIndex()` and `ior()`, as your array containers need to be extended again when ior() is called. The benchmark results below show this, and in general performance is the same or better, although there are circumstances where it does degrade slightly. 

The benchmark is targeted at producing bitmaps entirely of array containers, albeit of varying numbers of containers and densitities. The decrease in total allocations is almost entirely determined by the number of containers on each side, while the decrease in bytes allocated depends more on the total number of entries within the left side.

The tests are named like `leftContainerPower-rightContainerPower-leftItemsPerContainerPower-rightItemsPerContainerPower`, so that the test `UnionInplaceCopyOnWrite/4-7-10-3` Has a left bitmap of 16 (2^4) containers containing about 1024 (2^10) element, while the right bitmap has 128 (2^7) containers of about 8 (2^3) elements each.

I ran each test 4 times, using 
```
go test -run=NONE -cpu 1 -benchtime 100ms  -bench=BenchmarkUnionInplaceCopyOnWrite -benchmem  . >> new.txt
```

The runs were on golang 1.15, on a MacBook, so the CPU times aren't incredibly reliable. If they are a matter of concern I can get better tests on an EC2 box.


```
benchstat  old.txt new.txt
name                                 old time/op    new time/op    delta
UnionInplaceCopyOnWrite/4-4-3-3        3.85µs ± 5%    3.07µs ± 6%  -20.32%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/4-4-3-10       40.0µs ± 1%    41.0µs ± 9%     ~     (p=0.486 n=4+4)
UnionInplaceCopyOnWrite/4-4-10-3       35.9µs ± 4%    25.7µs ± 7%  -28.52%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/4-4-10-10       143µs ± 4%     143µs ± 3%     ~     (p=0.886 n=4+4)
UnionInplaceCopyOnWrite/4-7-3-3        9.65µs ± 9%    8.66µs ± 7%     ~     (p=0.114 n=4+4)
UnionInplaceCopyOnWrite/4-7-3-10       39.5µs ± 6%    39.2µs ± 3%     ~     (p=1.000 n=4+4)
UnionInplaceCopyOnWrite/4-7-10-3       36.5µs ± 5%    28.2µs ± 6%  -22.65%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/4-7-10-10       145µs ± 3%     146µs ± 3%     ~     (p=0.886 n=4+4)
UnionInplaceCopyOnWrite/4-10-3-3       48.2µs ± 1%    48.8µs ± 8%     ~     (p=1.000 n=4+4)
UnionInplaceCopyOnWrite/4-10-3-10      70.2µs ± 9%    65.5µs ± 9%     ~     (p=0.343 n=4+4)
UnionInplaceCopyOnWrite/4-10-10-3      76.9µs ± 3%    63.7µs ± 6%  -17.11%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/4-10-10-10      172µs ± 6%     167µs ± 5%     ~     (p=0.486 n=4+4)
UnionInplaceCopyOnWrite/7-4-3-3        4.58µs ±34%    4.60µs ±34%     ~     (p=0.686 n=4+4)
UnionInplaceCopyOnWrite/7-4-3-10       44.2µs ± 8%    41.4µs ± 3%     ~     (p=0.057 n=4+4)
UnionInplaceCopyOnWrite/7-4-10-3       44.6µs ± 9%    31.0µs ± 4%  -30.49%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/7-4-10-10       155µs ± 5%     149µs ± 5%     ~     (p=0.343 n=4+4)
UnionInplaceCopyOnWrite/7-7-3-3        35.8µs ± 6%    25.9µs ± 6%  -27.57%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/7-7-3-10        271µs ± 2%     265µs ± 3%     ~     (p=0.200 n=4+4)
UnionInplaceCopyOnWrite/7-7-10-3        243µs ± 7%     182µs ± 5%  -25.03%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/7-7-10-10      1.15ms ± 9%    1.12ms ± 6%     ~     (p=0.686 n=4+4)
UnionInplaceCopyOnWrite/7-10-3-3       69.5µs ± 8%    68.0µs ± 3%     ~     (p=0.886 n=4+4)
UnionInplaceCopyOnWrite/7-10-3-10       288µs ± 9%     289µs ± 3%     ~     (p=0.486 n=4+4)
UnionInplaceCopyOnWrite/7-10-10-3       283µs ± 8%     232µs ± 3%  -17.86%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/7-10-10-10     1.13ms ± 5%    1.09ms ± 1%     ~     (p=0.486 n=4+4)
UnionInplaceCopyOnWrite/10-4-3-3       12.7µs ± 6%     7.4µs ±36%  -41.58%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/10-4-3-10      50.3µs ±13%    68.1µs ±16%  +35.32%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/10-4-10-3      64.8µs ± 5%    49.5µs ±19%  -23.55%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/10-4-10-10      176µs ± 3%     163µs ±14%     ~     (p=0.114 n=4+4)
UnionInplaceCopyOnWrite/10-7-3-3       32.6µs ±42%    44.7µs ±15%     ~     (p=0.114 n=4+4)
UnionInplaceCopyOnWrite/10-7-3-10       358µs ± 4%     338µs ±10%     ~     (p=0.486 n=4+4)
UnionInplaceCopyOnWrite/10-7-10-3       301µs ±11%     228µs ± 9%  -24.13%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/10-7-10-10     1.17ms ± 6%    1.15ms ± 4%     ~     (p=0.886 n=4+4)
UnionInplaceCopyOnWrite/10-10-3-3       278µs ±14%     201µs ± 9%  -27.82%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/10-10-3-10     2.11ms ± 5%    2.15ms ± 7%     ~     (p=0.886 n=4+4)
UnionInplaceCopyOnWrite/10-10-10-3     2.05ms ± 6%    1.43ms ± 6%  -30.36%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/10-10-10-10    9.12ms ± 7%    8.67ms ± 2%     ~     (p=0.343 n=4+4)

name                                 old alloc/op   new alloc/op   delta
UnionInplaceCopyOnWrite/4-4-3-3        1.51kB ± 0%    1.15kB ± 0%  -23.82%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/4-4-3-10       35.5kB ± 0%    35.2kB ± 0%   -0.98%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/4-4-10-3       69.9kB ± 0%    35.3kB ± 1%  -49.54%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/4-4-10-10       104kB ± 0%      70kB ± 0%  -32.89%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/4-7-3-3        5.73kB ± 0%    5.39kB ± 0%   -5.91%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/4-7-3-10       39.8kB ± 0%    39.4kB ± 1%     ~     (p=0.114 n=4+4)
UnionInplaceCopyOnWrite/4-7-10-3       73.8kB ± 0%    39.5kB ± 1%  -46.53%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/4-7-10-10       110kB ± 0%      75kB ± 1%  -31.77%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/4-10-3-3       39.8kB ± 0%    39.4kB ± 0%   -0.87%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/4-10-3-10      74.2kB ± 0%    73.9kB ± 0%   -0.38%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/4-10-10-3       108kB ± 0%      74kB ± 0%  -31.91%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/4-10-10-10      142kB ± 0%     108kB ± 1%  -23.89%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/7-4-3-3        1.48kB ± 2%    1.14kB ± 1%  -23.19%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/7-4-3-10       35.9kB ± 1%    35.3kB ± 0%   -1.63%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/7-4-10-3       69.6kB ± 0%    35.3kB ± 0%  -49.28%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/7-4-10-10       104kB ± 0%      70kB ± 1%  -32.54%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/7-7-3-3        12.0kB ± 3%     9.1kB ± 0%  -24.16%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/7-7-3-10        285kB ± 0%     282kB ± 0%   -0.96%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/7-7-10-3        557kB ± 0%     282kB ± 0%  -49.31%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/7-7-10-10       838kB ± 0%     563kB ± 0%  -32.77%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/7-10-3-3       45.9kB ± 0%    43.1kB ± 0%   -6.04%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/7-10-3-10       319kB ± 0%     316kB ± 0%   -0.76%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/7-10-10-3       591kB ± 0%     316kB ± 0%  -46.52%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/7-10-10-10      873kB ± 0%     598kB ± 0%  -31.50%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/10-4-3-3       1.48kB ± 1%    1.13kB ± 1%  -23.73%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/10-4-3-10      35.6kB ± 0%    35.3kB ± 0%   -0.80%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/10-4-10-3      69.6kB ± 1%    35.1kB ± 1%  -49.53%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/10-4-10-10      105kB ± 0%      70kB ± 1%  -33.00%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/10-7-3-3       13.8kB ±14%    10.1kB ±29%     ~     (p=0.114 n=4+4)
UnionInplaceCopyOnWrite/10-7-3-10       286kB ± 0%     286kB ± 1%     ~     (p=0.343 n=4+4)
UnionInplaceCopyOnWrite/10-7-10-3       556kB ± 0%     282kB ± 0%  -49.27%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/10-7-10-10      839kB ± 0%     563kB ± 0%  -32.86%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/10-10-3-3       107kB ±10%      81kB ± 6%  -24.27%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/10-10-3-10     2.29MB ± 0%    2.27MB ± 0%   -1.20%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/10-10-10-3     4.46MB ± 0%    2.26MB ± 0%  -49.33%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/10-10-10-10    6.71MB ± 0%    4.51MB ± 0%  -32.80%  (p=0.029 n=4+4)

name                                 old allocs/op  new allocs/op  delta
UnionInplaceCopyOnWrite/4-4-3-3          48.0 ± 0%      32.0 ± 0%  -33.33%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/4-4-3-10         48.0 ± 0%      32.0 ± 0%  -33.33%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/4-4-10-3         48.0 ± 0%      32.0 ± 0%  -33.33%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/4-4-10-10        48.0 ± 0%      32.0 ± 0%  -33.33%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/4-7-3-3          56.5 ± 1%      41.0 ± 0%  -27.43%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/4-7-3-10         57.0 ± 0%      41.0 ± 0%  -28.07%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/4-7-10-3         57.0 ± 0%      40.8 ± 2%  -28.51%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/4-7-10-10        57.0 ± 0%      41.0 ± 0%  -28.07%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/4-10-3-3         66.0 ± 0%      50.0 ± 0%  -24.24%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/4-10-3-10        66.0 ± 0%      50.0 ± 0%  -24.24%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/4-10-10-3        66.0 ± 0%      50.0 ± 0%  -24.24%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/4-10-10-10       66.0 ± 0%      50.0 ± 0%  -24.24%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/7-4-3-3          48.0 ± 0%      32.0 ± 0%  -33.33%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/7-4-3-10         48.0 ± 0%      32.0 ± 0%  -33.33%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/7-4-10-3         48.0 ± 0%      32.0 ± 0%  -33.33%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/7-4-10-10        48.0 ± 0%      32.0 ± 0%  -33.33%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/7-7-3-3           384 ± 0%       256 ± 0%  -33.31%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/7-7-3-10          384 ± 0%       256 ± 0%  -33.33%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/7-7-10-3          384 ± 0%       256 ± 0%  -33.33%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/7-7-10-10         384 ± 0%       256 ± 0%  -33.33%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/7-10-3-3          392 ± 0%       264 ± 0%  -32.57%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/7-10-3-10         392 ± 0%       265 ± 0%  -32.48%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/7-10-10-3         393 ± 0%       265 ± 0%  -32.57%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/7-10-10-10        393 ± 0%       265 ± 0%  -32.57%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/10-4-3-3         48.0 ± 0%      32.0 ± 0%  -33.33%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/10-4-3-10        48.0 ± 0%      32.0 ± 0%  -33.33%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/10-4-10-3        47.8 ± 2%      31.8 ± 2%  -33.51%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/10-4-10-10       48.0 ± 0%      32.0 ± 0%  -33.33%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/10-7-3-3          384 ± 0%       256 ± 0%  -33.36%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/10-7-3-10         384 ± 0%       256 ± 0%  -33.33%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/10-7-10-3         384 ± 0%       256 ± 0%  -33.38%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/10-7-10-10        384 ± 0%       256 ± 0%  -33.33%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/10-10-3-3       3.07k ± 0%     2.05k ± 0%  -33.33%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/10-10-3-10      3.07k ± 0%     2.05k ± 0%  -33.34%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/10-10-10-3      3.07k ± 0%     2.05k ± 0%  -33.33%  (p=0.029 n=4+4)
UnionInplaceCopyOnWrite/10-10-10-10     3.07k ± 0%     2.05k ± 0%  -33.33%  (p=0.029 n=4+4)
```