### PR TITLE
Modify BSI existence bitmap on Increment

### DIFF
--- a/BitSliceIndexing/bsi.go
+++ b/BitSliceIndexing/bsi.go
@@ -839,6 +839,7 @@ func transposeWithCounts(input *BSI, batch []uint32, resultsChan chan *BSI, wg *
 // Increment - In-place increment of values in a BSI.  Found set select columns for incrementing.
 func (b *BSI) Increment(foundSet *roaring.Bitmap) {
 	b.addDigit(foundSet, 0)
+	b.eBM.Or(foundSet)
 }
 
 // IncrementAll - In-place increment of all values in a BSI.

--- a/roaring64/bsi64.go
+++ b/roaring64/bsi64.go
@@ -844,6 +844,7 @@ func transposeWithCounts(input *BSI, filterSet *Bitmap, batch []uint64, resultsC
 // Increment - In-place increment of values in a BSI.  Found set select columns for incrementing.
 func (b *BSI) Increment(foundSet *Bitmap) {
 	b.addDigit(foundSet, 0)
+	b.eBM.Or(foundSet)
 }
 
 // IncrementAll - In-place increment of all values in a BSI.


### PR DESCRIPTION
Somehow this got missed when BSI was added. There are no existing tests that check this directly, but it's easily discoverable.