### PR TITLE
Stop assuming ior is in-place for AndAny.

### DIFF
--- a/fastaggregation.go
+++ b/fastaggregation.go
@@ -301,9 +301,6 @@ func (x1 *Bitmap) AndAny(bitmaps ...*Bitmap) {
 					tmpBitmap = newBitmapContainer()
 				}
 				tmpBitmap.resetTo(keyContainers[0])
-				for _, c := range keyContainers[1:] {
-					tmpBitmap.ior(c)
-				}
 				ored = tmpBitmap
 			} else {
 				if tmpArray == nil {
@@ -311,10 +308,10 @@ func (x1 *Bitmap) AndAny(bitmaps ...*Bitmap) {
 				}
 				tmpArray.realloc(maxPossibleOr)
 				tmpArray.resetTo(keyContainers[0])
-				for _, c := range keyContainers[1:] {
-					tmpArray.ior(c)
-				}
 				ored = tmpArray
+			}
+			for _, c := range keyContainers[1:] {
+				ored = ored.ior(c)
 			}
 		}
 


### PR DESCRIPTION
As discussed in #309, not using the returned value of `ior()` makes the correctness of AndAny conditional on implementation details.