### PR TITLE
Fixing a deadlock.

### DIFF
--- a/roaring64/parallel64.go
+++ b/roaring64/parallel64.go
@@ -34,8 +34,10 @@ func ParOr(parallelism int, bitmaps ...*Bitmap) *Bitmap {
 	} else if len(bitmaps) == 1 {
 		return bitmaps[0]
 	}
-
-	keyRange := hKey - lKey + 1
+	// The following might overflow and we do not want that!
+	// as it might lead to a channel of size 0 later which,
+	// on some systems, would block indefinitely.
+	keyRange := uint64(hKey) - uint64(lKey) + 1
 	if keyRange == 1 {
 		// revert to FastOr. Since the key range is 0
 		// no container-level aggregation parallelism is achievable

--- a/roaring64/roaring64_test.go
+++ b/roaring64/roaring64_test.go
@@ -12,8 +12,8 @@ import (
 	"testing"
 
 	"github.com/RoaringBitmap/roaring"
-	"github.com/stretchr/testify/assert"
 	"github.com/bits-and-blooms/bitset"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestRoaringIntervalCheck(t *testing.T) {
@@ -27,6 +27,14 @@ func TestRoaringIntervalCheck(t *testing.T) {
 	rangeb2.AddRange(10, 1000)
 
 	assert.False(t, r.Intersects(rangeb2))
+}
+
+func TestIssue316(t *testing.T) {
+	a := BitmapOf(5, 18446744073709551613, 18446744073709551614, 18446744073709551615)
+	b := BitmapOf(0, 1, 2, 3, 4)
+	c := ParOr(0, a, b)
+	expected := BitmapOf(0, 1, 2, 3, 4, 5, 18446744073709551613, 18446744073709551614, 18446744073709551615)
+	assert.True(t, c.Equals(expected))
 }
 
 func TestIssue266(t *testing.T) {

--- a/roaring64/roaring64cow_test.go
+++ b/roaring64/roaring64cow_test.go
@@ -7,8 +7,8 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/bits-and-blooms/bitset"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestCloneOfCOW(t *testing.T) {

--- a/roaring64/util.go
+++ b/roaring64/util.go
@@ -13,6 +13,13 @@ func lowbits(x uint64) uint32 {
 const maxLowBit = roaring.MaxUint32
 const maxUint32 = roaring.MaxUint32
 
+func minOfInt64(a, b int64) int64 {
+	if a < b {
+		return a
+	}
+	return b
+}
+
 func minOfInt(a, b int) int {
 	if a < b {
 		return a


### PR DESCRIPTION
In some instances, the ParOr function in roaring64 could encounter an integer overflow which may lead to a size zero channel. A channel with size zero might block indefinitely under some systems. This would not show up as a data race.