### PR TITLE
Microoptimization for AdvanceIfNeeded

### DIFF
--- a/roaring.go
+++ b/roaring.go
@@ -321,14 +321,14 @@ func (ii *intIterator) PeekNext() uint32 {
 
 // AdvanceIfNeeded advances as long as the next value is smaller than minval
 func (ii *intIterator) AdvanceIfNeeded(minval uint32) {
-	to := minval >> 16
+	to := minval & 0xffff0000
 
-	for ii.HasNext() && (ii.hs>>16) < to {
+	for ii.HasNext() && ii.hs < to {
 		ii.pos++
 		ii.init()
 	}
 
-	if ii.HasNext() && (ii.hs>>16) == to {
+	if ii.HasNext() && ii.hs == to {
 		ii.iter.advanceIfNeeded(lowbits(minval))
 
 		if !ii.iter.hasNext() {


### PR DESCRIPTION
Comparing equality between high bits directly rather than shifting each
time, provides a slight boost to some operations.

benchstat output:

ShortIteratorAdvanceArray/init_size_1_shortIterator_advance-8
56.5ns ±17%    50.9ns ±18%  -9.91%  (p=0.050 n=29+5)
ShortIteratorAdvanceArray/init_size_650_shortIterator_advance-8
88.2ns ±12%    84.8ns ±14%    ~     (p=0.706 n=28+5)
ShortIteratorAdvanceArray/init_size_6500_shortIterator_advance-8
99.0ns ±10%    93.1ns ±10%    ~     (p=0.183 n=28+5)
ShortIteratorAdvanceArray/init_size_65535_shortIterator_advance-8
104ns ± 6%      98ns ±13%    ~     (p=0.099 n=25+5)
SparseAdvanceRoaring/advance_from_1-8
84.9ns ± 7%    83.3ns ±19%    ~     (p=0.827 n=28+5)
SparseAdvanceRoaring/advance_from_2-8
88.8ns ±24%    86.9ns ±15%    ~     (p=0.741 n=29+5)
SparseAdvanceRoaring/advance_from_65-8
91.6ns ±23%    92.9ns ± 8%    ~     (p=0.494 n=30+5)
SparseAdvanceRoaring/advance_from_650-8
91.9ns ±24%   101.7ns ±23%    ~     (p=0.141 n=30+5)
SparseAdvanceOnHugeData-8
681ns ±12%     657ns ±12%    ~     (p=0.418 n=27+5)
SparseAdvanceSequentially/advance_from_1-8
120µs ± 4%     122µs ± 4%    ~     (p=0.196 n=29+5)
SparseAdvanceSequentially/advance_from_2-8
114µs ± 3%     116µs ± 4%    ~     (p=0.775 n=26+5)
SparseAdvanceSequentially/advance_from_65-8
373µs ± 7%     347µs ±10%  -6.96%  (p=0.003 n=28+5)
SparseAdvanceSequentially/advance_from_650-8
366µs ± 5%     342µs ± 9%  -6.53%  (p=0.031 n=26+5)
ShortIteratorAdvanceBitmap/init_size_1_shortIterator_advance-8
42.2ns ± 9%    40.6ns ±12%    ~     (p=0.716 n=27+5)
ShortIteratorAdvanceBitmap/init_size_650_shortIterator_advance-8
45.0ns ±14%    40.5ns ±10%  -9.95%  (p=0.001 n=29+5)
ShortIteratorAdvanceBitmap/init_size_6500_shortIterator_advance-8
44.6ns ±13%    42.2ns ± 7%  -5.19%  (p=0.013 n=26+5)
ShortIteratorAdvanceBitmap/init_size_65535_shortIterator_advance-8
44.4ns ± 8%    42.3ns ±12%    ~     (p=0.132 n=27+5)
ShortIteratorAdvanceRuntime/init_size_1_shortIterator_advance-8
46.4ns ±14%    42.5ns ± 5%  -8.47%  (p=0.001 n=29+5)
ShortIteratorAdvanceRuntime/init_size_650_shortIterator_advance-8
52.3ns ±14%    49.7ns ±12%    ~     (p=0.334 n=30+5)
ShortIteratorAdvanceRuntime/init_size_6500_shortIterator_advance-8
52.7ns ±10%    52.0ns ± 8%    ~     (p=0.732 n=30+5)
ShortIteratorAdvanceRuntime/init_size_65535_shortIterator_advance-8
53.2ns ±12%    49.6ns ± 6%  -6.86%  (p=0.016 n=29+5)