### PR TITLE
Add FromUnsafeBytes to prevent small allocations caused by ByteInputAdapter

### DIFF
--- a/internal/byte_input.go
+++ b/internal/byte_input.go
@@ -42,6 +42,25 @@ type ByteBuffer struct {
 	off int
 }
 
+// NewByteBuffer creates a new ByteBuffer.
+func NewByteBuffer(buf []byte) *ByteBuffer {
+	return &ByteBuffer{
+		buf: buf,
+	}
+}
+
+var _ io.Reader = (*ByteBuffer)(nil)
+
+// Read implements io.Reader.
+func (b *ByteBuffer) Read(p []byte) (int, error) {
+	data, err := b.Next(len(p))
+	if err != nil {
+		return 0, err
+	}
+	copy(p, data)
+	return len(data), nil
+}
+
 // Next returns a slice containing the next n bytes from the reader
 // If there are fewer bytes than the given n, io.ErrUnexpectedEOF will be returned
 func (b *ByteBuffer) Next(n int) ([]byte, error) {

--- a/roaring.go
+++ b/roaring.go
@@ -63,7 +63,7 @@ func (rb *Bitmap) ToBytes() ([]byte, error) {
 func (rb *Bitmap) Checksum() uint64 {
 	const (
 		offset = 14695981039346656037
-		prime = 1099511628211
+		prime  = 1099511628211
 	)
 
 	var bytes []byte
@@ -106,6 +106,14 @@ func (rb *Bitmap) Checksum() uint64 {
 	return hash
 }
 
+// FromUnsafeBytes reads a serialized version of this bitmap from the byte buffer without copy.
+// It is the caller's responsibility to ensure that the input data is not modified and remains valid for the entire lifetime of this bitmap.
+// This method avoids small allocations but holds references to the input data buffer. It is GC-friendly, but it may consume more memory eventually.
+func (rb *Bitmap) FromUnsafeBytes(data []byte, cookieHeader ...byte) (p int64, err error) {
+	stream := internal.NewByteBuffer(data)
+	return rb.ReadFrom(stream)
+}
+
 // ReadFrom reads a serialized version of this bitmap from stream.
 // The format is compatible with other RoaringBitmap
 // implementations (Java, C) and is documented here:
@@ -114,12 +122,18 @@ func (rb *Bitmap) Checksum() uint64 {
 // So add cookieHeader to accept the 4-byte data that has been read in roaring64.ReadFrom.
 // It is not necessary to pass cookieHeader when call roaring.ReadFrom to read the roaring32 data directly.
 func (rb *Bitmap) ReadFrom(reader io.Reader, cookieHeader ...byte) (p int64, err error) {
-	stream := internal.ByteInputAdapterPool.Get().(*internal.ByteInputAdapter)
-	stream.Reset(reader)
+	stream, ok := reader.(internal.ByteInput)
+	if !ok {
+		byteInputAdapter := internal.ByteInputAdapterPool.Get().(*internal.ByteInputAdapter)
+		byteInputAdapter.Reset(reader)
+		stream = byteInputAdapter
+	}
 
 	p, err = rb.highlowcontainer.readFrom(stream, cookieHeader...)
-	internal.ByteInputAdapterPool.Put(stream)
 
+	if !ok {
+		internal.ByteInputAdapterPool.Put(stream.(*internal.ByteInputAdapter))
+	}
 	return
 }
 
@@ -144,7 +158,6 @@ func (rb *Bitmap) ReadFrom(reader io.Reader, cookieHeader ...byte) (p int64, err
 // bitmap derived from this bitmap (e.g., via Or, And) might
 // also be broken. Thus, before making buf unavailable, you should
 // call CloneCopyOnWriteContainers on all such bitmaps.
-//
 func (rb *Bitmap) FromBuffer(buf []byte) (p int64, err error) {
 	stream := internal.ByteBufferPool.Get().(*internal.ByteBuffer)
 	stream.Reset(buf)
@@ -276,9 +289,9 @@ type intIterator struct {
 	// This way, instead of making up-to 64k allocations per full iteration
 	// we get a single allocation and simply reinitialize the appropriate
 	// iterator and point to it in the generic `iter` member on each key bound.
-	shortIter        shortIterator
-	runIter          runIterator16
-	bitmapIter       bitmapContainerShortIterator
+	shortIter  shortIterator
+	runIter    runIterator16
+	bitmapIter bitmapContainerShortIterator
 }
 
 // HasNext returns true if there are more integers to iterate over
@@ -341,7 +354,6 @@ func (ii *intIterator) AdvanceIfNeeded(minval uint32) {
 // IntIterator is meant to allow you to iterate through the values of a bitmap, see Initialize(a *Bitmap)
 type IntIterator = intIterator
 
-
 // Initialize configures the existing iterator so that it can iterate through the values of
 // the provided bitmap.
 // The iteration results are undefined if the bitmap is modified (e.g., with Add or Remove).
@@ -357,9 +369,9 @@ type intReverseIterator struct {
 	iter             shortIterable
 	highlowcontainer *roaringArray
 
-	shortIter        reverseIterator
-	runIter          runReverseIterator16
-	bitmapIter       reverseBitmapContainerShortIterator
+	shortIter  reverseIterator
+	runIter    runReverseIterator16
+	bitmapIter reverseBitmapContainerShortIterator
 }
 
 // HasNext returns true if there are more integers to iterate over
@@ -434,9 +446,9 @@ type manyIntIterator struct {
 	iter             manyIterable
 	highlowcontainer *roaringArray
 
-	shortIter        shortIterator
-	runIter          runIterator16
-	bitmapIter       bitmapContainerManyIterator
+	shortIter  shortIterator
+	runIter    runIterator16
+	bitmapIter bitmapContainerManyIterator
 }
 
 func (ii *manyIntIterator) init() {
@@ -494,7 +506,6 @@ func (ii *manyIntIterator) NextMany64(hs64 uint64, buf []uint64) int {
 
 	return n
 }
-
 
 // ManyIntIterator is meant to allow you to iterate through the values of a bitmap, see Initialize(a *Bitmap)
 type ManyIntIterator = manyIntIterator
@@ -569,7 +580,7 @@ func (rb *Bitmap) Iterate(cb func(x uint32) bool) {
 // Iterator creates a new IntPeekable to iterate over the integers contained in the bitmap, in sorted order;
 // the iterator becomes invalid if the bitmap is modified (e.g., with Add or Remove).
 func (rb *Bitmap) Iterator() IntPeekable {
-    p := new(intIterator)
+	p := new(intIterator)
 	p.Initialize(rb)
 	return p
 }

--- a/roaring64/roaringarray64.go
+++ b/roaring64/roaringarray64.go
@@ -124,6 +124,8 @@ func (ra *roaringArray64) removeIndexRange(begin, end int) {
 
 func (ra *roaringArray64) resize(newsize int) {
 	for k := newsize; k < len(ra.containers); k++ {
+		ra.keys[k] = 0
+		ra.needCopyOnWrite[k] = false
 		ra.containers[k] = nil
 	}
 


### PR DESCRIPTION
We are utilizing [the rocksdb merge operator](https://github.com/facebook/rocksdb/wiki/Merge-Operator) to manipulate values that are encoded by roaring bitmap. The bitmap will be read from disk and merged together, these frequent operations can consume significant CPU resources due to the memory allocations.
 
So, I am proposing to add an alternative function called FromUnsafeBytes to address this problem. The caller can decide whether to make a copy or reuse those byte buffers if necessary.


The benchmark results (note that I have allocated a large buffer and made a copy before FromUnsafeBytes)
```
$ gotest -v -benchmem -bench=.+ -run=Benchmark -benchtime=100000x -count=1
goos: darwin
goarch: arm64
pkg: github.com/RoaringBitmap/roaring/roaring64
BenchmarkUnserializeFromUnsafeBytes
BenchmarkUnserializeFromUnsafeBytes/FromUnsafeBytes-650
BenchmarkUnserializeFromUnsafeBytes/FromUnsafeBytes-650-10                100000               403.2 ns/op          1660 B/op         11 allocs/op
BenchmarkUnserializeFromUnsafeBytes/FromUnsafeBytes-6500
BenchmarkUnserializeFromUnsafeBytes/FromUnsafeBytes-6500-10               100000               886.9 ns/op          9732 B/op         11 allocs/op
BenchmarkUnserializeFromUnsafeBytes/FromUnsafeBytes-65000
BenchmarkUnserializeFromUnsafeBytes/FromUnsafeBytes-65000-10              100000               839.7 ns/op          9732 B/op         11 allocs/op
BenchmarkUnserializeFromUnsafeBytes/FromUnsafeBytes-650000
BenchmarkUnserializeFromUnsafeBytes/FromUnsafeBytes-650000-10             100000              1106 ns/op           10120 B/op         20 allocs/op
BenchmarkUnserializeFromUnsafeBytes/FromUnsafeBytes-6500000
BenchmarkUnserializeFromUnsafeBytes/FromUnsafeBytes-6500000-10            100000              3643 ns/op           14456 B/op        110 allocs/op
BenchmarkUnserializeReadFrom
BenchmarkUnserializeReadFrom/ReadFrom-650
BenchmarkUnserializeReadFrom/ReadFrom-650-10                              100000               459.3 ns/op          1712 B/op         19 allocs/op
BenchmarkUnserializeReadFrom/ReadFrom-6500
BenchmarkUnserializeReadFrom/ReadFrom-6500-10                             100000              1074 ns/op            8507 B/op         19 allocs/op
BenchmarkUnserializeReadFrom/ReadFrom-65000
BenchmarkUnserializeReadFrom/ReadFrom-65000-10                            100000              1109 ns/op            8507 B/op         19 allocs/op
BenchmarkUnserializeReadFrom/ReadFrom-650000
BenchmarkUnserializeReadFrom/ReadFrom-650000-10                           100000              1705 ns/op            9059 B/op         46 allocs/op
BenchmarkUnserializeReadFrom/ReadFrom-6500000
BenchmarkUnserializeReadFrom/ReadFrom-6500000-10                          100000              6575 ns/op           14605 B/op        316 allocs/op
PASS
```