### PR TITLE
Check if Bitmap is empty in Contains

### DIFF
--- a/roaring.go
+++ b/roaring.go
@@ -819,6 +819,9 @@ func (rb *Bitmap) Maximum() uint32 {
 
 // Contains returns true if the integer is contained in the bitmap
 func (rb *Bitmap) Contains(x uint32) bool {
+	if rb.IsEmpty() {
+		return false
+	}
 	hb := highbits(x)
 	c := rb.highlowcontainer.getContainer(hb)
 	return c != nil && c.contains(lowbits(x))

--- a/roaring64/roaring64.go
+++ b/roaring64/roaring64.go
@@ -313,6 +313,9 @@ func (rb *Bitmap) Maximum() uint64 {
 
 // Contains returns true if the integer is contained in the bitmap
 func (rb *Bitmap) Contains(x uint64) bool {
+	if rb.IsEmpty() {
+		return false
+	}
 	hb := highbits(x)
 	c := rb.highlowcontainer.getContainer(hb)
 	return c != nil && c.Contains(lowbits(x))


### PR DESCRIPTION
I stumbled on this change in a call to Contains in a very tight loop. I believe Contains unnecessarily calls through to some relatively much more expensive contains on each of the container types when the empty state is readily available and avoids this cost for very little overhead.

I wasn't able to find a benchmark in roaring that demonstrated this advantage, however in my production system it shaved off a good 25% CPU.