### PR TITLE
improve performance of AndNot between array and run containers

### DIFF
--- a/arraycontainer.go
+++ b/arraycontainer.go
@@ -664,10 +664,25 @@ func (ac *arrayContainer) iandNot(a container) container {
 }
 
 func (ac *arrayContainer) iandNotRun16(rc *runContainer16) container {
-	rcb := rc.toBitmapContainer()
-	acb := ac.toBitmapContainer()
-	acb.iandNotBitmapSurely(rcb)
-	*ac = *(acb.toArrayContainer())
+	if len(ac.content) == 0 {
+		// Empty
+		return ac
+	}
+
+	for _, run := range rc.iv {
+		if run.start > ac.maximum() {
+			// Since the runs are sorted, we can stop here. (No subsequent runs will
+			// overlap with the array container.)
+			break
+		}
+		if run.last() < ac.minimum() {
+			// This run is entirely before the array container. We can skip it.
+			continue
+		}
+
+		out := ac.iremoveRange(int(run.start), int(run.start)+int(run.length)+1).(*arrayContainer)
+		*ac = *out
+	}
 	return ac
 }
 

--- a/arraycontainer_test.go
+++ b/arraycontainer_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestArrayContainerTransition(t *testing.T) {
@@ -330,6 +331,27 @@ func TestArrayContainerEtc070(t *testing.T) {
 	ac10.iadd(1)
 
 	assert.Equal(t, 1, ac10.numberOfRuns())
+}
+
+func TestArrayContainerIAndNot(t *testing.T) {
+	var ac container
+	ac = newArrayContainer()
+	ac.iadd(12)
+	ac.iadd(27)
+	ac.iadd(32)
+	ac.iadd(88)
+	ac.iadd(188)
+	ac.iadd(289)
+
+	var rc container
+	rc = newRunContainer16Range(0, 15)
+	rc = rc.iaddRange(1500, 2000)
+	rc = rc.iaddRange(55, 100)
+	rc = rc.iaddRange(25, 50)
+	ac = ac.iandNot(rc)
+
+	require.ElementsMatch(t, []uint16{188, 289}, ac.(*arrayContainer).content)
+	require.Equal(t, 2, ac.getCardinality())
 }
 
 func TestArrayContainerIand(t *testing.T) {

--- a/runcontainer.go
+++ b/runcontainer.go
@@ -47,6 +47,7 @@ import (
 // runContainer16 does run-length encoding of sets of
 // uint16 integers.
 type runContainer16 struct {
+	// iv is a slice of sorted, non-overlapping, non-adjacent intervals.
 	iv []interval16
 }
 


### PR DESCRIPTION
Improve the performance of in-place AndNot between array and run containers. The current approach converts both to bitmaps, performs the AndNot, and then returns the result. 

Instead, this approach scans the list of runs in the run container, and calls `iremoveRange` on each one in the array container. 

Before:
```
BenchmarkAndNot/inPlace=true/left=array/right=run-10        	  121395	     11533 ns/op
```

After:
```
BenchmarkAndNot/inPlace=true/left=array/right=run-10       	 1308555	      2369 ns/op
```