### PR TITLE
Add BSI.GetSizeInBytes

### DIFF
--- a/roaring64/bsi64.go
+++ b/roaring64/bsi64.go
@@ -920,3 +920,11 @@ func (b *BSI) Equals(other *BSI) bool {
 	}
 	return true
 }
+
+func (b *BSI) GetSizeInBytes() int {
+	size := b.eBM.GetSizeInBytes()
+	for _, bm := range b.bA {
+		size += bm.GetSizeInBytes()
+	}
+	return int(size)
+}


### PR DESCRIPTION
A missing method implemented in my production branch at https://github.com/anacrolix/roaring/tree/anacrolix.