### PR TITLE
Array container alloc optimizations

### DIFF
--- a/arraycontainer.go
+++ b/arraycontainer.go
@@ -362,7 +362,14 @@ func (ac *arrayContainer) iorArray(value2 *arrayContainer) container {
 	if maxPossibleCardinality > cap(value1.content) {
 		// doubling the capacity reduces new slice allocations in the case of
 		// repeated calls to iorArray().
-		newcontent := make([]uint16, 0, 2*maxPossibleCardinality)
+		newSize := 2 * maxPossibleCardinality
+		// the second check is to handle overly large array containers
+		// and should not occur in normal usage,
+		// as all array containers should be at most arrayDefaultMaxSize
+		if newSize > 8192 && maxPossibleCardinality <= 8192 {
+			newSize = 8192
+		}
+		newcontent := make([]uint16, 0, newSize)
 		copy(newcontent[len2:maxPossibleCardinality], ac.content[0:len1])
 		ac.content = newcontent
 	} else {

--- a/arraycontainer.go
+++ b/arraycontainer.go
@@ -359,28 +359,10 @@ func (ac *arrayContainer) iorArray(value2 *arrayContainer) container {
 	len1 := value1.getCardinality()
 	len2 := value2.getCardinality()
 	maxPossibleCardinality := len1 + len2
-	if maxPossibleCardinality > arrayDefaultMaxSize { // it could be a bitmap!
-		bc := newBitmapContainer()
-		for k := 0; k < len(value2.content); k++ {
-			v := value2.content[k]
-			i := uint(v) >> 6
-			mask := uint64(1) << (v % 64)
-			bc.bitmap[i] |= mask
-		}
-		for k := 0; k < len(ac.content); k++ {
-			v := ac.content[k]
-			i := uint(v) >> 6
-			mask := uint64(1) << (v % 64)
-			bc.bitmap[i] |= mask
-		}
-		bc.cardinality = int(popcntSlice(bc.bitmap))
-		if bc.cardinality <= arrayDefaultMaxSize {
-			return bc.toArrayContainer()
-		}
-		return bc
-	}
 	if maxPossibleCardinality > cap(value1.content) {
-		newcontent := make([]uint16, 0, maxPossibleCardinality)
+		// doubling the capacity reduces new slice allocations in the case of
+		// repeated calls to iorArray().
+		newcontent := make([]uint16, 0, 2*maxPossibleCardinality)
 		copy(newcontent[len2:maxPossibleCardinality], ac.content[0:len1])
 		ac.content = newcontent
 	} else {
@@ -388,6 +370,13 @@ func (ac *arrayContainer) iorArray(value2 *arrayContainer) container {
 	}
 	nl := union2by2(value1.content[len2:maxPossibleCardinality], value2.content, ac.content)
 	ac.content = ac.content[:nl] // reslice to match actual used capacity
+
+	if nl > arrayDefaultMaxSize {
+		// Only converting to a bitmap when arrayDefaultMaxSize
+		// is actually exceeded minimizes conversions in the case of repeated
+		// calls to iorArray().
+		return ac.toBitmapContainer()
+	}
 	return ac
 }
 


### PR DESCRIPTION
This contains a pair of changes to arrayContainer that together greatly reduce allocations in `arraycontainer.iorArray()`.

The problem(s):

 Currently it is possible for an array container to allocate a new slice with every call to iorArray(), even if no elements are actually added to it. The clearest cause is repeatedly having `maxPossibleCardinality > arrayDefaultMaxSize`. The current code can repeatedly allocate a new 8192 byte slice for a bitmap container, even if it always gets garbage collected. This is most clearly demonstrated in RepeatedSelfArrayUnion, and was the issue that I opened #258 to address.

However, even with this, arrayContainer can still allocate a very large number of slices. In particular, every time a larger value of maxPossibleCardinality is reached, a new slice has to be allocated. RepeatedGrowthArrayUnion demonstrates the worst case behavior of this, while InPlaceArrayUnions is a more realistic example resulting from ORing together a hundred arrays of about 100 elements on the [0,4096) interval. 

I've included a couple antagonistic benchmarks, which show that not everything is better. However, if you think about performance against the lifespan of a container, I think these changes dramatically improve both the average and worst-case behavior of iorArray() on array containers.


```
benchstat master.txt experiment.txt
name                                   old time/op    new time/op    delta
EvenIntervalArrayUnions-16               21.1µs ± 3%    15.7µs ± 5%   -25.47%  (p=0.008 n=5+5)
InPlaceArrayUnions-16                     354µs ± 3%     300µs ± 2%   -15.29%  (p=0.008 n=5+5)
AntagonisticArrayUnionsGrowth-16         14.0µs ± 2%    29.2µs ± 4%  +109.24%  (p=0.008 n=5+5)
RepeatedGrowthArrayUnion-16              4.89ms ± 2%    3.49ms ± 7%   -28.57%  (p=0.008 n=5+5)
RepeatedSelfArrayUnion-16                18.1ms ± 3%     6.4ms ± 1%   -64.60%  (p=0.008 n=5+5)
ArrayUnionThreshold/mostly-overlap-16    13.2µs ± 2%     7.9µs ± 3%   -40.09%  (p=0.008 n=5+5)
ArrayUnionThreshold/little-overlap-16    15.0µs ± 1%     9.6µs ± 1%   -36.10%  (p=0.008 n=5+5)
ArrayUnionThreshold/no-overlap-16        9.23µs ± 1%   18.33µs ± 2%   +98.68%  (p=0.008 n=5+5)

name                                   old alloc/op   new alloc/op   delta
EvenIntervalArrayUnions-16               32.5kB ± 0%     3.0kB ± 0%   -90.89%  (p=0.008 n=5+5)
InPlaceArrayUnions-16                     341kB ± 0%      16kB ± 0%   -95.43%  (p=0.008 n=5+5)
AntagonisticArrayUnionsGrowth-16         16.6kB ± 0%    49.3kB ± 0%  +197.64%  (p=0.008 n=5+5)
RepeatedGrowthArrayUnion-16              8.96MB ± 0%    0.05MB ± 0%   -99.46%  (p=0.008 n=5+5)
RepeatedSelfArrayUnion-16                16.4MB ± 0%     0.0MB ± 0%   -99.75%  (p=0.008 n=5+5)
ArrayUnionThreshold/mostly-overlap-16    19.2kB ± 0%    26.0kB ± 0%   +35.72%  (p=0.008 n=5+5)
ArrayUnionThreshold/little-overlap-16    22.0kB ± 0%    26.0kB ± 0%   +18.34%  (p=0.008 n=5+5)
ArrayUnionThreshold/no-overlap-16        13.8kB ± 0%    34.2kB ± 0%  +148.79%  (p=0.008 n=5+5)

name                                   old allocs/op  new allocs/op  delta
EvenIntervalArrayUnions-16                 44.0 ± 0%       7.0 ± 0%   -84.09%  (p=0.008 n=5+5)
InPlaceArrayUnions-16                      77.0 ± 0%       9.0 ± 0%   -88.31%  (p=0.008 n=5+5)
AntagonisticArrayUnionsGrowth-16           8.00 ± 0%      9.00 ± 0%   +12.50%  (p=0.008 n=5+5)
RepeatedGrowthArrayUnion-16               2.07k ± 0%     0.03k ± 0%   -98.45%  (p=0.008 n=5+5)
RepeatedSelfArrayUnion-16                 4.00k ± 0%     0.01k ± 0%   -99.85%  (p=0.008 n=5+5)
ArrayUnionThreshold/mostly-overlap-16      10.0 ± 0%       7.0 ± 0%   -30.00%  (p=0.008 n=5+5)
ArrayUnionThreshold/little-overlap-16      10.0 ± 0%       7.0 ± 0%   -30.00%  (p=0.008 n=5+5)
ArrayUnionThreshold/no-overlap-16          8.00 ± 0%      9.00 ± 0%   +12.50%  (p=0.008 n=5+5)

```