### PR TITLE
roaring: implement ToDense and FromDense

### DIFF
--- a/roaring.go
+++ b/roaring.go
@@ -111,8 +111,8 @@ func (rb *Bitmap) WriteDenseTo(bitmap []uint64) {
 				hi := int(hb|(end-1)) >> log2WordSize
 
 				if lo == hi {
-					bitmap[lo] |= ^uint64(0) << uint(start%64) &
-						^uint64(0) >> (uint(-end) % 64)
+					bitmap[lo] |= (^uint64(0) << uint(start%64)) &
+						(^uint64(0) >> (uint(-end) % 64))
 					continue
 				}
 

--- a/roaring.go
+++ b/roaring.go
@@ -147,7 +147,7 @@ func (rb *Bitmap) FromDense(bitmap []uint64) {
 				}
 				base += 64
 			}
-			rb.highlowcontainer.appendContainer(k, c, cow)
+			rb.highlowcontainer.appendContainer(k, c, false)
 		}
 
 		bitmap = bitmap[size:]

--- a/roaring.go
+++ b/roaring.go
@@ -59,10 +59,15 @@ const capacity = ^uint64(0)
 
 // DenseSize returns the size of the bitmap when stored as a dense bitmap.
 func (rb *Bitmap) DenseSize() int {
+	if rb.highlowcontainer.size() == 0 {
+		return 0
+	}
+
 	maximum := 1 + uint64(rb.Maximum())
 	if maximum > (capacity - wordSize + 1) {
 		return int(capacity >> log2WordSize)
 	}
+
 	return int((maximum + (wordSize - 1)) >> log2WordSize)
 }
 

--- a/roaring.go
+++ b/roaring.go
@@ -75,11 +75,12 @@ func (rb *Bitmap) DenseSize() int {
 // Useful to convert a roaring bitmap to a format that can be used by other libraries
 // like https://github.com/bits-and-blooms/bitset or https://github.com/kelindar/bitmap
 func (rb *Bitmap) ToDense() []uint64 {
-	if rb.DenseSize() == 0 {
+	sz := rb.DenseSize()
+	if sz == 0 {
 		return nil
 	}
 
-	bitmap := make([]uint64, rb.DenseSize())
+	bitmap := make([]uint64, sz)
 	rb.WriteDenseTo(bitmap)
 	return bitmap
 }

--- a/roaring.go
+++ b/roaring.go
@@ -75,6 +75,10 @@ func (rb *Bitmap) DenseSize() int {
 // Useful to convert a roaring bitmap to a format that can be used by other libraries
 // like https://github.com/bits-and-blooms/bitset or https://github.com/kelindar/bitmap
 func (rb *Bitmap) ToDense() []uint64 {
+	if rb.DenseSize() == 0 {
+		return nil
+	}
+
 	bitmap := make([]uint64, rb.DenseSize())
 	rb.WriteDenseTo(bitmap)
 	return bitmap

--- a/roaring.go
+++ b/roaring.go
@@ -122,6 +122,8 @@ func (rb *Bitmap) WriteDenseTo(bitmap []uint64) {
 				}
 				bitmap[hi] |= ^uint64(0) >> (uint(-end) % 64)
 			}
+		default:
+			panic("unsupported container type")
 		}
 	}
 }

--- a/roaring_test.go
+++ b/roaring_test.go
@@ -2545,8 +2545,8 @@ func TestIterateHalt(t *testing.T) {
 
 func testDense(fn func(string, *Bitmap)) {
 	bc := New()
-	for i := 1; i <= arrayDefaultMaxSize+1; i++ {
-		bc.Add(uint32(MaxUint16 + i*2))
+	for i := 0; i <= arrayDefaultMaxSize; i++ {
+		bc.Add(uint32(1 + MaxUint16 + i*2))
 	}
 
 	rc := New()
@@ -2571,7 +2571,7 @@ func testDense(fn func(string, *Bitmap)) {
 		{"array", ac},
 		{"bitmaps-and-runs", brc},
 	} {
-		fn(tc.name, tc.rb)
+		fn(tc.name+"-"+strconv.FormatUint(tc.rb.GetCardinality(), 10), tc.rb)
 	}
 }
 func TestToDense(t *testing.T) {

--- a/roaring_test.go
+++ b/roaring_test.go
@@ -2550,6 +2550,7 @@ func testDense(fn func(string, *Bitmap)) {
 	}
 
 	rc := New()
+	rc.AddRange(1, 2)
 	rc.AddRange(bc.GetCardinality(), bc.GetCardinality()*2)
 
 	ac := New()

--- a/roaring_test.go
+++ b/roaring_test.go
@@ -2589,14 +2589,12 @@ func TestToDense(t *testing.T) {
 func BenchmarkWriteDenseTo(b *testing.B) {
 	testDense(func(name string, rb *Bitmap) {
 		b.Run(name, func(b *testing.B) {
-			zeros := make([]uint64, rb.DenseSize())
 			dense := make([]uint64, rb.DenseSize())
 			b.ReportAllocs()
 			b.SetBytes(int64(len(dense) * 8))
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				rb.WriteDenseTo(dense)
-				copy(dense, zeros)
 			}
 		})
 	})


### PR DESCRIPTION
This commit introduces ToDense and FromDense as methods in Bitmap. They make conversion to and from dense bitmaps like https://github.com/bits-and-blooms/bitset or https://github.com/kelindar/bitmap performant and simple.

```
name                                     time/op
FromDense/bitmap-4097-10                   1.62µs ± 0%
FromDense/run-4098-10                      1.25µs ± 0%
FromDense/array-4096-10                    1.60µs ± 0%
FromDense/bitmaps-and-runs-300000-10       3.76µs ± 0%
WriteDenseTo/bitmap-4097-10                17.1ns ± 0%
WriteDenseTo/run-4098-10                   31.2ns ± 0%
WriteDenseTo/array-4096-10                 8.69µs ± 0%
WriteDenseTo/bitmaps-and-runs-300000-10    1.53µs ± 0%

name                                     speed
FromDense/bitmap-4097-10                 5.70GB/s ± 0%
FromDense/run-4098-10                     827MB/s ± 0%
FromDense/array-4096-10                  5.76GB/s ± 0%
FromDense/bitmaps-and-runs-300000-10     14.9GB/s ± 0%
WriteDenseTo/bitmap-4097-10               538GB/s ± 0%
WriteDenseTo/run-4098-10                 33.0GB/s ± 0%
WriteDenseTo/array-4096-10               1.06GB/s ± 0%
WriteDenseTo/bitmaps-and-runs-300000-10  36.7GB/s ± 0%

name                                     alloc/op
FromDense/bitmap-4097-10                   8.22kB ± 0%
FromDense/run-4098-10                      8.22kB ± 0%
FromDense/array-4096-10                    8.22kB ± 0%
FromDense/bitmaps-and-runs-300000-10       8.35kB ± 0%
WriteDenseTo/bitmap-4097-10                 0.00B     
WriteDenseTo/run-4098-10                    0.00B     
WriteDenseTo/array-4096-10                  0.00B     
WriteDenseTo/bitmaps-and-runs-300000-10     0.00B     

name                                     allocs/op
FromDense/bitmap-4097-10                     2.00 ± 0%
FromDense/run-4098-10                        2.00 ± 0%
FromDense/array-4096-10                      2.00 ± 0%
FromDense/bitmaps-and-runs-300000-10         6.00 ± 0%
WriteDenseTo/bitmap-4097-10                  0.00     
WriteDenseTo/run-4098-10                     0.00     
WriteDenseTo/array-4096-10                   0.00     
WriteDenseTo/bitmaps-and-runs-300000-10      0.00     

```