### PR TITLE
bugfix: return correct cardMinusOne in runArrayUnionToRuns

### DIFF
--- a/runcontainer.go
+++ b/runcontainer.go
@@ -2281,7 +2281,7 @@ func runArrayUnionToRuns(rc *runContainer16, ac *arrayContainer) ([]interval16, 
 			pos2++
 		}
 	}
-	cardMinusOne += previousInterval.length + 1
+	cardMinusOne += previousInterval.length
 	target = append(target, previousInterval)
 
 	return target, cardMinusOne

--- a/runcontainer_test.go
+++ b/runcontainer_test.go
@@ -109,6 +109,14 @@ func TestRunOffset(t *testing.T) {
 	}
 }
 
+func TestRunArrayUnionToRuns(t *testing.T) {
+	arrayArg := newArrayContainerRange(0, 10)
+	runArg := newRunContainer16Range(11, 65535)
+	intervals, cardMinusOne := runArrayUnionToRuns(runArg, arrayArg)
+	assert.Equal(t, uint16(65535), cardMinusOne)
+	assert.Equal(t, []interval16{{start: 0, length: 65535}}, intervals)
+}
+
 func TestRleRunIterator16(t *testing.T) {
 	t.Run("RunIterator16 unit tests for next, hasNext, and peekNext should pass", func(t *testing.T) {
 		{


### PR DESCRIPTION
runArrayUnionToRuns had a bug where it was returning the cardinality, rather than one less than the cardinality. This caused #358, in particular the value returned at https://github.com/RoaringBitmap/roaring/blob/294097852484945d6bc34af513641f3ec5cb9767/runcontainer.go#L2157. This only led to incorrect _behavior_ when the union result was a full container. This caused the cardMinusOne to overflow to 0, so it'd get incorrectly converted to an array container. Unfortunately, the runcontainer's toArrayContainer() method has never been safe to call if the size is larger than `arrayDefaultMaxSize`, as it doesn't handle `iaddRange()` returning a new container.

I wrote a unit test for this case, which now passes.