### PR TITLE
Add BSI WriteTo, ReadFrom and Equal

### DIFF
--- a/roaring64/bsi64-fuzz_test.go
+++ b/roaring64/bsi64-fuzz_test.go
@@ -1,0 +1,24 @@
+//go:build go1.18
+// +build go1.18
+
+package roaring64
+
+import "testing"
+
+func FuzzBsiStreaming(f *testing.F) {
+	f.Fuzz(func(t *testing.T, b []byte) {
+		slice, err := bytesToBsiColValPairs(b)
+		if err != nil {
+			t.SkipNow()
+		}
+		cols := make(map[uint64]struct{}, len(slice))
+		for _, pair := range slice {
+			_, ok := cols[pair.col]
+			if ok {
+				t.Skip("duplicate column")
+			}
+			cols[pair.col] = struct{}{}
+		}
+		testBsiRoundTrip(t, slice)
+	})
+}

--- a/roaring64/bsi64.go
+++ b/roaring64/bsi64.go
@@ -900,3 +900,25 @@ func (b *BSI) Increment(foundSet *Bitmap) {
 func (b *BSI) IncrementAll() {
 	b.Increment(b.GetExistenceBitmap())
 }
+
+func (b *BSI) Equals(other *BSI) bool {
+	if !b.eBM.Equals(other.eBM) {
+		return false
+	}
+	for i := 0; i < len(b.bA) || i < len(other.bA); i++ {
+		if i >= len(b.bA) {
+			if !other.bA[i].IsEmpty() {
+				return false
+			}
+		} else if i >= len(other.bA) {
+			if !b.bA[i].IsEmpty() {
+				return false
+			}
+		} else {
+			if !b.bA[i].Equals(other.bA[i]) {
+				return false
+			}
+		}
+	}
+	return true
+}

--- a/roaring64/bsi64.go
+++ b/roaring64/bsi64.go
@@ -14,8 +14,6 @@ const (
 	Min64BitSigned = -9223372036854775808
 	// Max64BitSigned - Maximum 64 bit value
 	Max64BitSigned = 9223372036854775807
-	// BSISerialFlag - BSI data detection header
-	BSISerialFlag = "BSI"
 )
 
 // BSI is at its simplest is an array of bitmaps that represent an encoded

--- a/roaring64/bsi64_test.go
+++ b/roaring64/bsi64_test.go
@@ -462,26 +462,22 @@ func TestMinMaxWithRandom(t *testing.T) {
 }
 
 func TestBSIWriteToReadFrom(t *testing.T) {
-	file, err := os.CreateTemp("./testdata", "bsi-test")
+	file, err := ioutil.TempFile("./testdata", "bsi-test")
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer t.Cleanup(func() { os.Remove(file.Name()) })
 	defer file.Close()
-	defer os.Remove(file.Name())
 	bsi := setupRandom()
 	_, err = bsi.WriteTo(file)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	file2, err2 := os.Open(file.Name())
-	if err2 != nil {
-		t.Fatal(err2)
-	}
-	defer file2.Close()
+	file.Seek(io.SeekStart, 0)
 
 	bsi2 := NewDefaultBSI()
-	_, err3 := bsi2.ReadFrom(file2)
+	_, err3 := bsi2.ReadFrom(file)
 	if err3 != nil {
 		t.Fatal(err3)
 	}

--- a/roaring64/bsi64_test.go
+++ b/roaring64/bsi64_test.go
@@ -1,15 +1,15 @@
 package roaring64
 
 import (
+	"fmt"
 	_ "fmt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"io/ioutil"
 	"math/rand"
+	"os"
 	"testing"
 	"time"
-	"fmt"
-	"os"
 )
 
 func TestSetAndGet(t *testing.T) {
@@ -265,47 +265,47 @@ func TestNewBSIRetainSet(t *testing.T) {
 func TestLargeFile(t *testing.T) {
 
 	datEBM, err := ioutil.ReadFile("./testdata/age/EBM")
-	if(err != nil) {
+	if err != nil {
 		fmt.Fprintf(os.Stderr, "\n\nIMPORTANT: For testing file IO, the roaring library requires disk access.\nWe omit some tests for now.\n\n")
 		return
 	}
 	dat1, err := ioutil.ReadFile("./testdata/age/1")
-	if(err != nil) {
+	if err != nil {
 		fmt.Fprintf(os.Stderr, "\n\nIMPORTANT: For testing file IO, the roaring library requires disk access.\nWe omit some tests for now.\n\n")
 		return
 	}
 	dat2, err := ioutil.ReadFile("./testdata/age/2")
-	if(err != nil) {
+	if err != nil {
 		fmt.Fprintf(os.Stderr, "\n\nIMPORTANT: For testing file IO, the roaring library requires disk access.\nWe omit some tests for now.\n\n")
 		return
 	}
 	dat3, err := ioutil.ReadFile("./testdata/age/3")
-	if(err != nil) {
+	if err != nil {
 		fmt.Fprintf(os.Stderr, "\n\nIMPORTANT: For testing file IO, the roaring library requires disk access.\nWe omit some tests for now.\n\n")
 		return
 	}
 	dat4, err := ioutil.ReadFile("./testdata/age/4")
-	if(err != nil) {
+	if err != nil {
 		fmt.Fprintf(os.Stderr, "\n\nIMPORTANT: For testing file IO, the roaring library requires disk access.\nWe omit some tests for now.\n\n")
 		return
 	}
 	dat5, err := ioutil.ReadFile("./testdata/age/5")
-	if(err != nil) {
+	if err != nil {
 		fmt.Fprintf(os.Stderr, "\n\nIMPORTANT: For testing file IO, the roaring library requires disk access.\nWe omit some tests for now.\n\n")
 		return
 	}
 	dat6, err := ioutil.ReadFile("./testdata/age/6")
-	if(err != nil) {
+	if err != nil {
 		fmt.Fprintf(os.Stderr, "\n\nIMPORTANT: For testing file IO, the roaring library requires disk access.\nWe omit some tests for now.\n\n")
 		return
 	}
 	dat7, err := ioutil.ReadFile("./testdata/age/7")
-	if(err != nil) {
+	if err != nil {
 		fmt.Fprintf(os.Stderr, "\n\nIMPORTANT: For testing file IO, the roaring library requires disk access.\nWe omit some tests for now.\n\n")
 		return
 	}
 	dat8, err := ioutil.ReadFile("./testdata/age/8")
-	if(err != nil) {
+	if err != nil {
 		fmt.Fprintf(os.Stderr, "\n\nIMPORTANT: For testing file IO, the roaring library requires disk access.\nWe omit some tests for now.\n\n")
 		return
 	}
@@ -454,4 +454,33 @@ func TestMinMaxWithRandom(t *testing.T) {
 	bsi := setupRandom()
 	assert.Equal(t, bsi.MinValue, bsi.MinMax(0, MIN, bsi.GetExistenceBitmap()))
 	assert.Equal(t, bsi.MaxValue, bsi.MinMax(0, MAX, bsi.GetExistenceBitmap()))
+}
+
+func TestBSI_WriteTo_ReadFrom(t *testing.T) {
+	file, err := os.CreateTemp("./testdata", "bsi-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	defer os.Remove(file.Name())
+	bsi := setupRandom()
+	n, err := bsi.WriteTo(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	file2, err2 := os.Open(file.Name())
+	if err2 != nil {
+		t.Fatal(err2)
+	}
+	defer file2.Close()
+
+	bsi2 := NewDefaultBSI()
+	n2, err3 := bsi2.ReadFrom(file2)
+	if err3 != nil {
+		t.Fatal(err3)
+	}
+	assert.Equal(t, n, n2)
+	assert.Equal(t, bsi.MinValue, bsi2.MinMax(0, MIN, bsi2.GetExistenceBitmap()))
+	assert.Equal(t, bsi.MaxValue, bsi2.MinMax(0, MAX, bsi2.GetExistenceBitmap()))
 }


### PR DESCRIPTION
This is an update to https://github.com/RoaringBitmap/roaring/pull/381.

I added fuzzing for the BSI storage, enabled for go1.18.

I removed all the unnecessary bitmap framing: roaring.Bitmaps are self contained and you can serialize them consecutively without any extra framing required. This significantly reduces overhead and storage requirements.

I removed a lot of excessive allocation, particularly around the framing above.

I added BSI.Equal, which was helpful in the tests.

I fixed the compatibility issue with go1.14.