### PR TITLE
treat lazyIOR as in-place in run container test.

### DIFF
--- a/runcontainer_test.go
+++ b/runcontainer_test.go
@@ -2253,7 +2253,7 @@ func TestAllContainerMethodsAllContainerTypesWithData067(t *testing.T) {
 
 							// In-place operation are best effort
 							// User should not assume the receiver is modified, returned container has to be used
-							if strings.HasPrefix(z, "i") {
+							if strings.HasPrefix(z, "i") || z == "lazyIOR" {
 								c1.cn = res1
 								c2.cn = res2
 								c3.cn = res3


### PR DESCRIPTION
I'm improving run containers and kept getting caught on this test until I realized this check was incomplete.