### PR TITLE
removing roaring64.FromUnsafeBytes

### DIFF
--- a/roaring64/serialization_test.go
+++ b/roaring64/serialization_test.go
@@ -25,7 +25,6 @@ func TestSerializationOfEmptyBitmap(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.EqualValues(t, buf.Len(), rb.GetSerializedSizeInBytes())
-	data := buf.Bytes()
 
 	newrb := NewBitmap()
 	_, err = newrb.ReadFrom(buf)
@@ -56,7 +55,6 @@ func TestSerializationBasic037(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.EqualValues(t, buf.Len(), rb.GetSerializedSizeInBytes())
-	data := buf.Bytes()
 
 	newrb := NewBitmap()
 	_, err = newrb.ReadFrom(buf)
@@ -112,7 +110,6 @@ func TestSerializationBasic2_041(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, l, buf.Len())
-	data := buf.Bytes()
 
 	newrb := NewBitmap()
 	_, err = newrb.ReadFrom(buf)
@@ -133,7 +130,6 @@ func TestSerializationBasic3_042(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.EqualValues(t, buf.Len(), int(rb.GetSerializedSizeInBytes()))
-	data := buf.Bytes()
 
 	newrb := NewBitmap()
 	_, err = newrb.ReadFrom(&buf)

--- a/roaring64/serialization_test.go
+++ b/roaring64/serialization_test.go
@@ -207,14 +207,6 @@ func TestHoldReference(t *testing.T) {
 	})
 }
 
-func BenchmarkUnserializeFromUnsafeBytes(b *testing.B) {
-	benchmarkUnserializeFunc(b, "FromUnsafeBytes", func(bitmap *Bitmap, data []byte) (int64, error) {
-		copied := make([]byte, len(data))
-		copy(copied, data)
-		return bitmap.FromUnsafeBytes(copied)
-	})
-}
-
 func BenchmarkUnserializeReadFrom(b *testing.B) {
 	benchmarkUnserializeFunc(b, "ReadFrom", func(bitmap *Bitmap, data []byte) (int64, error) {
 		return bitmap.ReadFrom(bytes.NewReader(data))

--- a/roaring64/serialization_test.go
+++ b/roaring64/serialization_test.go
@@ -32,11 +32,6 @@ func TestSerializationOfEmptyBitmap(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.True(t, rb.Equals(newrb))
-
-	newrb2 := NewBitmap()
-	_, err = newrb2.FromUnsafeBytes(data)
-	require.NoError(t, err)
-	assert.True(t, rb.Equals(newrb2))
 }
 
 func TestBase64_036(t *testing.T) {
@@ -68,11 +63,6 @@ func TestSerializationBasic037(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.True(t, rb.Equals(newrb))
-
-	newrb2 := NewBitmap()
-	_, err = newrb2.FromUnsafeBytes(data)
-	require.NoError(t, err)
-	assert.True(t, rb.Equals(newrb2))
 }
 
 func TestSerializationToFile038(t *testing.T) {
@@ -111,11 +101,6 @@ func TestSerializationToFile038(t *testing.T) {
 
 	_, _ = newrb.ReadFrom(teer)
 	assert.True(t, rb.Equals(newrb))
-
-	newrb2 := NewBitmap()
-	_, err = newrb2.FromUnsafeBytes(buf.Bytes())
-	require.NoError(t, err)
-	assert.True(t, rb.Equals(newrb2))
 }
 
 func TestSerializationBasic2_041(t *testing.T) {
@@ -134,11 +119,6 @@ func TestSerializationBasic2_041(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.True(t, rb.Equals(newrb))
-
-	newrb2 := NewBitmap()
-	_, err = newrb2.FromUnsafeBytes(data)
-	require.NoError(t, err)
-	assert.True(t, rb.Equals(newrb2))
 }
 
 // roaringarray.writeTo and .readFrom should serialize and unserialize when containing all 3 container types
@@ -160,11 +140,6 @@ func TestSerializationBasic3_042(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.True(t, newrb.Equals(rb))
-
-	newrb2 := NewBitmap()
-	_, err = newrb2.FromUnsafeBytes(data)
-	require.NoError(t, err)
-	assert.True(t, rb.Equals(newrb2))
 }
 
 func TestHoldReference(t *testing.T) {


### PR DESCRIPTION
Removing roaring64.FromUnsafeBytes, this function was never tested. It is likely unsafe.

Note that this is not to be confused with the regular FromUnsafeBytes.