### PR TITLE
fix: make RunOptimize idempotent

### DIFF
--- a/arraycontainer.go
+++ b/arraycontainer.go
@@ -1233,7 +1233,7 @@ func (ac *arrayContainer) toEfficientContainer() container {
 	card := ac.getCardinality()
 	sizeAsArrayContainer := arrayContainerSizeInBytes(card)
 
-	if sizeAsRunContainer <= minOfInt(sizeAsBitmapContainer, sizeAsArrayContainer) {
+	if sizeAsRunContainer < minOfInt(sizeAsBitmapContainer, sizeAsArrayContainer) {
 		return newRunContainer16FromArray(ac)
 	}
 	if card <= arrayDefaultMaxSize {

--- a/bitmapcontainer.go
+++ b/bitmapcontainer.go
@@ -1187,7 +1187,7 @@ func (bc *bitmapContainer) toEfficientContainer() container {
 	card := bc.getCardinality()
 	sizeAsArrayContainer := arrayContainerSizeInBytes(card)
 
-	if sizeAsRunContainer <= minOfInt(sizeAsBitmapContainer, sizeAsArrayContainer) {
+	if sizeAsRunContainer < minOfInt(sizeAsBitmapContainer, sizeAsArrayContainer) {
 		return newRunContainer16FromBitmapContainer(bc)
 	}
 	if card <= arrayDefaultMaxSize {

--- a/roaring_test.go
+++ b/roaring_test.go
@@ -13,6 +13,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestIssue440(t *testing.T) {
+	a := NewBitmap()
+	a.AddMany([]uint32{1, 2, 3})
+	a.RunOptimize()
+	b1, err := a.MarshalBinary()
+	require.NoError(t, err)
+	a.RunOptimize()
+	b2, err := a.MarshalBinary()
+	require.NoError(t, err)
+	require.Equal(t, b1, b2)
+}
+
 func checkValidity(t *testing.T, rb *Bitmap) {
 	t.Helper()
 


### PR DESCRIPTION
We should only use run containers if they are strictly smaller. Currently, when a container was just as concise using an array and a runcontainer, we would go back and forth with each optimization pass.

fixes https://github.com/RoaringBitmap/roaring/issues/440