### PR TITLE
Fix aliasing in ParOr

### DIFF
--- a/parallel.go
+++ b/parallel.go
@@ -354,7 +354,7 @@ func ParOr(parallelism int, bitmaps ...*Bitmap) *Bitmap {
 	if lKey == MaxUint16 && hKey == 0 {
 		return New()
 	} else if len(bitmaps) == 1 {
-		return bitmaps[0]
+		return bitmaps[0].Clone()
 	}
 
 	keyRange := int(hKey) - int(lKey) + 1


### PR DESCRIPTION
ParOr was returning a reference to the input when only one bitmaps was passed. This introduces aliasing and is inconsistent with the other union functions. Return a copy instead.