### PR TITLE
OR the intermediate values in bitmapContainer.addOffset

### DIFF
--- a/bitmapcontainer.go
+++ b/bitmapcontainer.go
@@ -1138,16 +1138,12 @@ func (bc *bitmapContainer) addOffset(x uint16) []container {
 		low.bitmap[b] = bc.bitmap[0] << i
 		for k := uint32(1); k < end; k++ {
 			newval := bc.bitmap[k] << i
-			if newval == 0 {
-				newval = bc.bitmap[k-1] >> (64 - i)
-			}
+			newval |= bc.bitmap[k-1] >> (64 - i)
 			low.bitmap[b+k] = newval
 		}
 		for k := end; k < 1024; k++ {
 			newval := bc.bitmap[k] << i
-			if newval == 0 {
-				newval = bc.bitmap[k-1] >> (64 - i)
-			}
+			newval |= bc.bitmap[k-1] >> (64 - i)
 			high.bitmap[k-end] = newval
 		}
 		high.bitmap[b] = bc.bitmap[1023] >> (64 - i)

--- a/bitmapcontainer_test.go
+++ b/bitmapcontainer_test.go
@@ -213,7 +213,7 @@ func BenchmarkShortIteratorNextBitmap(b *testing.B) {
 }
 
 func TestBitmapOffset(t *testing.T) {
-	nums := []uint16{10, 100, 1000}
+	nums := []uint16{10, 60, 70, 100, 1000}
 	expected := make([]int, len(nums))
 	offtest := uint16(65000)
 	v := container(newBitmapContainer())
@@ -225,7 +225,7 @@ func TestBitmapOffset(t *testing.T) {
 	w0card := w[0].getCardinality()
 	w1card := w[1].getCardinality()
 
-	assert.Equal(t, 3, w0card+w1card)
+	assert.Equal(t, v.getCardinality(), w0card+w1card)
 
 	wout := make([]int, len(nums))
 	for i := 0; i < w0card; i++ {


### PR DESCRIPTION
While porting the shift feature to CRoaring I found `bitmapContainer.addOffset` to be broken. Instead of `OR`ing the bits from two successive words it would pick either the high or the low word depending on if the low one was empty.