### PR TITLE
fix deserialization when size=0xFFFF

### DIFF
--- a/roaringarray.go
+++ b/roaringarray.go
@@ -569,7 +569,7 @@ func (ra *roaringArray) readFrom(stream internal.ByteInput, cookieHeader ...byte
 	var isRunBitmap []byte
 
 	if cookie&0x0000FFFF == serialCookie {
-		size = uint32(uint16(cookie>>16) + 1)
+		size = uint32(cookie>>16 + 1)
 		// create is-run-container bitmap
 		isRunBitmapSize := (int(size) + 7) / 8
 		isRunBitmap, err = stream.Next(isRunBitmapSize)


### PR DESCRIPTION
The spec at https://github.com/RoaringBitmap/RoaringFormatSpec says:

> The 16 least significant bits of the 32-bit cookie have value SERIAL_COOKIE. In that case, the 16 most significant
> bits of the 32-bit cookie are used to store the number of containers minus 1. That is, if you shift right by 16 the
> cookie and add 1, you get the number of containers.

However, the uint16() cast prior to + 1 causes a uint16 overflow, which results in a size of 0, which is invalid.