### PR TITLE
Implement hashing (#198)

### DIFF
--- a/serialization_generic.go
+++ b/serialization_generic.go
@@ -94,19 +94,6 @@ func interval16SliceAsByteSlice(slice []interval16) []byte {
 	}
 
 	return by
-	// make a new slice header
-	header := *(*reflect.SliceHeader)(unsafe.Pointer(&slice))
-
-	// update its capacity and length
-	header.Len *= 4
-	header.Cap *= 4
-
-	// instantiate result and use KeepAlive so data isn't unmapped.
-	result := *(*[]byte)(unsafe.Pointer(&header))
-	runtime.KeepAlive(&slice)
-
-	// return it
-	return result
 }
 
 func byteSliceAsUint16Slice(slice []byte) []uint16 {

--- a/serialization_generic.go
+++ b/serialization_generic.go
@@ -85,6 +85,30 @@ func uint16SliceAsByteSlice(slice []uint16) []byte {
 	return by
 }
 
+func interval16SliceAsByteSlice(slice []interval16) []byte {
+	by := make([]byte, len(slice)*4)
+
+	for i, v := range slice {
+		binary.LittleEndian.PutUint16(by[i*2:], v.start)
+		binary.LittleEndian.PutUint16(by[i*2+2:], v.length)
+	}
+
+	return by
+	// make a new slice header
+	header := *(*reflect.SliceHeader)(unsafe.Pointer(&slice))
+
+	// update its capacity and length
+	header.Len *= 4
+	header.Cap *= 4
+
+	// instantiate result and use KeepAlive so data isn't unmapped.
+	result := *(*[]byte)(unsafe.Pointer(&header))
+	runtime.KeepAlive(&slice)
+
+	// return it
+	return result
+}
+
 func byteSliceAsUint16Slice(slice []byte) []uint16 {
 	if len(slice)%2 != 0 {
 		panic("Slice size should be divisible by 2")


### PR DESCRIPTION
This is a proof of concept for hashing roaring bitmaps.  
It works by writing to a customizable `hash.Hash`, for each key, a sequence composed of the given key as an LE 16 bit number followed by the values represented by its matching container in the same format, followed by a `0x0000` delimiter.  
Since no empty containers are kept in the bitmap there's no conflict with a container starting with the `0` value, because a separator following a key is simply impossible.  
Because we store the key and the the values following it is impossible for two containers corresponding to different sets but with the same lower parts to end up passing the same input for the hasher, so any collisions that could happen are caused by the hashing algorithm itself, rather than by two different sets creating the same data.