### PR TITLE
Addoffset allocation optimizations

### DIFF
--- a/arraycontainer.go
+++ b/arraycontainer.go
@@ -1007,7 +1007,7 @@ func (ac *arrayContainer) containerType() contype {
 	return arrayContype
 }
 
-func (ac *arrayContainer) addOffset(x uint16) []container {
+func (ac *arrayContainer) addOffset(x uint16) (container, container) {
 	low := &arrayContainer{}
 	high := &arrayContainer{}
 	for _, val := range ac.content {
@@ -1018,5 +1018,5 @@ func (ac *arrayContainer) addOffset(x uint16) []container {
 			low.content = append(low.content, lowbits(y))
 		}
 	}
-	return []container{low, high}
+	return low, high
 }

--- a/arraycontainer.go
+++ b/arraycontainer.go
@@ -1008,15 +1008,41 @@ func (ac *arrayContainer) containerType() contype {
 }
 
 func (ac *arrayContainer) addOffset(x uint16) (container, container) {
-	low := &arrayContainer{}
-	high := &arrayContainer{}
+	var low, high *arrayContainer
+
+	if len(ac.content) == 0 {
+		return nil, nil
+	}
+
+	if y := uint32(ac.content[0]) + uint32(x); highbits(y) == 0 {
+		// Some elements will fall into low part, allocate a container.
+		// Checking the first one is enough because they are ordered.
+		low = &arrayContainer{}
+	}
+	if y := uint32(ac.content[len(ac.content)-1]) + uint32(x); highbits(y) > 0 {
+		// Some elements will fall into high part, allocate a container.
+		// Checking the last one is enough because they are ordered.
+		high = &arrayContainer{}
+	}
+
 	for _, val := range ac.content {
 		y := uint32(val) + uint32(x)
 		if highbits(y) > 0 {
+			// OK, if high == nil then highbits(y) == 0 for all y.
 			high.content = append(high.content, lowbits(y))
 		} else {
+			// OK, if low == nil then highbits(y) > 0 for all y.
 			low.content = append(low.content, lowbits(y))
 		}
 	}
+
+	// Ensure proper nil interface.
+	if low == nil {
+		return nil, high
+	}
+	if high == nil {
+		return low, nil
+	}
+
 	return low, high
 }

--- a/arraycontainer_test.go
+++ b/arraycontainer_test.go
@@ -70,18 +70,27 @@ func TestArrayOffset(t *testing.T) {
 		expected[i] = int(n) + int(offtest)
 	}
 	l, h := v.addOffset(offtest)
-	w0card := l.getCardinality()
-	w1card := h.getCardinality()
+
+	var w0card, w1card int
+	wout := make([]int, len(nums))
+
+	if l != nil {
+		w0card = l.getCardinality()
+
+		for i := 0; i < w0card; i++ {
+			wout[i] = l.selectInt(uint16(i))
+		}
+	}
+
+	if h != nil {
+		w1card = h.getCardinality()
+
+		for i := 0; i < w1card; i++ {
+			wout[i+w0card] = h.selectInt(uint16(i)) + 65536
+		}
+	}
 
 	assert.Equal(t, 3, w0card+w1card)
-
-	wout := make([]int, len(nums))
-	for i := 0; i < w0card; i++ {
-		wout[i] = l.selectInt(uint16(i))
-	}
-	for i := 0; i < w1card; i++ {
-		wout[i+w0card] = h.selectInt(uint16(i)) + 65536
-	}
 	for i, x := range wout {
 		assert.Equal(t, expected[i], x)
 	}

--- a/arraycontainer_test.go
+++ b/arraycontainer_test.go
@@ -69,18 +69,18 @@ func TestArrayOffset(t *testing.T) {
 		v = v.iaddReturnMinimized(n)
 		expected[i] = int(n) + int(offtest)
 	}
-	w := v.addOffset(offtest)
-	w0card := w[0].getCardinality()
-	w1card := w[1].getCardinality()
+	l, h := v.addOffset(offtest)
+	w0card := l.getCardinality()
+	w1card := h.getCardinality()
 
 	assert.Equal(t, 3, w0card+w1card)
 
 	wout := make([]int, len(nums))
 	for i := 0; i < w0card; i++ {
-		wout[i] = w[0].selectInt(uint16(i))
+		wout[i] = l.selectInt(uint16(i))
 	}
 	for i := 0; i < w1card; i++ {
-		wout[i+w0card] = w[1].selectInt(uint16(i)) + 65536
+		wout[i+w0card] = h.selectInt(uint16(i)) + 65536
 	}
 	for i, x := range wout {
 		assert.Equal(t, expected[i], x)

--- a/bitmapcontainer.go
+++ b/bitmapcontainer.go
@@ -1125,7 +1125,7 @@ func (bc *bitmapContainer) containerType() contype {
 	return bitmapContype
 }
 
-func (bc *bitmapContainer) addOffset(x uint16) []container {
+func (bc *bitmapContainer) addOffset(x uint16) (container, container) {
 	low := newBitmapContainer()
 	high := newBitmapContainer()
 	b := uint32(x) >> 6
@@ -1150,5 +1150,5 @@ func (bc *bitmapContainer) addOffset(x uint16) []container {
 	}
 	low.computeCardinality()
 	high.computeCardinality()
-	return []container{low, high}
+	return low, high
 }

--- a/bitmapcontainer.go
+++ b/bitmapcontainer.go
@@ -1126,14 +1126,19 @@ func (bc *bitmapContainer) containerType() contype {
 }
 
 func (bc *bitmapContainer) addOffset(x uint16) (container, container) {
-	low := newBitmapContainer()
-	high := newBitmapContainer()
+	var low, high *bitmapContainer
+
+	if bc.cardinality == 0 {
+		return nil, nil
+	}
+
 	b := uint32(x) >> 6
 	i := uint32(x) % 64
 	end := uint32(1024) - b
+
+	low = newBitmapContainer()
 	if i == 0 {
 		copy(low.bitmap[b:], bc.bitmap[:end])
-		copy(high.bitmap[:b], bc.bitmap[end:])
 	} else {
 		low.bitmap[b] = bc.bitmap[0] << i
 		for k := uint32(1); k < end; k++ {
@@ -1141,6 +1146,26 @@ func (bc *bitmapContainer) addOffset(x uint16) (container, container) {
 			newval |= bc.bitmap[k-1] >> (64 - i)
 			low.bitmap[b+k] = newval
 		}
+	}
+	low.computeCardinality()
+
+	if low.cardinality == bc.cardinality {
+		// All elements from bc ended up in low, meaning high will be empty.
+		return low, nil
+	}
+
+	if low.cardinality == 0 {
+		// low is empty, let's reuse the container for high.
+		high = low
+		low = nil
+	} else {
+		// None of the containers will be empty, so allocate both.
+		high = newBitmapContainer()
+	}
+
+	if i == 0 {
+		copy(high.bitmap[:b], bc.bitmap[end:])
+	} else {
 		for k := end; k < 1024; k++ {
 			newval := bc.bitmap[k] << i
 			newval |= bc.bitmap[k-1] >> (64 - i)
@@ -1148,7 +1173,12 @@ func (bc *bitmapContainer) addOffset(x uint16) (container, container) {
 		}
 		high.bitmap[b] = bc.bitmap[1023] >> (64 - i)
 	}
-	low.computeCardinality()
 	high.computeCardinality()
+
+	// Ensure proper nil interface.
+	if low == nil {
+		return nil, high
+	}
+
 	return low, high
 }

--- a/bitmapcontainer_test.go
+++ b/bitmapcontainer_test.go
@@ -222,19 +222,27 @@ func TestBitmapOffset(t *testing.T) {
 		expected[i] = int(n) + int(offtest)
 	}
 	l, h := v.addOffset(offtest)
-	w0card := l.getCardinality()
-	w1card := h.getCardinality()
+
+	var w0card, w1card int
+	wout := make([]int, len(nums))
+
+	if l != nil {
+		w0card = l.getCardinality()
+
+		for i := 0; i < w0card; i++ {
+			wout[i] = l.selectInt(uint16(i))
+		}
+	}
+
+	if h != nil {
+		w1card = h.getCardinality()
+
+		for i := 0; i < w1card; i++ {
+			wout[i+w0card] = h.selectInt(uint16(i)) + 65536
+		}
+	}
 
 	assert.Equal(t, v.getCardinality(), w0card+w1card)
-
-	wout := make([]int, len(nums))
-	for i := 0; i < w0card; i++ {
-		wout[i] = l.selectInt(uint16(i))
-	}
-	for i := 0; i < w1card; i++ {
-		wout[i+w0card] = h.selectInt(uint16(i)) + 65536
-	}
-
 	for i, x := range wout {
 		assert.Equal(t, expected[i], x)
 	}

--- a/bitmapcontainer_test.go
+++ b/bitmapcontainer_test.go
@@ -221,18 +221,18 @@ func TestBitmapOffset(t *testing.T) {
 		v.iadd(n)
 		expected[i] = int(n) + int(offtest)
 	}
-	w := v.addOffset(offtest)
-	w0card := w[0].getCardinality()
-	w1card := w[1].getCardinality()
+	l, h := v.addOffset(offtest)
+	w0card := l.getCardinality()
+	w1card := h.getCardinality()
 
 	assert.Equal(t, v.getCardinality(), w0card+w1card)
 
 	wout := make([]int, len(nums))
 	for i := 0; i < w0card; i++ {
-		wout[i] = w[0].selectInt(uint16(i))
+		wout[i] = l.selectInt(uint16(i))
 	}
 	for i := 0; i < w1card; i++ {
-		wout[i+w0card] = w[1].selectInt(uint16(i)) + 65536
+		wout[i+w0card] = h.selectInt(uint16(i)) + 65536
 	}
 
 	for i, x := range wout {

--- a/roaring.go
+++ b/roaring.go
@@ -545,9 +545,9 @@ func AddOffset64(x *Bitmap, offset int64) (answer *Bitmap) {
 			key += containerOffset
 
 			c := x.highlowcontainer.getContainerAtIndex(pos)
-			offsetted := c.addOffset(inOffset)
+			lo, hi := c.addOffset(inOffset)
 
-			if !offsetted[0].isEmpty() && (key >= 0 && key <= MaxUint16) {
+			if !lo.isEmpty() && (key >= 0 && key <= MaxUint16) {
 				curSize := answer.highlowcontainer.size()
 				lastkey := int32(0)
 
@@ -557,15 +557,15 @@ func AddOffset64(x *Bitmap, offset int64) (answer *Bitmap) {
 
 				if curSize > 0 && lastkey == key {
 					prev := answer.highlowcontainer.getContainerAtIndex(curSize - 1)
-					orrseult := prev.ior(offsetted[0])
+					orrseult := prev.ior(lo)
 					answer.highlowcontainer.setContainerAtIndex(curSize-1, orrseult)
 				} else {
-					answer.highlowcontainer.appendContainer(uint16(key), offsetted[0], false)
+					answer.highlowcontainer.appendContainer(uint16(key), lo, false)
 				}
 			}
 
-			if !offsetted[1].isEmpty() && ((key+1) >= 0 && (key+1) <= MaxUint16) {
-				answer.highlowcontainer.appendContainer(uint16(key+1), offsetted[1], false)
+			if !hi.isEmpty() && ((key+1) >= 0 && (key+1) <= MaxUint16) {
+				answer.highlowcontainer.appendContainer(uint16(key+1), hi, false)
 			}
 		}
 	}

--- a/roaring.go
+++ b/roaring.go
@@ -547,7 +547,7 @@ func AddOffset64(x *Bitmap, offset int64) (answer *Bitmap) {
 			c := x.highlowcontainer.getContainerAtIndex(pos)
 			lo, hi := c.addOffset(inOffset)
 
-			if !lo.isEmpty() && (key >= 0 && key <= MaxUint16) {
+			if lo != nil && (key >= 0 && key <= MaxUint16) {
 				curSize := answer.highlowcontainer.size()
 				lastkey := int32(0)
 
@@ -564,7 +564,7 @@ func AddOffset64(x *Bitmap, offset int64) (answer *Bitmap) {
 				}
 			}
 
-			if !hi.isEmpty() && ((key+1) >= 0 && (key+1) <= MaxUint16) {
+			if hi != nil && ((key+1) >= 0 && (key+1) <= MaxUint16) {
 				answer.highlowcontainer.appendContainer(uint16(key+1), hi, false)
 			}
 		}

--- a/roaring.go
+++ b/roaring.go
@@ -557,8 +557,8 @@ func AddOffset64(x *Bitmap, offset int64) (answer *Bitmap) {
 
 				if curSize > 0 && lastkey == key {
 					prev := answer.highlowcontainer.getContainerAtIndex(curSize - 1)
-					orrseult := prev.ior(lo)
-					answer.highlowcontainer.setContainerAtIndex(curSize-1, orrseult)
+					orresult := prev.ior(lo)
+					answer.highlowcontainer.setContainerAtIndex(curSize-1, orresult)
 				} else {
 					answer.highlowcontainer.appendContainer(uint16(key), lo, false)
 				}

--- a/roaringarray.go
+++ b/roaringarray.go
@@ -9,7 +9,7 @@ import (
 )
 
 type container interface {
-	addOffset(uint16) []container
+	addOffset(uint16) (container, container)
 
 	clone() container
 	and(container) container

--- a/roaringarray.go
+++ b/roaringarray.go
@@ -9,6 +9,9 @@ import (
 )
 
 type container interface {
+	// addOffset returns the (low, high) parts of the shifted container.
+	// Whenever one of them would be empty, nil will be returned instead to
+	// avoid unnecessary allocations.
 	addOffset(uint16) (container, container)
 
 	clone() container

--- a/runcontainer.go
+++ b/runcontainer.go
@@ -2582,7 +2582,7 @@ func (rc *runContainer16) serializedSizeInBytes() int {
 	return 2 + len(rc.iv)*4
 }
 
-func (rc *runContainer16) addOffset(x uint16) []container {
+func (rc *runContainer16) addOffset(x uint16) (container, container) {
 	low := newRunContainer16()
 	high := newRunContainer16()
 
@@ -2600,5 +2600,5 @@ func (rc *runContainer16) addOffset(x uint16) []container {
 			high.iv = append(high.iv, interval16{uint16(val & 0xffff), iv.length})
 		}
 	}
-	return []container{low, high}
+	return low, high
 }

--- a/runcontainer.go
+++ b/runcontainer.go
@@ -2583,8 +2583,26 @@ func (rc *runContainer16) serializedSizeInBytes() int {
 }
 
 func (rc *runContainer16) addOffset(x uint16) (container, container) {
-	low := newRunContainer16()
-	high := newRunContainer16()
+	var low, high *runContainer16
+
+	if len(rc.iv) == 0 {
+		return nil, nil
+	}
+
+	first := uint32(rc.iv[0].start) + uint32(x)
+	if highbits(first) == 0 {
+		// Some elements will fall into low part, allocate a container.
+		// Checking the first one is enough because they are ordered.
+		low = newRunContainer16()
+	}
+	last := uint32(rc.iv[len(rc.iv)-1].start)
+	last += uint32(rc.iv[len(rc.iv)-1].length)
+	last += uint32(x)
+	if highbits(last) > 0 {
+		// Some elements will fall into high part, allocate a container.
+		// Checking the last one is enough because they are ordered.
+		high = newRunContainer16()
+	}
 
 	for _, iv := range rc.iv {
 		val := int(iv.start) + int(x)
@@ -2600,5 +2618,14 @@ func (rc *runContainer16) addOffset(x uint16) (container, container) {
 			high.iv = append(high.iv, interval16{uint16(val & 0xffff), iv.length})
 		}
 	}
+
+	// Ensure proper nil interface.
+	if low == nil {
+		return nil, high
+	}
+	if high == nil {
+		return low, nil
+	}
+
 	return low, high
 }

--- a/runcontainer_test.go
+++ b/runcontainer_test.go
@@ -80,9 +80,9 @@ func TestRleInterval16s(t *testing.T) {
 func TestRunOffset(t *testing.T) {
 	v := newRunContainer16TakeOwnership([]interval16{newInterval16Range(34, 39)})
 	offtest := uint16(65500)
-	w := v.addOffset(offtest)
-	w0card := w[0].getCardinality()
-	w1card := w[1].getCardinality()
+	l, h := v.addOffset(offtest)
+	w0card := l.getCardinality()
+	w1card := h.getCardinality()
 
 	if w0card+w1card != 6 {
 		t.Errorf("Bogus cardinality.")
@@ -91,10 +91,10 @@ func TestRunOffset(t *testing.T) {
 	expected := []int{65534, 65535, 65536, 65537, 65538, 65539}
 	wout := make([]int, len(expected))
 	for i := 0; i < w0card; i++ {
-		wout[i] = w[0].selectInt(uint16(i))
+		wout[i] = l.selectInt(uint16(i))
 	}
 	for i := 0; i < w1card; i++ {
-		wout[i+w0card] = w[1].selectInt(uint16(i)) + 65536
+		wout[i+w0card] = h.selectInt(uint16(i)) + 65536
 	}
 
 	for i, x := range wout {

--- a/runcontainer_test.go
+++ b/runcontainer_test.go
@@ -81,26 +81,31 @@ func TestRunOffset(t *testing.T) {
 	v := newRunContainer16TakeOwnership([]interval16{newInterval16Range(34, 39)})
 	offtest := uint16(65500)
 	l, h := v.addOffset(offtest)
-	w0card := l.getCardinality()
-	w1card := h.getCardinality()
-
-	if w0card+w1card != 6 {
-		t.Errorf("Bogus cardinality.")
-	}
 
 	expected := []int{65534, 65535, 65536, 65537, 65538, 65539}
 	wout := make([]int, len(expected))
-	for i := 0; i < w0card; i++ {
-		wout[i] = l.selectInt(uint16(i))
-	}
-	for i := 0; i < w1card; i++ {
-		wout[i+w0card] = h.selectInt(uint16(i)) + 65536
+
+	var w0card, w1card int
+
+	if l != nil {
+		w0card = l.getCardinality()
+
+		for i := 0; i < w0card; i++ {
+			wout[i] = l.selectInt(uint16(i))
+		}
 	}
 
-	for i, x := range wout {
-		if x != expected[i] {
-			t.Errorf("found discrepancy %d!=%d", x, expected[i])
+	if h != nil {
+		w1card = h.getCardinality()
+
+		for i := 0; i < w1card; i++ {
+			wout[i+w0card] = h.selectInt(uint16(i)) + 65536
 		}
+	}
+
+	assert.Equal(t, v.getCardinality(), w0card+w1card)
+	for i, x := range wout {
+		assert.Equal(t, expected[i], x)
 	}
 }
 


### PR DESCRIPTION
This work reduces allocation made by the `addOffset` methods applied to containers by `AddOffset64`.

First, it replaces the return of a slice with the low and high parts by a simple multivalue return.
Presumably this was simply taken from the Java implementation, where multivalue returns aren't present.
This saves two allocations (one for the header, one for the buffer) per container and adds some brevity.

Then, it replaces the use of empty containers in the output by a `nil`-is-empty protocol.
Implementations detect whether they'll be returning 0, 1 or 2 containers eagerly and avoid unneeded allocation.
The 0 case could be omitted.
Special care was taken to avoid the creation of boxed nil pointers.