### PR TITLE
fix: fix roaring64 bitmap size in bytes

### DIFF
--- a/roaring64/roaring64.go
+++ b/roaring64/roaring64.go
@@ -215,7 +215,7 @@ func (rb *Bitmap) ToArray() []uint64 {
 func (rb *Bitmap) GetSizeInBytes() uint64 {
 	size := uint64(8)
 	for _, c := range rb.highlowcontainer.containers {
-		size += uint64(2) + c.GetSizeInBytes()
+		size += uint64(4) + c.GetSizeInBytes()
 	}
 	return size
 }


### PR DESCRIPTION
The roaring64 bitmap size should be uint(4) + c.GetSizeInBytes() in GetSizeInBytes function，because the keys of roaringArray64 is uint32 array ?
```
func (rb *Bitmap) GetSizeInBytes() uint64 {
	size := uint64(8)
	for _, c := range rb.highlowcontainer.containers {
                // there keys uint32
		size += uint64(4) + c.GetSizeInBytes()
	}
	return size
}
```