### PR TITLE
faster iandnot between bitmap containers and run containers

### DIFF
--- a/bitmapcontainer.go
+++ b/bitmapcontainer.go
@@ -904,7 +904,7 @@ func (bc *bitmapContainer) iandNotRun16(rc *runContainer16) container {
 	cardinalityChange := popcntSlice(bc.bitmap[wordRangeStart : wordRangeEnd+1]) // before cardinality - after cardinality (for word range)
 
 	for _, iv := range rc.iv {
-		resetBitmapRange(bc.bitmap, int(iv.start), int(iv.last()+1))
+		resetBitmapRange(bc.bitmap, int(iv.start), int(iv.last())+1)
 	}
 
 	cardinalityChange -= popcntSlice(bc.bitmap[wordRangeStart : wordRangeEnd+1])

--- a/bitmapcontainer.go
+++ b/bitmapcontainer.go
@@ -893,8 +893,28 @@ func (bc *bitmapContainer) iandNotArray(ac *arrayContainer) container {
 }
 
 func (bc *bitmapContainer) iandNotRun16(rc *runContainer16) container {
-	rcb := rc.toBitmapContainer()
-	return bc.iandNotBitmapSurely(rcb)
+	if rc.isEmpty() || bc.isEmpty() {
+		// Nothing to do.
+		return bc
+	}
+
+	wordRangeStart := rc.iv[0].start / 64
+	wordRangeEnd := (rc.iv[len(rc.iv)-1].last()) / 64 // inclusive
+
+	cardinalityChange := popcntSlice(bc.bitmap[wordRangeStart : wordRangeEnd+1]) // before cardinality - after cardinality (for word range)
+
+	for _, iv := range rc.iv {
+		resetBitmapRange(bc.bitmap, int(iv.start), int(iv.last()+1))
+	}
+
+	cardinalityChange -= popcntSlice(bc.bitmap[wordRangeStart : wordRangeEnd+1])
+
+	bc.cardinality -= int(cardinalityChange)
+
+	if bc.getCardinality() <= arrayDefaultMaxSize {
+		return bc.toArrayContainer()
+	}
+	return bc
 }
 
 func (bc *bitmapContainer) andNotArray(value2 *arrayContainer) container {

--- a/bitmapcontainer_test.go
+++ b/bitmapcontainer_test.go
@@ -1,6 +1,7 @@
 package roaring
 
 import (
+	"math"
 	"math/rand"
 	"testing"
 
@@ -313,12 +314,14 @@ func TestBitmapContainerIAndNot(t *testing.T) {
 	for i := 0; i < arrayDefaultMaxSize; i++ {
 		bc.iadd(uint16(i * 3))
 	}
+	bc.iadd(math.MaxUint16)
 
 	var rc container
 	rc = newRunContainer16Range(0, 1)
 	for i := 0; i < arrayDefaultMaxSize-3; i++ {
 		rc = rc.iaddRange(i*3, i*3+1)
 	}
+	rc.iaddRange(math.MaxUint16-3, math.MaxUint16+1)
 
 	bc = bc.iandNot(rc)
 

--- a/bitmapcontainer_test.go
+++ b/bitmapcontainer_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // bitmapContainer's numberOfRuns() function should be correct against the runContainer equivalent
@@ -304,4 +305,23 @@ func TestBitmapContainerResetTo(t *testing.T) {
 		assert.EqualValues(t, dirty.cardinality, run.getCardinality())
 		assert.True(t, dirty.toEfficientContainer().equals(run))
 	})
+}
+
+func TestBitmapContainerIAndNot(t *testing.T) {
+	var bc container
+	bc = newBitmapContainer()
+	for i := 0; i < arrayDefaultMaxSize; i++ {
+		bc.iadd(uint16(i * 3))
+	}
+
+	var rc container
+	rc = newRunContainer16Range(0, 1)
+	for i := 0; i < arrayDefaultMaxSize-3; i++ {
+		rc = rc.iaddRange(i*3, i*3+1)
+	}
+
+	bc = bc.iandNot(rc)
+
+	require.ElementsMatch(t, []uint16{12279, 12282, 12285}, bc.(*arrayContainer).content)
+	require.Equal(t, 3, bc.getCardinality())
 }


### PR DESCRIPTION
Rather than converting a run container to a bitmap container and then performing iandnot, call removeRange directly. 

```
name                                          old time/op  new time/op  delta
AndNot/inPlace=true/left=bitmap/right=run-10  6.71µs ±32%  3.08µs ±45%  -54.05%  (p=0.000 n=20+17)
```