### PR TITLE
Allowing soft disabling of IO tests.

### DIFF
--- a/BitSliceIndexing/bsi_test.go
+++ b/BitSliceIndexing/bsi_test.go
@@ -266,47 +266,47 @@ func TestLargeFile(t *testing.T) {
 
 	datEBM, err := ioutil.ReadFile("./testdata/age/EBM")
 	if(err != nil) {
-		fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+		fmt.Fprintf(os.Stderr, "\n\nIMPORTANT: For testing file IO, the roaring library requires disk access.\nWe omit some tests for now.\n\n")
 		return
 	}
 	dat1, err := ioutil.ReadFile("./testdata/age/1")
 	if(err != nil) {
-		fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+		fmt.Fprintf(os.Stderr, "\n\nIMPORTANT: For testing file IO, the roaring library requires disk access.\nWe omit some tests for now.\n\n")
 		return
 	}
 	dat2, err := ioutil.ReadFile("./testdata/age/2")
 	if(err != nil) {
-		fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+		fmt.Fprintf(os.Stderr, "\n\nIMPORTANT: For testing file IO, the roaring library requires disk access.\nWe omit some tests for now.\n\n")
 		return
 	}
 	dat3, err := ioutil.ReadFile("./testdata/age/3")
 	if(err != nil) {
-		fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+		fmt.Fprintf(os.Stderr, "\n\nIMPORTANT: For testing file IO, the roaring library requires disk access.\nWe omit some tests for now.\n\n")
 		return
 	}
 	dat4, err := ioutil.ReadFile("./testdata/age/4")
 	if(err != nil) {
-		fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+		fmt.Fprintf(os.Stderr, "\n\nIMPORTANT: For testing file IO, the roaring library requires disk access.\nWe omit some tests for now.\n\n")
 		return
 	}
 	dat5, err := ioutil.ReadFile("./testdata/age/5")
 	if(err != nil) {
-		fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+		fmt.Fprintf(os.Stderr, "\n\nIMPORTANT: For testing file IO, the roaring library requires disk access.\nWe omit some tests for now.\n\n")
 		return
 	}
 	dat6, err := ioutil.ReadFile("./testdata/age/6")
 	if(err != nil) {
-		fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+		fmt.Fprintf(os.Stderr, "\n\nIMPORTANT: For testing file IO, the roaring library requires disk access.\nWe omit some tests for now.\n\n")
 		return
 	}
 	dat7, err := ioutil.ReadFile("./testdata/age/7")
 	if(err != nil) {
-		fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+		fmt.Fprintf(os.Stderr, "\n\nIMPORTANT: For testing file IO, the roaring library requires disk access.\nWe omit some tests for now.\n\n")
 		return
 	}
 	dat8, err := ioutil.ReadFile("./testdata/age/8")
 	if(err != nil) {
-		fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+		fmt.Fprintf(os.Stderr, "\n\nIMPORTANT: For testing file IO, the roaring library requires disk access.\nWe omit some tests for now.\n\n")
 		return
 	}
 

--- a/BitSliceIndexing/bsi_test.go
+++ b/BitSliceIndexing/bsi_test.go
@@ -9,6 +9,8 @@ import (
 	"math/rand"
 	"testing"
 	"time"
+	"fmt"
+	"os"
 )
 
 func TestSetAndGet(t *testing.T) {
@@ -263,23 +265,50 @@ func TestNewBSIRetainSet(t *testing.T) {
 func TestLargeFile(t *testing.T) {
 
 	datEBM, err := ioutil.ReadFile("./testdata/age/EBM")
-	require.Nil(t, err)
+	if(err != nil) {
+		fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+		return
+	}
 	dat1, err := ioutil.ReadFile("./testdata/age/1")
-	require.Nil(t, err)
+	if(err != nil) {
+		fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+		return
+	}
 	dat2, err := ioutil.ReadFile("./testdata/age/2")
-	require.Nil(t, err)
+	if(err != nil) {
+		fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+		return
+	}
 	dat3, err := ioutil.ReadFile("./testdata/age/3")
-	require.Nil(t, err)
+	if(err != nil) {
+		fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+		return
+	}
 	dat4, err := ioutil.ReadFile("./testdata/age/4")
-	require.Nil(t, err)
+	if(err != nil) {
+		fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+		return
+	}
 	dat5, err := ioutil.ReadFile("./testdata/age/5")
-	require.Nil(t, err)
+	if(err != nil) {
+		fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+		return
+	}
 	dat6, err := ioutil.ReadFile("./testdata/age/6")
-	require.Nil(t, err)
+	if(err != nil) {
+		fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+		return
+	}
 	dat7, err := ioutil.ReadFile("./testdata/age/7")
-	require.Nil(t, err)
+	if(err != nil) {
+		fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+		return
+	}
 	dat8, err := ioutil.ReadFile("./testdata/age/8")
-	require.Nil(t, err)
+	if(err != nil) {
+		fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+		return
+	}
 
 	b := [][]byte{datEBM, dat1, dat2, dat3, dat4, dat5, dat6, dat7, dat8}
 

--- a/README.md
+++ b/README.md
@@ -169,9 +169,11 @@ Note that the smat library requires Go 1.6 or better.
 
 ### Instructions for contributors
 
+Using bash or other common shells:
 ```
 $ git clone git@github.com:RoaringBitmap/roaring.git
-$ GO111MODULE=on go mod tidy
+$ export GO111MODULE=on 
+$ go mod tidy
 $ go test -v
 ```
 

--- a/roaring64/bsi64_test.go
+++ b/roaring64/bsi64_test.go
@@ -8,6 +8,8 @@ import (
 	"math/rand"
 	"testing"
 	"time"
+	"fmt"
+	"os"
 )
 
 func TestSetAndGet(t *testing.T) {
@@ -263,34 +265,56 @@ func TestNewBSIRetainSet(t *testing.T) {
 func TestLargeFile(t *testing.T) {
 
 	datEBM, err := ioutil.ReadFile("./testdata/age/EBM")
-	require.Nil(t, err)
+	if(err != nil) {
+		fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+		return
+	}
 	dat1, err := ioutil.ReadFile("./testdata/age/1")
-	require.Nil(t, err)
+	if(err != nil) {
+		fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+		return
+	}
 	dat2, err := ioutil.ReadFile("./testdata/age/2")
-	require.Nil(t, err)
+	if(err != nil) {
+		fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+		return
+	}
 	dat3, err := ioutil.ReadFile("./testdata/age/3")
-	require.Nil(t, err)
+	if(err != nil) {
+		fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+		return
+	}
 	dat4, err := ioutil.ReadFile("./testdata/age/4")
-	require.Nil(t, err)
+	if(err != nil) {
+		fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+		return
+	}
 	dat5, err := ioutil.ReadFile("./testdata/age/5")
-	require.Nil(t, err)
+	if(err != nil) {
+		fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+		return
+	}
 	dat6, err := ioutil.ReadFile("./testdata/age/6")
-	require.Nil(t, err)
+	if(err != nil) {
+		fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+		return
+	}
 	dat7, err := ioutil.ReadFile("./testdata/age/7")
-	require.Nil(t, err)
+	if(err != nil) {
+		fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+		return
+	}
 	dat8, err := ioutil.ReadFile("./testdata/age/8")
-	require.Nil(t, err)
+	if(err != nil) {
+		fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+		return
+	}
 
 	b := [][]byte{datEBM, dat1, dat2, dat3, dat4, dat5, dat6, dat7, dat8}
 
 	bsi := NewDefaultBSI()
 	//bsi.RunOptimize()
 	err = bsi.UnmarshalBinary(b)
-	for i := 0; i < bsi.BitCount(); i++ {
-		//assert.True(t, bsi.bA[i].HasRunCompression())
-		//bsi.bA[i].RunOptimize()
-	}
-	//assert.True(t, bsi.eBM.HasRunCompression())
 	require.Nil(t, err)
 
 	resultA := bsi.CompareValue(0, EQ, 55, 0, nil)

--- a/roaring64/bsi64_test.go
+++ b/roaring64/bsi64_test.go
@@ -266,47 +266,47 @@ func TestLargeFile(t *testing.T) {
 
 	datEBM, err := ioutil.ReadFile("./testdata/age/EBM")
 	if(err != nil) {
-		fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+		fmt.Fprintf(os.Stderr, "\n\nIMPORTANT: For testing file IO, the roaring library requires disk access.\nWe omit some tests for now.\n\n")
 		return
 	}
 	dat1, err := ioutil.ReadFile("./testdata/age/1")
 	if(err != nil) {
-		fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+		fmt.Fprintf(os.Stderr, "\n\nIMPORTANT: For testing file IO, the roaring library requires disk access.\nWe omit some tests for now.\n\n")
 		return
 	}
 	dat2, err := ioutil.ReadFile("./testdata/age/2")
 	if(err != nil) {
-		fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+		fmt.Fprintf(os.Stderr, "\n\nIMPORTANT: For testing file IO, the roaring library requires disk access.\nWe omit some tests for now.\n\n")
 		return
 	}
 	dat3, err := ioutil.ReadFile("./testdata/age/3")
 	if(err != nil) {
-		fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+		fmt.Fprintf(os.Stderr, "\n\nIMPORTANT: For testing file IO, the roaring library requires disk access.\nWe omit some tests for now.\n\n")
 		return
 	}
 	dat4, err := ioutil.ReadFile("./testdata/age/4")
 	if(err != nil) {
-		fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+		fmt.Fprintf(os.Stderr, "\n\nIMPORTANT: For testing file IO, the roaring library requires disk access.\nWe omit some tests for now.\n\n")
 		return
 	}
 	dat5, err := ioutil.ReadFile("./testdata/age/5")
 	if(err != nil) {
-		fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+		fmt.Fprintf(os.Stderr, "\n\nIMPORTANT: For testing file IO, the roaring library requires disk access.\nWe omit some tests for now.\n\n")
 		return
 	}
 	dat6, err := ioutil.ReadFile("./testdata/age/6")
 	if(err != nil) {
-		fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+		fmt.Fprintf(os.Stderr, "\n\nIMPORTANT: For testing file IO, the roaring library requires disk access.\nWe omit some tests for now.\n\n")
 		return
 	}
 	dat7, err := ioutil.ReadFile("./testdata/age/7")
 	if(err != nil) {
-		fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+		fmt.Fprintf(os.Stderr, "\n\nIMPORTANT: For testing file IO, the roaring library requires disk access.\nWe omit some tests for now.\n\n")
 		return
 	}
 	dat8, err := ioutil.ReadFile("./testdata/age/8")
 	if(err != nil) {
-		fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+		fmt.Fprintf(os.Stderr, "\n\nIMPORTANT: For testing file IO, the roaring library requires disk access.\nWe omit some tests for now.\n\n")
 		return
 	}
 

--- a/roaring64/roaring64_test.go
+++ b/roaring64/roaring64_test.go
@@ -2003,7 +2003,7 @@ func Test_tryReadFromRoaring32(t *testing.T) {
 func Test_tryReadFromRoaring32_File(t *testing.T) {
 	tempDir, err := ioutil.TempDir("./", "testdata")
 	if(err != nil) {
-		fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+		fmt.Fprintf(os.Stderr, "\n\nIMPORTANT: For testing file IO, the roaring library requires disk access.\nWe omit some tests for now.\n\n")
 		return
 	}
 	defer os.RemoveAll(tempDir)
@@ -2019,7 +2019,7 @@ func Test_tryReadFromRoaring32_File(t *testing.T) {
 	}
 	file, err := os.Open(name)
 	if(err != nil) {
-		fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+		fmt.Fprintf(os.Stderr, "\n\nIMPORTANT: For testing file IO, the roaring library requires disk access.\nWe omit some tests for now.\n\n")
 		return
 	}
 	defer file.Close()
@@ -2049,7 +2049,7 @@ func Test_tryReadFromRoaring32WithRoaring64(t *testing.T) {
 func Test_tryReadFromRoaring32WithRoaring64_File(t *testing.T) {
 	tempDir, err := ioutil.TempDir("./", "testdata")
 	if(err != nil) {
-		fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+		fmt.Fprintf(os.Stderr, "\n\nIMPORTANT: For testing file IO, the roaring library requires disk access.\nWe omit some tests for now.\n\n")
 		return
 	}
 	defer os.RemoveAll(tempDir)
@@ -2066,7 +2066,7 @@ func Test_tryReadFromRoaring32WithRoaring64_File(t *testing.T) {
 	}
 	file, err := os.Open(name)
 	if(err != nil) {
-		fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+		fmt.Fprintf(os.Stderr, "\n\nIMPORTANT: For testing file IO, the roaring library requires disk access.\nWe omit some tests for now.\n\n")
 		return
 	}
 	defer file.Close()

--- a/roaring64/roaring64_test.go
+++ b/roaring64/roaring64_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"testing"
+	"fmt"
 
 	"github.com/RoaringBitmap/roaring"
 	"github.com/bits-and-blooms/bitset"
@@ -2001,8 +2002,9 @@ func Test_tryReadFromRoaring32(t *testing.T) {
 
 func Test_tryReadFromRoaring32_File(t *testing.T) {
 	tempDir, err := ioutil.TempDir("./", "testdata")
-	if err != nil {
-		t.Fail()
+	if(err != nil) {
+		fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+		return
 	}
 	defer os.RemoveAll(tempDir)
 
@@ -2016,8 +2018,9 @@ func Test_tryReadFromRoaring32_File(t *testing.T) {
 		t.Fatal(err)
 	}
 	file, err := os.Open(name)
-	if err != nil {
-		t.Fatal(err)
+	if(err != nil) {
+		fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+		return
 	}
 	defer file.Close()
 
@@ -2045,8 +2048,9 @@ func Test_tryReadFromRoaring32WithRoaring64(t *testing.T) {
 
 func Test_tryReadFromRoaring32WithRoaring64_File(t *testing.T) {
 	tempDir, err := ioutil.TempDir("./", "testdata")
-	if err != nil {
-		t.Fail()
+	if(err != nil) {
+		fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+		return
 	}
 	defer os.RemoveAll(tempDir)
 
@@ -2061,8 +2065,9 @@ func Test_tryReadFromRoaring32WithRoaring64_File(t *testing.T) {
 		t.Fatal(err)
 	}
 	file, err := os.Open(name)
-	if err != nil {
-		t.Fatal(err)
+	if(err != nil) {
+		fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+		return
 	}
 	defer file.Close()
 

--- a/roaring64/serialization_test.go
+++ b/roaring64/serialization_test.go
@@ -64,14 +64,14 @@ func TestSerializationToFile038(t *testing.T) {
 	fname := "myfile.bin"
 	fout, err := os.OpenFile(fname, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0660)
 	if(err != nil) {
-		fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+		fmt.Fprintf(os.Stderr, "\n\nIMPORTANT: For testing file IO, the roaring library requires disk access.\nWe omit some tests for now.\n\n")
 		return
 	}
 
 	var l int64
 	l, err = rb.WriteTo(fout)
 	if(err != nil) {
-		fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+		fmt.Fprintf(os.Stderr, "\n\nIMPORTANT: For testing file IO, the roaring library requires disk access.\nWe omit some tests for now.\n\n")
 		return
 	}
 
@@ -82,7 +82,7 @@ func TestSerializationToFile038(t *testing.T) {
 	newrb := NewBitmap()
 	fin, err := os.Open(fname)
 	if(err != nil) {
-		fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+		fmt.Fprintf(os.Stderr, "\n\nIMPORTANT: For testing file IO, the roaring library requires disk access.\nWe omit some tests for now.\n\n")
 		return
 	}
 

--- a/roaring64/serialization_test.go
+++ b/roaring64/serialization_test.go
@@ -64,28 +64,31 @@ func TestSerializationToFile038(t *testing.T) {
 	fname := "myfile.bin"
 	fout, err := os.OpenFile(fname, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0660)
 	if(err != nil) {
-		fmt.Println("IMPORTANT: For testing file IO, the roaring library requires disk access.")
+		fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
 		return
 	}
 
-	require.NoError(t, err)
-
 	var l int64
 	l, err = rb.WriteTo(fout)
+	if(err != nil) {
+		fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+		return
+	}
 
-	require.NoError(t, err)
 	assert.EqualValues(t, l, rb.GetSerializedSizeInBytes())
 
 	fout.Close()
 
 	newrb := NewBitmap()
 	fin, err := os.Open(fname)
-
-	require.NoError(t, err)
+	if(err != nil) {
+		fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+		return
+	}
 
 	defer func() {
 		fin.Close()
-		require.NoError(t, os.Remove(fname))
+		_ = os.Remove(fname)
 	}()
 
 	_, _ = newrb.ReadFrom(fin)

--- a/serialization_frozen_test.go
+++ b/serialization_frozen_test.go
@@ -8,6 +8,8 @@ import (
 	"io/ioutil"
 	"reflect"
 	"testing"
+	"os"
+	"fmt"
 )
 
 func TestFrozenFormat(t *testing.T) {
@@ -47,11 +49,13 @@ func TestFrozenFormat(t *testing.T) {
 
 			frozenBuf, err := ioutil.ReadFile(fpath)
 			if err != nil {
-				t.Fatalf("failed to open %s: %s", fpath, err)
+				fmt.Fprintf(os.Stderr, "\n\nIMPORTANT: For testing file IO, the roaring library requires disk access.\nWe omit some tests for now.\n\n")
+				return
 			}
 			portableBuf, err := ioutil.ReadFile(ppath)
 			if err != nil {
-				t.Fatalf("failed to open %s: %s", ppath, err)
+				fmt.Fprintf(os.Stderr, "\n\nIMPORTANT: For testing file IO, the roaring library requires disk access.\nWe omit some tests for now.\n\n")
+				return
 			}
 
 			frozen, portable := New(), New()
@@ -71,11 +75,13 @@ func TestFrozenFormat(t *testing.T) {
 
 			frozenBuf, err := ioutil.ReadFile(fpath)
 			if err != nil {
-				t.Fatalf("failed to open %s: %s", fpath, err)
+				fmt.Fprintf(os.Stderr, "\n\nIMPORTANT: For testing file IO, the roaring library requires disk access.\nWe omit some tests for now.\n\n")
+				return
 			}
 			portableBuf, err := ioutil.ReadFile(ppath)
 			if err != nil {
-				t.Fatalf("failed to open %s: %s", ppath, err)
+				fmt.Fprintf(os.Stderr, "\n\nIMPORTANT: For testing file IO, the roaring library requires disk access.\nWe omit some tests for now.\n\n")
+				return
 			}
 
 			portable := New()
@@ -100,11 +106,13 @@ func TestFrozenFormat(t *testing.T) {
 
 			frozenBuf, err := ioutil.ReadFile(fpath)
 			if err != nil {
-				t.Fatalf("failed to open %s: %s", fpath, err)
+				fmt.Fprintf(os.Stderr, "\n\nIMPORTANT: For testing file IO, the roaring library requires disk access.\nWe omit some tests for now.\n\n")
+				return
 			}
 			portableBuf, err := ioutil.ReadFile(ppath)
 			if err != nil {
-				t.Fatalf("failed to open %s: %s", ppath, err)
+				fmt.Fprintf(os.Stderr, "\n\nIMPORTANT: For testing file IO, the roaring library requires disk access.\nWe omit some tests for now.\n\n")
+				return
 			}
 
 			portable := New()

--- a/serialization_test.go
+++ b/serialization_test.go
@@ -68,14 +68,14 @@ func TestSerializationToFile038(t *testing.T) {
 	fname := "myfile.bin"
 	fout, err := os.OpenFile(fname, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0660)
 	if(err != nil) {
-		fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+		fmt.Fprintf(os.Stderr, "\n\nIMPORTANT: For testing file IO, the roaring library requires disk access.\nWe omit some tests for now.\n\n")
 		return
 	}
 
 	var l int64
 	l, err = rb.WriteTo(fout)
 	if(err != nil) {
-		fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+		fmt.Fprintf(os.Stderr, "\n\nIMPORTANT: For testing file IO, the roaring library requires disk access.\nWe omit some tests for now.\n\n")
 		return
 	}
 
@@ -86,7 +86,7 @@ func TestSerializationToFile038(t *testing.T) {
 	newrb := NewBitmap()
 	fin, err := os.Open(fname)
 	if(err != nil) {
-		fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+		fmt.Fprintf(os.Stderr, "\n\nIMPORTANT: For testing file IO, the roaring library requires disk access.\nWe omit some tests for now.\n\n")
 		return
 	}
 
@@ -104,7 +104,7 @@ func TestSerializationReadRunsFromFile039(t *testing.T) {
 
 	by, err := ioutil.ReadFile(fn)
 	if(err != nil) {
-		fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+		fmt.Fprintf(os.Stderr, "\n\nIMPORTANT: For testing file IO, the roaring library requires disk access.\nWe omit some tests for now.\n\n")
 		return
 	}
 
@@ -131,7 +131,7 @@ func TestSerializationBasic4WriteAndReadFile040(t *testing.T) {
 	rb.highlowcontainer.runOptimize()
 	fout, err := os.Create(fname)
 	if(err != nil) {
-		fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+		fmt.Fprintf(os.Stderr, "\n\nIMPORTANT: For testing file IO, the roaring library requires disk access.\nWe omit some tests for now.\n\n")
 		return
 	}
 
@@ -140,7 +140,7 @@ func TestSerializationBasic4WriteAndReadFile040(t *testing.T) {
 	l, err = rb.WriteTo(fout)
 
 	if(err != nil) {
-		fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+		fmt.Fprintf(os.Stderr, "\n\nIMPORTANT: For testing file IO, the roaring library requires disk access.\nWe omit some tests for now.\n\n")
 		return
 	}
 	assert.EqualValues(t, l, rb.GetSerializedSizeInBytes())
@@ -148,7 +148,7 @@ func TestSerializationBasic4WriteAndReadFile040(t *testing.T) {
 	fout.Close()
 	fin, err := os.Open(fname)
 	if(err != nil) {
-		fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+		fmt.Fprintf(os.Stderr, "\n\nIMPORTANT: For testing file IO, the roaring library requires disk access.\nWe omit some tests for now.\n\n")
 		return
 	}
 
@@ -166,7 +166,7 @@ func TestSerializationFromJava051(t *testing.T) {
 	newrb := NewBitmap()
 	fin, err := os.Open(fname)
 	if(err != nil) {
-		fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+		fmt.Fprintf(os.Stderr, "\n\nIMPORTANT: For testing file IO, the roaring library requires disk access.\nWe omit some tests for now.\n\n")
 		return
 	}
 
@@ -196,7 +196,7 @@ func TestSerializationFromJavaWithRuns052(t *testing.T) {
 	newrb := NewBitmap()
 	fin, err := os.Open(fname)
 	if(err != nil) {
-		fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+		fmt.Fprintf(os.Stderr, "\n\nIMPORTANT: For testing file IO, the roaring library requires disk access.\nWe omit some tests for now.\n\n")
 		return
 	}
 
@@ -454,7 +454,7 @@ func TestBitmap_FromBuffer(t *testing.T) {
 
 		buf, err := ioutil.ReadFile(file)
 		if(err != nil) {
-			fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+			fmt.Fprintf(os.Stderr, "\n\nIMPORTANT: For testing file IO, the roaring library requires disk access.\nWe omit some tests for now.\n\n")
 			return
 		}
 
@@ -471,7 +471,7 @@ func TestBitmap_FromBuffer(t *testing.T) {
 		buf, err := ioutil.ReadFile(fn)
 
 		if(err != nil) {
-			fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+			fmt.Fprintf(os.Stderr, "\n\nIMPORTANT: For testing file IO, the roaring library requires disk access.\nWe omit some tests for now.\n\n")
 			return
 		}
 
@@ -487,7 +487,7 @@ func TestBitmap_FromBuffer(t *testing.T) {
 		buf, err := ioutil.ReadFile(file)
 
 		if(err != nil) {
-			fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+			fmt.Fprintf(os.Stderr, "\n\nIMPORTANT: For testing file IO, the roaring library requires disk access.\nWe omit some tests for now.\n\n")
 			return
 		}
 
@@ -502,7 +502,7 @@ func TestBitmap_FromBuffer(t *testing.T) {
 		buf, err := ioutil.ReadFile(file)
 
 		if(err != nil) {
-			fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+			fmt.Fprintf(os.Stderr, "\n\nIMPORTANT: For testing file IO, the roaring library requires disk access.\nWe omit some tests for now.\n\n")
 			return
 		}
 
@@ -536,7 +536,7 @@ func TestBitmap_FromBuffer(t *testing.T) {
 		buf, err := ioutil.ReadFile(file)
 
 		if(err != nil) {
-			fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+			fmt.Fprintf(os.Stderr, "\n\nIMPORTANT: For testing file IO, the roaring library requires disk access.\nWe omit some tests for now.\n\n")
 			return
 		}
 
@@ -555,14 +555,14 @@ func TestSerializationCrashers(t *testing.T) {
 	crashers, err := filepath.Glob("testdata/crash*")
 
 	if(err != nil) {
-		fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+		fmt.Fprintf(os.Stderr, "\n\nIMPORTANT: For testing file IO, the roaring library requires disk access.\nWe omit some tests for now.\n\n")
 		return
 	}
 
 	for _, crasher := range crashers {
 		data, err := ioutil.ReadFile(crasher)
 		if(err != nil) {
-			fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+			fmt.Fprintf(os.Stderr, "\n\nIMPORTANT: For testing file IO, the roaring library requires disk access.\nWe omit some tests for now.\n\n")
 			return
 		}
 

--- a/serialization_test.go
+++ b/serialization_test.go
@@ -68,28 +68,31 @@ func TestSerializationToFile038(t *testing.T) {
 	fname := "myfile.bin"
 	fout, err := os.OpenFile(fname, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0660)
 	if(err != nil) {
-		fmt.Println("IMPORTANT: For testing file IO, the roaring library requires disk access.")
+		fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
 		return
 	}
 
-	require.NoError(t, err)
-
 	var l int64
 	l, err = rb.WriteTo(fout)
+	if(err != nil) {
+		fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+		return
+	}
 
-	require.NoError(t, err)
 	assert.EqualValues(t, l, rb.GetSerializedSizeInBytes())
 
 	fout.Close()
 
 	newrb := NewBitmap()
 	fin, err := os.Open(fname)
-
-	require.NoError(t, err)
+	if(err != nil) {
+		fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+		return
+	}
 
 	defer func() {
 		fin.Close()
-		require.NoError(t, os.Remove(fname))
+		_ = os.Remove(fname)
 	}()
 
 	_, _ = newrb.ReadFrom(fin)
@@ -100,7 +103,10 @@ func TestSerializationReadRunsFromFile039(t *testing.T) {
 	fn := "testdata/bitmapwithruns.bin"
 
 	by, err := ioutil.ReadFile(fn)
-	require.NoError(t, err)
+	if(err != nil) {
+		fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+		return
+	}
 
 	newrb := NewBitmap()
 	_, err = newrb.ReadFrom(bytes.NewBuffer(by))
@@ -124,20 +130,27 @@ func TestSerializationBasic4WriteAndReadFile040(t *testing.T) {
 
 	rb.highlowcontainer.runOptimize()
 	fout, err := os.Create(fname)
-
-	require.NoError(t, err)
+	if(err != nil) {
+		fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+		return
+	}
 
 	var l int64
 
 	l, err = rb.WriteTo(fout)
 
-	require.NoError(t, err)
+	if(err != nil) {
+		fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+		return
+	}
 	assert.EqualValues(t, l, rb.GetSerializedSizeInBytes())
 
 	fout.Close()
 	fin, err := os.Open(fname)
-
-	require.NoError(t, err)
+	if(err != nil) {
+		fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+		return
+	}
 
 	defer fin.Close()
 
@@ -152,8 +165,10 @@ func TestSerializationFromJava051(t *testing.T) {
 	fname := "testdata/bitmapwithoutruns.bin"
 	newrb := NewBitmap()
 	fin, err := os.Open(fname)
-
-	require.NoError(t, err)
+	if(err != nil) {
+		fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+		return
+	}
 
 	defer func() {
 		fin.Close()
@@ -180,8 +195,10 @@ func TestSerializationFromJavaWithRuns052(t *testing.T) {
 
 	newrb := NewBitmap()
 	fin, err := os.Open(fname)
-
-	require.NoError(t, err)
+	if(err != nil) {
+		fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+		return
+	}
 
 	defer func() {
 		fin.Close()
@@ -436,7 +453,10 @@ func TestBitmap_FromBuffer(t *testing.T) {
 		file := "testdata/bitmapwithruns.bin"
 
 		buf, err := ioutil.ReadFile(file)
-		require.NoError(t, err)
+		if(err != nil) {
+			fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+			return
+		}
 
 		rb := NewBitmap()
 		_, err = rb.FromBuffer(buf)
@@ -450,7 +470,10 @@ func TestBitmap_FromBuffer(t *testing.T) {
 		fn := "testdata/bitmapwithruns.bin"
 		buf, err := ioutil.ReadFile(fn)
 
-		require.NoError(t, err)
+		if(err != nil) {
+			fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+			return
+		}
 
 		rb := NewBitmap()
 		_, err = rb.FromBuffer(buf)
@@ -463,7 +486,10 @@ func TestBitmap_FromBuffer(t *testing.T) {
 		file := "testdata/all3.classic"
 		buf, err := ioutil.ReadFile(file)
 
-		require.NoError(t, err)
+		if(err != nil) {
+			fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+			return
+		}
 
 		rb := NewBitmap()
 		_, err = rb.FromBuffer(buf)
@@ -475,7 +501,10 @@ func TestBitmap_FromBuffer(t *testing.T) {
 		file := "testdata/bitmapwithruns.bin"
 		buf, err := ioutil.ReadFile(file)
 
-		require.NoError(t, err)
+		if(err != nil) {
+			fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+			return
+		}
 
 		empt := NewBitmap()
 
@@ -506,7 +535,10 @@ func TestBitmap_FromBuffer(t *testing.T) {
 		file := "testdata/bitmapwithruns.bin"
 		buf, err := ioutil.ReadFile(file)
 
-		require.NoError(t, err)
+		if(err != nil) {
+			fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+			return
+		}
 
 		rb := NewBitmap()
 		_, err = rb.FromBuffer(buf)
@@ -522,11 +554,17 @@ func TestBitmap_FromBuffer(t *testing.T) {
 func TestSerializationCrashers(t *testing.T) {
 	crashers, err := filepath.Glob("testdata/crash*")
 
-	require.NoError(t, err)
+	if(err != nil) {
+		fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+		return
+	}
 
 	for _, crasher := range crashers {
 		data, err := ioutil.ReadFile(crasher)
-		require.NoError(t, err)
+		if(err != nil) {
+			fmt.Fprintf(os.Stderr, "IMPORTANT: For testing file IO, the roaring library requires disk access.")
+			return
+		}
 
 		// take a copy in case the stream is modified during unpacking attempt
 		orig := make([]byte, len(data))


### PR DESCRIPTION
Some people want to run our tests without file access. We will allow it, but it is a troubling idea because we effectively allow partial testing. We will be issuing warnings.