### PR TITLE
Fix issue #315, Negative BSI values fail range comparisons.

### DIFF
--- a/BitSliceIndexing/bsi_test.go
+++ b/BitSliceIndexing/bsi_test.go
@@ -1,7 +1,7 @@
 package roaring
 
 import (
-    "fmt"
+    _ "fmt"
 	"github.com/RoaringBitmap/roaring"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -339,19 +339,12 @@ func TestSumWithNegative(t *testing.T) {
 }
 
 func TestGEWithNegative(t *testing.T) {
-    fmt.Println("running TestGEWithNegative");
 	bsi := setupNegativeBoundary()
-    fmt.Println("running TestGEWithNegative -- setupNegativeBoundary done");
 	assert.Equal(t, uint64(11), bsi.GetCardinality())
-    fmt.Println("running TestGEWithNegative -- assert.Equal(t, uint64(11), bsi.GetCardinality()) done");
 	set := bsi.CompareValue(0, GE, 3, 0, nil)
-    fmt.Println("running TestGEWithNegative -- set := bsi.CompareValue(0, GE, 3, 0, nil) done");
 	assert.Equal(t, uint64(3), set.GetCardinality())
-    fmt.Println("running TestGEWithNegative -- assert.Equal(t, uint64(3), set.GetCardinality()) done");
 	set = bsi.CompareValue(0, GE, -3, 0, nil)
-    fmt.Println("running TestGEWithNegative -- set = bsi.CompareValue(0, GE, -3, 0, nil) done");
 	assert.Equal(t, uint64(9), set.GetCardinality())
-    fmt.Println("running TestGEWithNegative -- assert.Equal(t, uint64(9), set.GetCardinality()) done");
 }
 
 func TestLEWithNegative(t *testing.T) {

--- a/BitSliceIndexing/bsi_test.go
+++ b/BitSliceIndexing/bsi_test.go
@@ -31,8 +31,35 @@ func setup() *BSI {
 	return bsi
 }
 
-func TestEQ(t *testing.T) {
+func setupNegativeBoundary() *BSI {
 
+	bsi := NewBSI(5, -5)
+	// Setup values
+	for i := int(bsi.MinValue); i <= int(bsi.MaxValue); i++ {
+		bsi.SetValue(uint64(i), int64(i))
+	}
+	return bsi
+}
+
+func setupAllNegative() *BSI {
+	bsi := NewBSI(-1, -100)
+	// Setup values
+	for i := int(bsi.MinValue); i <= int(bsi.MaxValue); i++ {
+		bsi.SetValue(uint64(i), int64(i))
+	}
+	return bsi
+}
+
+func setupAutoSizeNegativeBoundary() *BSI {
+	bsi := NewDefaultBSI()
+	// Setup values
+	for i := int(-5); i <= int(5); i++ {
+		bsi.SetValue(uint64(i), int64(i))
+	}
+	return bsi
+}
+
+func TestEQ(t *testing.T) {
 	bsi := setup()
 	eq := bsi.CompareValue(0, EQ, 50, 0, nil)
 	assert.Equal(t, uint64(1), eq.GetCardinality())
@@ -287,4 +314,74 @@ func TestTransposeWithCounts(t *testing.T) {
 	a, ok := transposed.GetValue(uint64(50))
 	assert.True(t, ok)
 	assert.Equal(t, int64(2), a)
+}
+
+func TestRangeAllNegative(t *testing.T) {
+	bsi := setupAllNegative()
+	assert.Equal(t, uint64(100), bsi.GetCardinality())
+	set := bsi.CompareValue(0, RANGE, -55, -45, nil)
+	assert.Equal(t, uint64(11), set.GetCardinality())
+
+	i := set.Iterator()
+	for i.HasNext() {
+		val, _ := bsi.GetValue(uint64(i.Next()))
+		assert.GreaterOrEqual(t, val, int64(-55))
+		assert.LessOrEqual(t, val, int64(-45))
+	}
+}
+
+func TestSumWithNegative(t *testing.T) {
+	bsi := setupNegativeBoundary()
+	assert.Equal(t, uint64(11), bsi.GetCardinality())
+	sum, cnt := bsi.Sum(bsi.GetExistenceBitmap())
+	assert.Equal(t, uint64(11), cnt)
+	assert.Equal(t, int64(0), sum)
+}
+
+func TestGEWithNegative(t *testing.T) {
+
+	bsi := setupNegativeBoundary()
+	assert.Equal(t, uint64(11), bsi.GetCardinality())
+	set := bsi.CompareValue(0, GE, 3, 0, nil)
+	assert.Equal(t, uint64(3), set.GetCardinality())
+	set = bsi.CompareValue(0, GE, -3, 0, nil)
+	assert.Equal(t, uint64(9), set.GetCardinality())
+}
+
+func TestLEWithNegative(t *testing.T) {
+	bsi := setupNegativeBoundary()
+	assert.Equal(t, uint64(11), bsi.GetCardinality())
+	set := bsi.CompareValue(0, LE, -3, 0, nil)
+	assert.Equal(t, uint64(3), set.GetCardinality())
+	set = bsi.CompareValue(0, LE, 3, 0, nil)
+	assert.Equal(t, uint64(9), set.GetCardinality())
+}
+
+func TestRangeWithNegative(t *testing.T) {
+	bsi := setupNegativeBoundary()
+	assert.Equal(t, uint64(11), bsi.GetCardinality())
+	set := bsi.CompareValue(0, RANGE, -3, 3, nil)
+	assert.Equal(t, uint64(7), set.GetCardinality())
+
+	i := set.Iterator()
+	for i.HasNext() {
+		val, _ := bsi.GetValue(uint64(i.Next()))
+		assert.GreaterOrEqual(t, val, int64(-3))
+		assert.LessOrEqual(t, val, int64(3))
+	}
+}
+
+func TestAutoSizeWithNegative(t *testing.T) {
+	bsi := setupAutoSizeNegativeBoundary()
+	assert.Equal(t, uint64(11), bsi.GetCardinality())
+	assert.Equal(t, 64, bsi.BitCount())
+	set := bsi.CompareValue(0, RANGE, -3, 3, nil)
+	assert.Equal(t, uint64(7), set.GetCardinality())
+
+	i := set.Iterator()
+	for i.HasNext() {
+		val, _ := bsi.GetValue(uint64(i.Next()))
+		assert.GreaterOrEqual(t, val, int64(-3))
+		assert.LessOrEqual(t, val, int64(3))
+	}
 }

--- a/BitSliceIndexing/bsi_test.go
+++ b/BitSliceIndexing/bsi_test.go
@@ -1,7 +1,7 @@
 package roaring
 
 import (
-	_ "fmt"
+    "fmt"
 	"github.com/RoaringBitmap/roaring"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -339,13 +339,19 @@ func TestSumWithNegative(t *testing.T) {
 }
 
 func TestGEWithNegative(t *testing.T) {
-
+    fmt.Println("running TestGEWithNegative");
 	bsi := setupNegativeBoundary()
+    fmt.Println("running TestGEWithNegative -- setupNegativeBoundary done");
 	assert.Equal(t, uint64(11), bsi.GetCardinality())
+    fmt.Println("running TestGEWithNegative -- assert.Equal(t, uint64(11), bsi.GetCardinality()) done");
 	set := bsi.CompareValue(0, GE, 3, 0, nil)
+    fmt.Println("running TestGEWithNegative -- set := bsi.CompareValue(0, GE, 3, 0, nil) done");
 	assert.Equal(t, uint64(3), set.GetCardinality())
+    fmt.Println("running TestGEWithNegative -- assert.Equal(t, uint64(3), set.GetCardinality()) done");
 	set = bsi.CompareValue(0, GE, -3, 0, nil)
+    fmt.Println("running TestGEWithNegative -- set = bsi.CompareValue(0, GE, -3, 0, nil) done");
 	assert.Equal(t, uint64(9), set.GetCardinality())
+    fmt.Println("running TestGEWithNegative -- assert.Equal(t, uint64(9), set.GetCardinality()) done");
 }
 
 func TestLEWithNegative(t *testing.T) {

--- a/roaring64/roaring64_test.go
+++ b/roaring64/roaring64_test.go
@@ -12,8 +12,8 @@ import (
 	"testing"
 
 	"github.com/RoaringBitmap/roaring"
-	"github.com/stretchr/testify/assert"
 	"github.com/bits-and-blooms/bitset"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestRoaringIntervalCheck(t *testing.T) {
@@ -27,6 +27,14 @@ func TestRoaringIntervalCheck(t *testing.T) {
 	rangeb2.AddRange(10, 1000)
 
 	assert.False(t, r.Intersects(rangeb2))
+}
+
+func TestIssue316(t *testing.T) {
+	a := BitmapOf(5, 18446744073709551613, 18446744073709551614, 18446744073709551615)
+	b := BitmapOf(0, 1, 2, 3, 4)
+	c := ParOr(0, a, b)
+	expected := BitmapOf(0, 1, 2, 3, 4, 5, 18446744073709551613, 18446744073709551614, 18446744073709551615)
+	assert.True(t, c.Equals(expected))
 }
 
 func TestIssue266(t *testing.T) {

--- a/roaring64/roaring64cow_test.go
+++ b/roaring64/roaring64cow_test.go
@@ -7,8 +7,8 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/bits-and-blooms/bitset"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestCloneOfCOW(t *testing.T) {

--- a/roaring64/util.go
+++ b/roaring64/util.go
@@ -13,6 +13,13 @@ func lowbits(x uint64) uint32 {
 const maxLowBit = roaring.MaxUint32
 const maxUint32 = roaring.MaxUint32
 
+func minOfInt64(a, b int64) int64 {
+	if a < b {
+		return a
+	}
+	return b
+}
+
 func minOfInt(a, b int) int {
 	if a < b {
 		return a


### PR DESCRIPTION
Fix for issue #315.  BSI were not correctly supporting twos complement negative values.