### PR TITLE
More AddOffset optimizations

### DIFF
--- a/roaring.go
+++ b/roaring.go
@@ -544,6 +544,10 @@ func AddOffset64(x *Bitmap, offset int64) (answer *Bitmap) {
 			key := int32(x.highlowcontainer.getKeyAtIndex(pos))
 			key += containerOffset
 
+			if key+1 < 0 || key > MaxUint16 {
+				continue
+			}
+
 			c := x.highlowcontainer.getContainerAtIndex(pos)
 			lo, hi := c.addOffset(inOffset)
 

--- a/roaring.go
+++ b/roaring.go
@@ -551,7 +551,7 @@ func AddOffset64(x *Bitmap, offset int64) (answer *Bitmap) {
 			c := x.highlowcontainer.getContainerAtIndex(pos)
 			lo, hi := c.addOffset(inOffset)
 
-			if lo != nil && (key >= 0 && key <= MaxUint16) {
+			if lo != nil && key >= 0 {
 				curSize := answer.highlowcontainer.size()
 				lastkey := int32(0)
 
@@ -568,7 +568,7 @@ func AddOffset64(x *Bitmap, offset int64) (answer *Bitmap) {
 				}
 			}
 
-			if hi != nil && ((key+1) >= 0 && (key+1) <= MaxUint16) {
+			if hi != nil && key+1 <= MaxUint16 {
 				answer.highlowcontainer.appendContainer(uint16(key+1), hi, false)
 			}
 		}


### PR DESCRIPTION
This PR skips computation of shifted containers that would be discarded due to  out of bounds keys in the case of container unaligned offsets.
It should both reduce load on the GC due to these temporary objects and CPU use due to the computation itself.