### PR TITLE
Verifying and fixing issue 396 :  `UnmarshalBinary`  or `FromBase64` should not have their containers marked as needing copy-on-write

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -12,7 +12,6 @@ import (
 
 // BENCHMARKS, to run them type "go test -bench Benchmark -run -"
 
-
 // go test -bench BenchmarkIteratorAlloc -benchmem -run -
 func BenchmarkIteratorAlloc(b *testing.B) {
 	bm := NewBitmap()
@@ -84,7 +83,6 @@ func BenchmarkIteratorAlloc(b *testing.B) {
 		b.Fatalf("Cardinalities don't match: %d, %d", counter, expected_cardinality)
 	}
 
-
 	b.Run("many iteration with alloc", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
 			counter = 0
@@ -116,7 +114,6 @@ func BenchmarkIteratorAlloc(b *testing.B) {
 		b.Fatalf("Cardinalities don't match: %d, %d", counter, expected_cardinality)
 	}
 }
-
 
 // go test -bench BenchmarkOrs -benchmem -run -
 func BenchmarkOrs(b *testing.B) {

--- a/bitmapcontainer.go
+++ b/bitmapcontainer.go
@@ -1062,7 +1062,6 @@ func (bc *bitmapContainer) PrevSetBit(i int) int {
 
 // reference the java implementation
 // https://github.com/RoaringBitmap/RoaringBitmap/blob/master/src/main/java/org/roaringbitmap/BitmapContainer.java#L875-L892
-//
 func (bc *bitmapContainer) numberOfRuns() int {
 	if bc.cardinality == 0 {
 		return 0

--- a/internal/byte_input.go
+++ b/internal/byte_input.go
@@ -10,6 +10,11 @@ type ByteInput interface {
 	// Next returns a slice containing the next n bytes from the buffer,
 	// advancing the buffer as if the bytes had been returned by Read.
 	Next(n int) ([]byte, error)
+	// NextReturnsSafeSlice returns true if Next() returns a safe slice as opposed
+	// to a slice that points to an underlying buffer possibly owned by another system.
+	// When NextReturnsSafeSlice returns false, the result from Next() should be copied
+	// before it is modified (i.e., it is immutable).
+	NextReturnsSafeSlice() bool
 	// ReadUInt32 reads uint32 with LittleEndian order
 	ReadUInt32() (uint32, error)
 	// ReadUInt16 reads uint16 with LittleEndian order
@@ -74,6 +79,12 @@ func (b *ByteBuffer) Next(n int) ([]byte, error) {
 	b.off += n
 
 	return data, nil
+}
+
+// NextReturnsSafeSlice returns false since ByteBuffer might hold
+// an array owned by some other systems.
+func (b *ByteBuffer) NextReturnsSafeSlice() bool {
+	return false
 }
 
 // ReadUInt32 reads uint32 with LittleEndian order
@@ -155,6 +166,12 @@ func (b *ByteInputAdapter) Next(n int) ([]byte, error) {
 		return nil, err
 	}
 	return buf, nil
+}
+
+// NextReturnsSafeSlice returns true since ByteInputAdapter always returns a slice
+// allocated with make([]byte, ...)
+func (b *ByteInputAdapter) NextReturnsSafeSlice() bool {
+	return true
 }
 
 // ReadUInt32 reads uint32 with LittleEndian order

--- a/roaring.go
+++ b/roaring.go
@@ -135,8 +135,6 @@ func (rb *Bitmap) ReadFrom(reader io.Reader, cookieHeader ...byte) (p int64, err
 		stream = byteInputAdapter
 	}
 
-	// We pass false to readFrom to indicate that we don't want to resulting containers to be copy-on-write.
-	// They are regular, mutable containers.
 	p, err = rb.highlowcontainer.readFrom(stream, cookieHeader...)
 
 	if !ok {

--- a/roaring.go
+++ b/roaring.go
@@ -117,10 +117,7 @@ func (rb *Bitmap) Checksum() uint64 {
 // See https://github.com/RoaringBitmap/roaring/pull/395 for more details.
 func (rb *Bitmap) FromUnsafeBytes(data []byte, cookieHeader ...byte) (p int64, err error) {
 	stream := internal.NewByteBuffer(data)
-
-	// We pass true to readFrom to indicate that we want to resulting containers to be copy-on-write.
-	// They are immutable containers tied to the provided byte array.
-	return rb.highlowcontainer.readFrom(stream, true, cookieHeader...)
+	return rb.ReadFrom(stream)
 }
 
 // ReadFrom reads a serialized version of this bitmap from stream.
@@ -140,7 +137,7 @@ func (rb *Bitmap) ReadFrom(reader io.Reader, cookieHeader ...byte) (p int64, err
 
 	// We pass false to readFrom to indicate that we don't want to resulting containers to be copy-on-write.
 	// They are regular, mutable containers.
-	p, err = rb.highlowcontainer.readFrom(stream, false, cookieHeader...)
+	p, err = rb.highlowcontainer.readFrom(stream, cookieHeader...)
 
 	if !ok {
 		internal.ByteInputAdapterPool.Put(stream.(*internal.ByteInputAdapter))
@@ -179,9 +176,7 @@ func (rb *Bitmap) FromBuffer(buf []byte) (p int64, err error) {
 	stream := internal.ByteBufferPool.Get().(*internal.ByteBuffer)
 	stream.Reset(buf)
 
-	// We pass true to readFrom to indicate that we want to resulting containers to be copy-on-write.
-	// They are immutable containers tried to the provided byte array.
-	p, err = rb.highlowcontainer.readFrom(stream, true)
+	p, err = rb.highlowcontainer.readFrom(stream)
 	internal.ByteBufferPool.Put(stream)
 
 	return

--- a/roaring_test.go
+++ b/roaring_test.go
@@ -54,11 +54,11 @@ func hashTest(t *testing.T, N uint64) {
 		rb1, rb2 = NewBitmap(), NewBitmap()
 		for x := uint64(0); x <= N*gap; x += gap {
 			// x+3 guarantees runs, gap/2 guarantees some variety
-			if x + 3 + gap/2 > MaxUint32 {
+			if x+3+gap/2 > MaxUint32 {
 				break
 			}
-			rb1.AddRange(uint64(x), uint64(x + 3 + gap/2))
-			rb2.AddRange(uint64(x), uint64(x + 3 + gap/2))
+			rb1.AddRange(uint64(x), uint64(x+3+gap/2))
+			rb2.AddRange(uint64(x), uint64(x+3+gap/2))
 		}
 
 		rb1.RunOptimize()

--- a/roaringarray.go
+++ b/roaringarray.go
@@ -555,7 +555,7 @@ func (ra *roaringArray) toBytes() ([]byte, error) {
 // the parameter willNeedCopyOnWrite should be set to true (e.g., if the buffer is mmapped). Otherwise, if reading from
 // a file or from the network into a temporary buffer, then set willNeedCopyOnWrite should be set to false because the
 // resulting buffers are owned by the newly created roaringArray.
-func (ra *roaringArray) readFrom(stream internal.ByteInput, willNeedCopyOnWrite bool, cookieHeader ...byte) (int64, error) {
+func (ra *roaringArray) readFrom(stream internal.ByteInput, cookieHeader ...byte) (int64, error) {
 	var cookie uint32
 	var err error
 	if len(cookieHeader) > 0 && len(cookieHeader) != 4 {
@@ -569,6 +569,8 @@ func (ra *roaringArray) readFrom(stream internal.ByteInput, willNeedCopyOnWrite 
 			return stream.GetReadBytes(), fmt.Errorf("error in roaringArray.readFrom: could not read initial cookie: %s", err)
 		}
 	}
+	// If NextReturnsSafeSlice is false, then willNeedCopyOnWrite should be true
+	willNeedCopyOnWrite := !stream.NextReturnsSafeSlice()
 
 	var size uint32
 	var isRunBitmap []byte

--- a/roaringarray.go
+++ b/roaringarray.go
@@ -551,10 +551,7 @@ func (ra *roaringArray) toBytes() ([]byte, error) {
 	return buf.Bytes(), err
 }
 
-// Reads a serialized roaringArray from a byte slice. If we are pointing at a raw buffer that must be immutable, then
-// the parameter willNeedCopyOnWrite should be set to true (e.g., if the buffer is mmapped). Otherwise, if reading from
-// a file or from the network into a temporary buffer, then set willNeedCopyOnWrite should be set to false because the
-// resulting buffers are owned by the newly created roaringArray.
+// Reads a serialized roaringArray from a byte slice.
 func (ra *roaringArray) readFrom(stream internal.ByteInput, cookieHeader ...byte) (int64, error) {
 	var cookie uint32
 	var err error

--- a/runcontainer.go
+++ b/runcontainer.go
@@ -253,10 +253,8 @@ func newRunContainer16FromBitmapContainer(bc *bitmapContainer) *runContainer16 {
 
 }
 
-//
 // newRunContainer16FromArray populates a new
 // runContainer16 from the contents of arr.
-//
 func newRunContainer16FromArray(arr *arrayContainer) *runContainer16 {
 	// keep this in sync with newRunContainer16FromVals above
 
@@ -834,24 +832,23 @@ func (rc *runContainer16) numIntervals() int {
 // If key is not already present, then whichInterval16 is
 // set as follows:
 //
-//  a) whichInterval16 == len(rc.iv)-1 if key is beyond our
-//     last interval16 in rc.iv;
+//	a) whichInterval16 == len(rc.iv)-1 if key is beyond our
+//	   last interval16 in rc.iv;
 //
-//  b) whichInterval16 == -1 if key is before our first
-//     interval16 in rc.iv;
+//	b) whichInterval16 == -1 if key is before our first
+//	   interval16 in rc.iv;
 //
-//  c) whichInterval16 is set to the minimum index of rc.iv
-//     which comes strictly before the key;
-//     so  rc.iv[whichInterval16].last < key,
-//     and  if whichInterval16+1 exists, then key < rc.iv[whichInterval16+1].start
-//     (Note that whichInterval16+1 won't exist when
-//     whichInterval16 is the last interval.)
+//	c) whichInterval16 is set to the minimum index of rc.iv
+//	   which comes strictly before the key;
+//	   so  rc.iv[whichInterval16].last < key,
+//	   and  if whichInterval16+1 exists, then key < rc.iv[whichInterval16+1].start
+//	   (Note that whichInterval16+1 won't exist when
+//	   whichInterval16 is the last interval.)
 //
 // runContainer16.search always returns whichInterval16 < len(rc.iv).
 //
 // The search space is from startIndex to endxIndex. If endxIndex is set to zero, then there
 // no upper bound.
-//
 func (rc *runContainer16) searchRange(key int, startIndex int, endxIndex int) (whichInterval16 int, alreadyPresent bool, numCompares int) {
 	n := int(len(rc.iv))
 	if n == 0 {
@@ -937,21 +934,20 @@ func (rc *runContainer16) searchRange(key int, startIndex int, endxIndex int) (w
 // If key is not already present, then whichInterval16 is
 // set as follows:
 //
-//  a) whichInterval16 == len(rc.iv)-1 if key is beyond our
-//     last interval16 in rc.iv;
+//	a) whichInterval16 == len(rc.iv)-1 if key is beyond our
+//	   last interval16 in rc.iv;
 //
-//  b) whichInterval16 == -1 if key is before our first
-//     interval16 in rc.iv;
+//	b) whichInterval16 == -1 if key is before our first
+//	   interval16 in rc.iv;
 //
-//  c) whichInterval16 is set to the minimum index of rc.iv
-//     which comes strictly before the key;
-//     so  rc.iv[whichInterval16].last < key,
-//     and  if whichInterval16+1 exists, then key < rc.iv[whichInterval16+1].start
-//     (Note that whichInterval16+1 won't exist when
-//     whichInterval16 is the last interval.)
+//	c) whichInterval16 is set to the minimum index of rc.iv
+//	   which comes strictly before the key;
+//	   so  rc.iv[whichInterval16].last < key,
+//	   and  if whichInterval16+1 exists, then key < rc.iv[whichInterval16+1].start
+//	   (Note that whichInterval16+1 won't exist when
+//	   whichInterval16 is the last interval.)
 //
 // runContainer16.search always returns whichInterval16 < len(rc.iv).
-//
 func (rc *runContainer16) search(key int) (whichInterval16 int, alreadyPresent bool, numCompares int) {
 	return rc.searchRange(key, 0, 0)
 }
@@ -994,7 +990,6 @@ func newRunContainer16() *runContainer16 {
 
 // newRunContainer16CopyIv creates a run container, initializing
 // with a copy of the supplied iv slice.
-//
 func newRunContainer16CopyIv(iv []interval16) *runContainer16 {
 	rc := &runContainer16{
 		iv: make([]interval16, len(iv)),
@@ -1011,7 +1006,6 @@ func (rc *runContainer16) Clone() *runContainer16 {
 // newRunContainer16TakeOwnership returns a new runContainer16
 // backed by the provided iv slice, which we will
 // assume exclusive control over from now on.
-//
 func newRunContainer16TakeOwnership(iv []interval16) *runContainer16 {
 	rc := &runContainer16{
 		iv: iv,
@@ -2006,7 +2000,6 @@ func (rc *runContainer16) not(firstOfRange, endx int) container {
 // Current routine is correct but
 // makes 2 more passes through the arrays than should be
 // strictly necessary. Measure both ways though--this may not matter.
-//
 func (rc *runContainer16) Not(firstOfRange, endx int) *runContainer16 {
 
 	if firstOfRange > endx {
@@ -2329,7 +2322,6 @@ func runArrayUnionToRuns(rc *runContainer16, ac *arrayContainer) ([]interval16, 
 // the backing array, and then you write
 // the answer at the beginning. What this
 // trick does is minimize memory allocations.
-//
 func (rc *runContainer16) lazyIOR(a container) container {
 	// not lazy at the moment
 	return rc.ior(a)

--- a/serialization.go
+++ b/serialization.go
@@ -7,7 +7,6 @@ import (
 
 // writeTo for runContainer16 follows this
 // spec: https://github.com/RoaringBitmap/RoaringFormatSpec
-//
 func (b *runContainer16) writeTo(stream io.Writer) (int, error) {
 	buf := make([]byte, 2+4*len(b.iv))
 	binary.LittleEndian.PutUint16(buf[0:], uint16(len(b.iv)))

--- a/serialization_frozen_test.go
+++ b/serialization_frozen_test.go
@@ -5,11 +5,11 @@ package roaring
 
 import (
 	"bytes"
+	"fmt"
 	"io/ioutil"
+	"os"
 	"reflect"
 	"testing"
-	"os"
-	"fmt"
 )
 
 func TestFrozenFormat(t *testing.T) {

--- a/serialization_littleendian.go
+++ b/serialization_littleendian.go
@@ -79,12 +79,12 @@ func (bc *bitmapContainer) asLittleEndianByteSlice() []byte {
 
 // Deserialization code follows
 
-////
+// //
 // These methods (byteSliceAsUint16Slice,...) do not make copies,
 // they are pointer-based (unsafe). The caller is responsible to
 // ensure that the input slice does not get garbage collected, deleted
 // or modified while you hold the returned slince.
-////
+// //
 func byteSliceAsUint16Slice(slice []byte) (result []uint16) { // here we create a new slice holder
 	if len(slice)%2 != 0 {
 		panic("Slice size should be divisible by 2")
@@ -295,7 +295,6 @@ func byteSliceAsBoolSlice(slice []byte) (result []bool) {
 // bitmap derived from this bitmap (e.g., via Or, And) might
 // also be broken. Thus, before making buf unavailable, you should
 // call CloneCopyOnWriteContainers on all such bitmaps.
-//
 func (rb *Bitmap) FrozenView(buf []byte) error {
 	return rb.highlowcontainer.frozenView(buf)
 }
@@ -412,11 +411,11 @@ func (ra *roaringArray) frozenView(buf []byte) error {
 	}
 
 	var c container
-	containersSz := int(unsafe.Sizeof(c))*nCont
-	bitsetsSz := int(unsafe.Sizeof(bitmapContainer{}))*nBitmap
-	arraysSz := int(unsafe.Sizeof(arrayContainer{}))*nArray
-	runsSz := int(unsafe.Sizeof(runContainer16{}))*nRun
-	needCOWSz := int(unsafe.Sizeof(true))*nCont
+	containersSz := int(unsafe.Sizeof(c)) * nCont
+	bitsetsSz := int(unsafe.Sizeof(bitmapContainer{})) * nBitmap
+	arraysSz := int(unsafe.Sizeof(arrayContainer{})) * nArray
+	runsSz := int(unsafe.Sizeof(runContainer16{})) * nRun
+	needCOWSz := int(unsafe.Sizeof(true)) * nCont
 
 	bitmapArenaSz := containersSz + bitsetsSz + arraysSz + runsSz + needCOWSz
 	bitmapArena := make([]byte, bitmapArenaSz)

--- a/serialization_test.go
+++ b/serialization_test.go
@@ -67,14 +67,14 @@ func TestSerializationToFile038(t *testing.T) {
 	rb := BitmapOf(1, 2, 3, 4, 5, 100, 1000)
 	fname := "myfile.bin"
 	fout, err := os.OpenFile(fname, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0660)
-	if(err != nil) {
+	if err != nil {
 		fmt.Fprintf(os.Stderr, "\n\nIMPORTANT: For testing file IO, the roaring library requires disk access.\nWe omit some tests for now.\n\n")
 		return
 	}
 
 	var l int64
 	l, err = rb.WriteTo(fout)
-	if(err != nil) {
+	if err != nil {
 		fmt.Fprintf(os.Stderr, "\n\nIMPORTANT: For testing file IO, the roaring library requires disk access.\nWe omit some tests for now.\n\n")
 		return
 	}
@@ -85,7 +85,7 @@ func TestSerializationToFile038(t *testing.T) {
 
 	newrb := NewBitmap()
 	fin, err := os.Open(fname)
-	if(err != nil) {
+	if err != nil {
 		fmt.Fprintf(os.Stderr, "\n\nIMPORTANT: For testing file IO, the roaring library requires disk access.\nWe omit some tests for now.\n\n")
 		return
 	}
@@ -103,7 +103,7 @@ func TestSerializationReadRunsFromFile039(t *testing.T) {
 	fn := "testdata/bitmapwithruns.bin"
 
 	by, err := ioutil.ReadFile(fn)
-	if(err != nil) {
+	if err != nil {
 		fmt.Fprintf(os.Stderr, "\n\nIMPORTANT: For testing file IO, the roaring library requires disk access.\nWe omit some tests for now.\n\n")
 		return
 	}
@@ -130,7 +130,7 @@ func TestSerializationBasic4WriteAndReadFile040(t *testing.T) {
 
 	rb.highlowcontainer.runOptimize()
 	fout, err := os.Create(fname)
-	if(err != nil) {
+	if err != nil {
 		fmt.Fprintf(os.Stderr, "\n\nIMPORTANT: For testing file IO, the roaring library requires disk access.\nWe omit some tests for now.\n\n")
 		return
 	}
@@ -139,7 +139,7 @@ func TestSerializationBasic4WriteAndReadFile040(t *testing.T) {
 
 	l, err = rb.WriteTo(fout)
 
-	if(err != nil) {
+	if err != nil {
 		fmt.Fprintf(os.Stderr, "\n\nIMPORTANT: For testing file IO, the roaring library requires disk access.\nWe omit some tests for now.\n\n")
 		return
 	}
@@ -147,7 +147,7 @@ func TestSerializationBasic4WriteAndReadFile040(t *testing.T) {
 
 	fout.Close()
 	fin, err := os.Open(fname)
-	if(err != nil) {
+	if err != nil {
 		fmt.Fprintf(os.Stderr, "\n\nIMPORTANT: For testing file IO, the roaring library requires disk access.\nWe omit some tests for now.\n\n")
 		return
 	}
@@ -165,7 +165,7 @@ func TestSerializationFromJava051(t *testing.T) {
 	fname := "testdata/bitmapwithoutruns.bin"
 	newrb := NewBitmap()
 	fin, err := os.Open(fname)
-	if(err != nil) {
+	if err != nil {
 		fmt.Fprintf(os.Stderr, "\n\nIMPORTANT: For testing file IO, the roaring library requires disk access.\nWe omit some tests for now.\n\n")
 		return
 	}
@@ -195,7 +195,7 @@ func TestSerializationFromJavaWithRuns052(t *testing.T) {
 
 	newrb := NewBitmap()
 	fin, err := os.Open(fname)
-	if(err != nil) {
+	if err != nil {
 		fmt.Fprintf(os.Stderr, "\n\nIMPORTANT: For testing file IO, the roaring library requires disk access.\nWe omit some tests for now.\n\n")
 		return
 	}
@@ -453,7 +453,7 @@ func TestBitmap_FromBuffer(t *testing.T) {
 		file := "testdata/bitmapwithruns.bin"
 
 		buf, err := ioutil.ReadFile(file)
-		if(err != nil) {
+		if err != nil {
 			fmt.Fprintf(os.Stderr, "\n\nIMPORTANT: For testing file IO, the roaring library requires disk access.\nWe omit some tests for now.\n\n")
 			return
 		}
@@ -470,7 +470,7 @@ func TestBitmap_FromBuffer(t *testing.T) {
 		fn := "testdata/bitmapwithruns.bin"
 		buf, err := ioutil.ReadFile(fn)
 
-		if(err != nil) {
+		if err != nil {
 			fmt.Fprintf(os.Stderr, "\n\nIMPORTANT: For testing file IO, the roaring library requires disk access.\nWe omit some tests for now.\n\n")
 			return
 		}
@@ -486,7 +486,7 @@ func TestBitmap_FromBuffer(t *testing.T) {
 		file := "testdata/all3.classic"
 		buf, err := ioutil.ReadFile(file)
 
-		if(err != nil) {
+		if err != nil {
 			fmt.Fprintf(os.Stderr, "\n\nIMPORTANT: For testing file IO, the roaring library requires disk access.\nWe omit some tests for now.\n\n")
 			return
 		}
@@ -501,7 +501,7 @@ func TestBitmap_FromBuffer(t *testing.T) {
 		file := "testdata/bitmapwithruns.bin"
 		buf, err := ioutil.ReadFile(file)
 
-		if(err != nil) {
+		if err != nil {
 			fmt.Fprintf(os.Stderr, "\n\nIMPORTANT: For testing file IO, the roaring library requires disk access.\nWe omit some tests for now.\n\n")
 			return
 		}
@@ -535,7 +535,7 @@ func TestBitmap_FromBuffer(t *testing.T) {
 		file := "testdata/bitmapwithruns.bin"
 		buf, err := ioutil.ReadFile(file)
 
-		if(err != nil) {
+		if err != nil {
 			fmt.Fprintf(os.Stderr, "\n\nIMPORTANT: For testing file IO, the roaring library requires disk access.\nWe omit some tests for now.\n\n")
 			return
 		}
@@ -554,14 +554,14 @@ func TestBitmap_FromBuffer(t *testing.T) {
 func TestSerializationCrashers(t *testing.T) {
 	crashers, err := filepath.Glob("testdata/crash*")
 
-	if(err != nil) {
+	if err != nil {
 		fmt.Fprintf(os.Stderr, "\n\nIMPORTANT: For testing file IO, the roaring library requires disk access.\nWe omit some tests for now.\n\n")
 		return
 	}
 
 	for _, crasher := range crashers {
 		data, err := ioutil.ReadFile(crasher)
-		if(err != nil) {
+		if err != nil {
 			fmt.Fprintf(os.Stderr, "\n\nIMPORTANT: For testing file IO, the roaring library requires disk access.\nWe omit some tests for now.\n\n")
 			return
 		}
@@ -579,6 +579,25 @@ func TestSerializationCrashers(t *testing.T) {
 
 		assert.Error(t, err)
 	}
+}
+
+func TestIssue396(t *testing.T) {
+	id := uint64(100000)
+	bitmap := NewBitmap()
+	for i := uint64(0); i < id; i++ {
+		if i%2 == 0 {
+			bitmap.Add(uint32(i))
+		}
+	}
+	bitmapBytes, err := bitmap.MarshalBinary()
+	require.Nil(t, err)
+
+	bitmapUnmarshalled := NewBitmap()
+	err = bitmapUnmarshalled.UnmarshalBinary(bitmapBytes)
+	require.Nil(t, err)
+	assert.True(t, bitmap.Equals(bitmapUnmarshalled))
+	bitmapUnmarshalled = bitmapUnmarshalled.Clone()
+	assert.True(t, bitmap.Equals(bitmapUnmarshalled))
 }
 
 func TestBitmapFromBufferCOW(t *testing.T) {


### PR DESCRIPTION
In Go, garbage collection is a substantial cost and burden. For this reason, we put a lot of effort in efficient bitmap deserialization, optimizing the case where the resulting bitmaps are effectively immutable most of the time.

It appears that, over time, we made it so that all bitmap deserialization routines would have containers with copy-on-write set to true. Indeed, `roaringArray` has `ra.needCopyOnWrite[i] = true` in its `readFrom` function. In turn, this `readFrom` method is called from multiple functions such as `UnmarshalBinary`  or `FromBase64`.

What the `ra.needCopyOnWrite[i] = true` line does is that it ensures that we never try to write to the slices/buffers. Instead, if a modification is needed, we just make a whole copy. This is important because the byte array we use in a function like `FromBuffer` or `FromUnsafeBytes` could be read-only memory-mapped data, and writing to it could cause a crash.

However, there is no reason to believe that we have such a problem with  `UnmarshalBinary` or `FromBase64`. Thus it is likely that our current code causes unnecessary copies to be made when `UnmarshalBinary` or `FromBase64` are used, and later the resulting bitmap is modified. That's potentially harmful from a performance point of view.

I traced it back to this PR https://github.com/RoaringBitmap/roaring/pull/225 by @alldroll. Prior to that PR, we had two deserialization routine, one which set copy-on-write on the containers, and one that did not. In the fusion, we set all copy-on-write to true.

Digging into it, we find that `readFrom` in `roaringArray` calls `buf, err := stream.Next(...)` which provides a byte slice, and the slice is later 'casted' to the appropriate type using methods such as `byteSliceAsInterval16Slice`. 

For functions such as`UnmarshalBinary` or `FromBase64`,  the `readFrom` function in `roaringArray` gets a `ByteInputAdapter` and its `Next` function returns fresh slices that are safe to mutate?  The code is like so...

```
// Next returns a slice containing the next n bytes from the buffer,
// advancing the buffer as if the bytes had been returned by Read.
func (b *ByteInputAdapter) Next(n int) ([]byte, error) {
	buf := make([]byte, n)
	_, err := b.Read(buf)

	if err != nil {
		return nil, err
	}
	return buf, nil
}
```

At least as a byte slice, this is usable as is and does not require copy-on-write.

That's for `ByteInputAdapter`, if you have a `ByteBuffer`, the result is different. The `Next` function returns a potentially immutable slice:

```
func (b *ByteBuffer) Next(n int) ([]byte, error) {
	m := len(b.buf) - b.off

	if n > m {
		return nil, io.ErrUnexpectedEOF
	}

	data := b.buf[b.off : b.off+n]
	b.off += n

	return data, nil
}
```

The `FromBuffer` and `FromUnsafeBytes` use that type (`ByteInputAdapter`) and so they clearly require copy-on-write.

So I am proposing that the `readFrom` function in `roaringArray` distinguishes between the two. I could just check the type of the provided generic `ByteInput` interface, but instead I added a new function `NextReturnsSafeSlice()` that tells me whether `Next()` returns a 'safe' slice (one that can always be mutated). The change is simple enough:

```
fnc (ra *roaringArray) readFrom(stream internal.ByteInput,...)

  willNeedCopyOnWrite := !stream.NextReturnsSafeSlice()

  ...
  ra.needCopyOnWrite[i] = willNeedCopyOnWrite
```




**Remark**. Annoyingly, this PR also introduces a bunch of formatting changes due to `go fmt` (go 1.20). I am not sure why this would be the case (do they change their formatting conventions all the time?), but, thankfully, the changes are easy to ignore. 

cc @maciej

Fixes: https://github.com/RoaringBitmap/roaring/issues/396
