### PR TITLE
optimise bitmaps

### DIFF
--- a/bitmapcontainer.go
+++ b/bitmapcontainer.go
@@ -113,7 +113,7 @@ type bitmapContainerShortIterator struct {
 
 func (bcsi *bitmapContainerShortIterator) next() uint16 {
 	j := bcsi.i
-	bcsi.i = bcsi.ptr.NextSetBit(bcsi.i + 1)
+	bcsi.i = bcsi.ptr.NextSetBit(uint(bcsi.i) + 1)
 	return uint16(j)
 }
 func (bcsi *bitmapContainerShortIterator) hasNext() bool {
@@ -126,7 +126,7 @@ func (bcsi *bitmapContainerShortIterator) peekNext() uint16 {
 
 func (bcsi *bitmapContainerShortIterator) advanceIfNeeded(minval uint16) {
 	if bcsi.hasNext() && bcsi.peekNext() < minval {
-		bcsi.i = bcsi.ptr.NextSetBit(int(minval))
+		bcsi.i = bcsi.ptr.NextSetBit(uint(minval))
 	}
 }
 
@@ -1007,20 +1007,23 @@ func (bc *bitmapContainer) fillArray(container []uint16) {
 	}
 }
 
-func (bc *bitmapContainer) NextSetBit(i int) int {
-	x := i / 64
-	if x >= len(bc.bitmap) {
+func (bc *bitmapContainer) NextSetBit(i uint) int {
+	var (
+		x      = i / 64
+		length = uint(len(bc.bitmap))
+	)
+	if x >= length {
 		return -1
 	}
 	w := bc.bitmap[x]
 	w = w >> uint(i%64)
 	if w != 0 {
-		return i + countTrailingZeros(w)
+		return int(i) + countTrailingZeros(w)
 	}
 	x++
-	for ; x < len(bc.bitmap); x++ {
+	for ; x < length; x++ {
 		if bc.bitmap[x] != 0 {
-			return (x * 64) + countTrailingZeros(bc.bitmap[x])
+			return int(x*64) + countTrailingZeros(bc.bitmap[x])
 		}
 	}
 	return -1

--- a/bitmapcontainer_test.go
+++ b/bitmapcontainer_test.go
@@ -1,9 +1,10 @@
 package roaring
 
 import (
-	"github.com/stretchr/testify/assert"
 	"math/rand"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 // bitmapContainer's numberOfRuns() function should be correct against the runContainer equivalent
@@ -169,7 +170,7 @@ func TestBitmapNextSet(t *testing.T) {
 
 	m := 0
 
-	for n := 0; m < testSize; n, m = bc.NextSetBit(n+1), m+1 {
+	for n := 0; m < testSize; n, m = bc.NextSetBit(uint(n)+1), m+1 {
 		assert.Equal(t, m, n)
 	}
 

--- a/roaring_test.go
+++ b/roaring_test.go
@@ -1744,7 +1744,7 @@ func validate(bc *bitmapContainer, ac *arrayContainer) bool {
 	// Checking that the two containers contain the same values
 	counter := 0
 
-	for i := bc.NextSetBit(0); i >= 0; i = bc.NextSetBit(i + 1) {
+	for i := bc.NextSetBit(0); i >= 0; i = bc.NextSetBit(uint(i) + 1) {
 		counter++
 		if !ac.contains(uint16(i)) {
 			log.Println("content differs")


### PR DESCRIPTION
Shifting bits and using binary operations instead of multiplication, division and modulo yielded the following results.
```
name                                                                  old time/op    new time/op    delta
ShortIteratorAdvanceArray/init_size_1_shortIterator_advance-12          41.8ns ± 0%    40.3ns ± 0%   -3.48%  (p=0.016 n=4+5)
ShortIteratorAdvanceArray/init_size_650_shortIterator_advance-12        77.2ns ± 1%    76.1ns ± 2%     ~     (p=0.659 n=5+5)
ShortIteratorAdvanceArray/init_size_6500_shortIterator_advance-12       86.8ns ± 2%    89.4ns ± 5%     ~     (p=0.056 n=5+5)
ShortIteratorAdvanceArray/init_size_65535_shortIterator_advance-12      90.2ns ± 0%    90.0ns ± 2%     ~     (p=0.651 n=5+5)
ShortIteratorNextArray/init_size_1_shortIterator_next-12                37.9ns ± 1%    37.4ns ± 6%     ~     (p=0.135 n=5+5)
ShortIteratorNextArray/init_size_650_shortIterator_next-12              2.35µs ± 3%    2.23µs ± 1%   -5.29%  (p=0.008 n=5+5)
ShortIteratorNextArray/init_size_6500_shortIterator_next-12             22.2µs ± 1%    22.0µs ± 3%     ~     (p=0.690 n=5+5)
ShortIteratorNextArray/init_size_65535_shortIterator_next-12             226µs ± 1%     230µs ± 9%     ~     (p=0.841 n=5+5)
ShortIteratorAdvanceBitmap/init_size_1_shortIterator_advance-12         37.9ns ± 1%    36.2ns ± 1%   -4.49%  (p=0.008 n=5+5)
ShortIteratorAdvanceBitmap/init_size_650_shortIterator_advance-12       42.1ns ± 1%    38.9ns ± 0%   -7.74%  (p=0.008 n=5+5)
ShortIteratorAdvanceBitmap/init_size_6500_shortIterator_advance-12      44.1ns ± 3%    38.8ns ± 1%  -12.14%  (p=0.008 n=5+5)
ShortIteratorAdvanceBitmap/init_size_65535_shortIterator_advance-12     44.9ns ±17%    38.9ns ± 0%  -13.36%  (p=0.008 n=5+5)
ShortIteratorNextBitmap/init_size_1_shortIterator_next-12                582ns ± 2%     313ns ± 1%  -46.25%  (p=0.008 n=5+5)
ShortIteratorNextBitmap/init_size_650_shortIterator_next-12             5.14µs ± 1%    4.36µs ± 1%  -15.24%  (p=0.008 n=5+5)
ShortIteratorNextBitmap/init_size_6500_shortIterator_next-12            45.8µs ± 2%    40.8µs ± 1%  -10.93%  (p=0.008 n=5+5)
ShortIteratorNextBitmap/init_size_65535_shortIterator_next-12            455µs ± 0%     416µs ± 4%   -8.45%  (p=0.008 n=5+5)
ShortIteratorAdvanceRuntime/init_size_1_shortIterator_advance-12        43.8ns ± 1%    42.2ns ± 2%   -3.47%  (p=0.008 n=5+5)
ShortIteratorAdvanceRuntime/init_size_650_shortIterator_advance-12      49.2ns ± 1%    47.5ns ± 1%   -3.45%  (p=0.008 n=5+5)
ShortIteratorAdvanceRuntime/init_size_6500_shortIterator_advance-12     49.2ns ± 1%    47.6ns ± 1%   -3.21%  (p=0.008 n=5+5)
ShortIteratorAdvanceRuntime/init_size_65535_shortIterator_advance-12    49.0ns ± 1%    47.9ns ± 1%   -2.16%  (p=0.008 n=5+5)
ShortIteratorNextRuntime/init_size_1_shortIterator_next-12              40.4ns ± 0%    39.2ns ± 1%   -2.97%  (p=0.008 n=5+5)
ShortIteratorNextRuntime/init_size_650_shortIterator_next-12            3.60µs ± 2%    3.52µs ± 3%     ~     (p=0.095 n=5+5)
ShortIteratorNextRuntime/init_size_6500_shortIterator_next-12           35.1µs ± 1%    34.2µs ± 0%   -2.71%  (p=0.008 n=5+5)
ShortIteratorNextRuntime/init_size_65535_shortIterator_next-12           352µs ± 1%     345µs ± 0%   -2.04%  (p=0.008 n=5+5)
```