### PR TITLE
use serialization_littleendian for arm64,

### DIFF
--- a/serialization_generic.go
+++ b/serialization_generic.go
@@ -1,4 +1,4 @@
-// +build !amd64,!386 appengine
+// +build !arm64,!amd64,!386 appengine
 
 package roaring
 

--- a/serialization_littleendian.go
+++ b/serialization_littleendian.go
@@ -1,4 +1,4 @@
-// +build 386 amd64,!appengine
+// +build 386 amd64 arm64,!appengine
 
 package roaring
 


### PR DESCRIPTION
as golang doesn't support big-endian ARM.
https://github.com/golang/go/issues/11079