### PR TITLE
BSI library expanded to include support for large arbitrary values via the big.Int library

### DIFF
--- a/.github/workflows/bigendiantests.yml
+++ b/.github/workflows/bigendiantests.yml
@@ -7,7 +7,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.14.x]
+        go-version: [1.17.x]
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/legacytests.yml
+++ b/.github/workflows/legacytests.yml
@@ -7,7 +7,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.14.x]
+        go-version: [1.17.x]
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/RoaringBitmap/roaring/v2
 
-go 1.22
+go 1.15
 
 require (
 	github.com/bits-and-blooms/bitset v1.12.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/RoaringBitmap/roaring/v2
 
-go 1.22.0
+go 1.22
 
 toolchain go1.23.2
 

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,18 @@
 module github.com/RoaringBitmap/roaring/v2
 
-go 1.14
+go 1.22.0
+
+toolchain go1.23.2
 
 require (
 	github.com/bits-and-blooms/bitset v1.12.0
-	github.com/google/uuid v1.6.0 // indirect
+	github.com/google/uuid v1.6.0
 	github.com/mschoch/smat v0.2.0
 	github.com/stretchr/testify v1.7.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.14
 
 require (
 	github.com/bits-and-blooms/bitset v1.12.0
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/mschoch/smat v0.2.0
 	github.com/stretchr/testify v1.7.0
 )

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/RoaringBitmap/roaring/v2
 
 go 1.22
 
-toolchain go1.23.2
-
 require (
 	github.com/bits-and-blooms/bitset v1.12.0
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/bits-and-blooms/bitset v1.12.0 h1:U/q1fAF7xXRhFCrhROzIfffYnu+dlS38vCZ
 github.com/bits-and-blooms/bitset v1.12.0/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/mschoch/smat v0.2.0 h1:8imxQsjDm8yFEAVBe7azKmKSgzSkZXDuKkSq9374khM=
 github.com/mschoch/smat v0.2.0/go.mod h1:kc9mz7DoBKqDyiRL7VZN8KvXQMWeTaVnttLRXOlotKw=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/roaring64/bsi64.go
+++ b/roaring64/bsi64.go
@@ -8,13 +8,6 @@ import (
 	"sync"
 )
 
-const (
-	// Min64BitSigned - Minimum 64 bit value
-	Min64BitSigned = -9223372036854775808
-	// Max64BitSigned - Maximum 64 bit value
-	Max64BitSigned = 9223372036854775807
-)
-
 // BSI is at its simplest is an array of bitmaps that represent an encoded
 // binary value.  The advantage of a BSI is that comparisons can be made
 // across ranges of values whereas a bitmap can only represent the existence
@@ -109,20 +102,13 @@ func (b *BSI) SetBigValue(columnID uint64, value *big.Int) {
 		}
 	}
 
-//fmt.Printf(" text = %v\n", value.Text(2))
-//fmt.Printf("value = %b\n      ->", value.Int64())
-//fmt.Println("->")
-	//for i := 0; i < b.BitCount(); i++ {
 	for i := b.BitCount(); i >= 0; i-- {
 		if value.Bit(i) == 0 {
-//fmt.Print("0")
 			b.bA[i].Remove(columnID)
 		} else {
-//fmt.Print("1")
 			b.bA[i].Add(columnID)
 		}
 	}
-//fmt.Println()
 	b.eBM.Add(columnID)
 }
 
@@ -137,7 +123,6 @@ func (b *BSI) GetValue(columnID uint64) (value int64, exists bool) {
 	if !exists {
 		return
 	}
-/*
 	if !bv.IsInt64() {
 		if bv.Sign() == -1 {
 			msg := fmt.Errorf("can't represent a negative %d bit value as an int64", b.BitCount())
@@ -148,24 +133,7 @@ func (b *BSI) GetValue(columnID uint64) (value int64, exists bool) {
 			panic(msg)
 		}
 	}
-*/
 	return bv.Int64(), exists
-}
-
-func (b *BSI) DumpBits(columnID uint64) {
-	exists := b.eBM.Contains(columnID)
-	if !exists {
-		return
-	}
-	fmt.Printf("BITS[")
-	for i := b.BitCount(); i >= 0; i-- {
-		if b.bA[i].Contains(columnID) {
-			fmt.Print("1")
-		} else {
-			fmt.Print("0")
-		}
-	}
-	fmt.Println("]")
 }
 
 // GetBigValue gets the value at the column ID. Second param will be false for non-existent values.
@@ -175,18 +143,13 @@ func (b *BSI) GetBigValue(columnID uint64) (value *big.Int, exists bool) {
 		return
 	}
 	val := big.NewInt(0)
-//fmt.Printf("LEN ARRAY = %d\n", len(b.bA))
-//fmt.Printf("ISNEG = %v\n", b.IsNegative(columnID))
-//fmt.Printf("GETVAL ->")
 	for i := b.BitCount(); i >= 0; i-- {
 		if b.bA[i].Contains(columnID) {
 			bigBit := big.NewInt(1)
 			bigBit.Lsh(bigBit, uint(i))
 			val.Or(val, bigBit)
-//fmt.Printf("[%s]1 ", bigBit.Text(2))
 		}
 	}
-//fmt.Println()
 
 	if b.IsNegative(columnID) {
 		val = negativeTwosComplementToInt(val)

--- a/roaring64/bsi64.go
+++ b/roaring64/bsi64.go
@@ -3,10 +3,9 @@ package roaring64
 import (
 	"fmt"
 	"io"
-	"math/bits"
+	"math/big"
 	"runtime"
 	"sync"
-	"sync/atomic"
 )
 
 const (
@@ -37,9 +36,11 @@ type BSI struct {
 // work correctly if the min/max values are not set correctly.
 func NewBSI(maxValue int64, minValue int64) *BSI {
 
-	bitsz := bits.Len64(uint64(minValue))
-	if bits.Len64(uint64(maxValue)) > bitsz {
-		bitsz = bits.Len64(uint64(maxValue))
+	bitszmin := big.NewInt(minValue).BitLen() + 1
+	bitszmax := big.NewInt(maxValue).BitLen() + 1
+	bitsz := bitszmin
+	if bitszmax > bitsz {
+		bitsz = bitszmax
 	}
 	ba := make([]Bitmap, bitsz)
 	return &BSI{bA: ba, MaxValue: maxValue, MinValue: minValue}
@@ -82,41 +83,124 @@ func (b *BSI) GetCardinality() uint64 {
 
 // BitCount returns the number of bits needed to represent values.
 func (b *BSI) BitCount() int {
-	return len(b.bA)
+	return len(b.bA) - 1  // Exclude sign bit
 }
 
-// SetValue sets a value for a given columnID.
-func (b *BSI) SetValue(columnID uint64, value int64) {
+// IsBigUInt returns the number of bits needed to represent values.
+func (b *BSI) isBig() bool {
+	return len(b.bA) > 64
+}
+
+// IsNegative returns true for negative values
+func (b *BSI) IsNegative(columnID uint64) bool {
+	if len(b.bA) == 0 {
+		return false
+	}
+	return b.bA[b.BitCount()].Contains(columnID)
+}
+
+// SetBigValue sets a value that exceeds 64 bits
+func (b *BSI) SetBigValue(columnID uint64, value *big.Int) {
 	// If max/min values are set to zero then automatically determine bit array size
 	if b.MaxValue == 0 && b.MinValue == 0 {
-		minBits := bits.Len64(uint64(value))
+		minBits := value.BitLen() + 1
 		for len(b.bA) < minBits {
 			b.bA = append(b.bA, Bitmap{})
 		}
 	}
 
-	for i := 0; i < b.BitCount(); i++ {
-		if uint64(value)&(1<<uint64(i)) > 0 {
-			b.bA[i].Add(columnID)
-		} else {
+//fmt.Printf(" text = %v\n", value.Text(2))
+//fmt.Printf("value = %b\n      ->", value.Int64())
+//fmt.Println("->")
+	//for i := 0; i < b.BitCount(); i++ {
+	for i := b.BitCount(); i >= 0; i-- {
+		if value.Bit(i) == 0 {
+//fmt.Print("0")
 			b.bA[i].Remove(columnID)
+		} else {
+//fmt.Print("1")
+			b.bA[i].Add(columnID)
 		}
 	}
+//fmt.Println()
 	b.eBM.Add(columnID)
+}
+
+// SetValue sets a value for a given columnID.
+func (b *BSI) SetValue(columnID uint64, value int64) {
+	b.SetBigValue(columnID, big.NewInt(value))
 }
 
 // GetValue gets the value at the column ID. Second param will be false for non-existent values.
 func (b *BSI) GetValue(columnID uint64) (value int64, exists bool) {
+	bv, exists := b.GetBigValue(columnID)
+	if !exists {
+		return
+	}
+/*
+	if !bv.IsInt64() {
+		if bv.Sign() == -1 {
+			msg := fmt.Errorf("can't represent a negative %d bit value as an int64", b.BitCount())
+			panic(msg)
+		}
+		if bv.Sign() == 1 {
+			msg := fmt.Errorf("can't represent a positive %d bit value as an int64", b.BitCount())
+			panic(msg)
+		}
+	}
+*/
+	return bv.Int64(), exists
+}
+
+func (b *BSI) DumpBits(columnID uint64) {
+	exists := b.eBM.Contains(columnID)
+	if !exists {
+		return
+	}
+	fmt.Printf("BITS[")
+	for i := b.BitCount(); i >= 0; i-- {
+		if b.bA[i].Contains(columnID) {
+			fmt.Print("1")
+		} else {
+			fmt.Print("0")
+		}
+	}
+	fmt.Println("]")
+}
+
+// GetBigValue gets the value at the column ID. Second param will be false for non-existent values.
+func (b *BSI) GetBigValue(columnID uint64) (value *big.Int, exists bool) {
 	exists = b.eBM.Contains(columnID)
 	if !exists {
 		return
 	}
-	for i := 0; i < b.BitCount(); i++ {
+	val := big.NewInt(0)
+//fmt.Printf("LEN ARRAY = %d\n", len(b.bA))
+//fmt.Printf("ISNEG = %v\n", b.IsNegative(columnID))
+//fmt.Printf("GETVAL ->")
+	for i := b.BitCount(); i >= 0; i-- {
 		if b.bA[i].Contains(columnID) {
-			value |= 1 << i
+			bigBit := big.NewInt(1)
+			bigBit.Lsh(bigBit, uint(i))
+			val.Or(val, bigBit)
+//fmt.Printf("[%s]1 ", bigBit.Text(2))
 		}
 	}
-	return
+//fmt.Println()
+
+	if b.IsNegative(columnID) {
+		val = negativeTwosComplementToInt(val)
+	}
+	return val, exists
+}
+
+func negativeTwosComplementToInt(val *big.Int) *big.Int {
+	inverted := new(big.Int).Not(val)
+	mask := new(big.Int).Lsh(big.NewInt(1), uint(val.BitLen()))
+	inverted.And(inverted, mask.Sub(mask, big.NewInt(1)))
+	inverted.Add(inverted, big.NewInt(1))
+	val.Neg(inverted)
+	return val
 }
 
 type action func(t *task, batch []uint64, resultsChan chan *Bitmap, wg *sync.WaitGroup)
@@ -236,8 +320,8 @@ const (
 type task struct {
 	bsi          *BSI
 	op           Operation
-	valueOrStart int64
-	end          int64
+	valueOrStart *big.Int
+	end          *big.Int
 	values       map[int64]struct{}
 	bits         *Bitmap
 }
@@ -252,11 +336,85 @@ type task struct {
 func (b *BSI) CompareValue(parallelism int, op Operation, valueOrStart, end int64,
 	foundSet *Bitmap) *Bitmap {
 
+	return b.CompareBigValue(parallelism, op, big.NewInt(valueOrStart), big.NewInt(end), foundSet)
+}
+
+
+// CompareBigValue compares value.
+// Values should be in the range of the BSI (max, min).  If the value is outside the range, the result
+// might erroneous.  The operation parameter indicates the type of comparison to be made.
+// For all operations with the exception of RANGE, the value to be compared is specified by valueOrStart.
+// For the RANGE parameter the comparison criteria is >= valueOrStart and <= end.
+// The parallelism parameter indicates the number of CPU threads to be applied for processing.  A value
+// of zero indicates that all available CPU resources will be potentially utilized.
+func (b *BSI) CompareBigValue(parallelism int, op Operation, valueOrStart, end *big.Int,
+	foundSet *Bitmap) *Bitmap {
+
 	comp := &task{bsi: b, op: op, valueOrStart: valueOrStart, end: end}
 	if foundSet == nil {
 		return parallelExecutor(parallelism, comp, compareValue, &b.eBM)
 	}
 	return parallelExecutor(parallelism, comp, compareValue, foundSet)
+}
+
+/*
+func twosComplement(val *big.Int, bits int) *big.Int {
+	if val.Sign() != -1 {
+		return val
+	}
+	inverted := new(big.Int).Not(val)
+    mask := new(big.Int).Lsh(big.NewInt(1), uint(val.BitLen() + 1))
+    inverted.And(val, mask.Sub(mask, big.NewInt(1)))
+	val.Set(inverted)
+	return val
+}
+*/
+
+// Returns a twos complement value given a value, the return will be bit extended to 'bits' length
+// if the value is negative
+func twosComplement(num *big.Int, bitCount int) *big.Int {
+    // Check if the number is negative
+    isNegative := num.Sign() < 0
+
+    // Get the absolute value if negative
+    abs := new(big.Int).Abs(num)
+
+    // Convert to binary string
+    binStr := abs.Text(2)
+
+    // Pad with zeros to the left
+    if len(binStr) < bitCount {
+        binStr = fmt.Sprintf("%0*s", bitCount, binStr)
+    }
+
+    // If negative, calculate two's complement
+    if isNegative {
+        // Invert bits
+        inverted := make([]byte, len(binStr))
+        for i := range binStr {
+            if binStr[i] == '0' {
+                inverted[i] = '1'
+            } else {
+                inverted[i] = '0'
+            }
+        }
+
+        // Add 1
+        carry := byte(1)
+        for i := len(inverted) - 1; i >= 0; i-- {
+            inverted[i] += carry
+            if inverted[i] == '2' {
+                inverted[i] = '0'
+            } else {
+                break
+            }
+        }
+        binStr = string(inverted)
+    }
+
+    bigInt := new(big.Int)
+    _, _ = bigInt.SetString(binStr, 2)
+    return bigInt
 }
 
 func compareValue(e *task, batch []uint64, resultsChan chan *Bitmap, wg *sync.WaitGroup) {
@@ -268,32 +426,28 @@ func compareValue(e *task, batch []uint64, resultsChan chan *Bitmap, wg *sync.Wa
 		results.RunOptimize()
 	}
 
-	x := e.bsi.BitCount()
-	startIsNegative := x == 64 && uint64(e.valueOrStart)&(1<<uint64(x-1)) > 0
-	endIsNegative := x == 64 && uint64(e.end)&(1<<uint64(x-1)) > 0
-
+	startIsNegative := e.valueOrStart.Sign() == -1
+	endIsNegative := e.end.Sign() == -1
+	
 	for i := 0; i < len(batch); i++ {
 		cID := batch[i]
 		eq1, eq2 := true, true
 		lt1, lt2, gt1 := false, false, false
-		j := e.bsi.BitCount() - 1
-		isNegative := false
-		if x == 64 {
-			isNegative = e.bsi.bA[j].Contains(cID)
-			j--
-		}
+		j := e.bsi.BitCount()
+		isNegative := e.bsi.IsNegative(cID)
 		compStartValue := e.valueOrStart
 		compEndValue := e.end
 		if isNegative != startIsNegative {
-			compStartValue = ^e.valueOrStart + 1
+			compStartValue = twosComplement(e.valueOrStart, e.bsi.BitCount() + 1)
 		}
 		if isNegative != endIsNegative {
-			compEndValue = ^e.end + 1
+			compEndValue = twosComplement(e.end, e.bsi.BitCount() + 1)
 		}
+
 		for ; j >= 0; j-- {
 			sliceContainsBit := e.bsi.bA[j].Contains(cID)
 
-			if uint64(compStartValue)&(1<<uint64(j)) > 0 {
+			if compStartValue.Bit(j) == 1 {
 				// BIT in value is SET
 				if !sliceContainsBit {
 					if eq1 {
@@ -306,9 +460,11 @@ func compareValue(e *task, batch []uint64, resultsChan chan *Bitmap, wg *sync.Wa
 							}
 						}
 						eq1 = false
-						break
+						if e.op != RANGE {
+							break
+						}
 					}
-				}
+				} 
 			} else {
 				// BIT in value is CLEAR
 				if sliceContainsBit {
@@ -322,6 +478,7 @@ func compareValue(e *task, batch []uint64, resultsChan chan *Bitmap, wg *sync.Wa
 							}
 						}
 						eq1 = false
+
 						if e.op != RANGE {
 							break
 						}
@@ -329,7 +486,7 @@ func compareValue(e *task, batch []uint64, resultsChan chan *Bitmap, wg *sync.Wa
 				}
 			}
 
-			if e.op == RANGE && uint64(compEndValue)&(1<<uint64(j)) > 0 {
+			if e.op == RANGE && compEndValue.Bit(j) == 1 {
 				// BIT in value is SET
 				if !sliceContainsBit {
 					if eq2 {
@@ -350,12 +507,11 @@ func compareValue(e *task, batch []uint64, resultsChan chan *Bitmap, wg *sync.Wa
 							lt2 = true
 						}
 						eq2 = false
-						break
 					}
 				}
 			}
+		} 
 
-		}
 
 		switch e.op {
 		case LT:
@@ -390,15 +546,20 @@ func compareValue(e *task, batch []uint64, resultsChan chan *Bitmap, wg *sync.Wa
 	resultsChan <- results
 }
 
-// MinMax - Find minimum or maximum value.
+// MinMax - Find minimum or maximum int64 value.
 func (b *BSI) MinMax(parallelism int, op Operation, foundSet *Bitmap) int64 {
+	return b.MinMaxBig(parallelism, op, foundSet).Int64()
+}
+
+// MinMaxBig - Find minimum or maximum value.
+func (b *BSI) MinMaxBig(parallelism int, op Operation, foundSet *Bitmap) *big.Int {
 
 	var n int = parallelism
 	if n == 0 {
 		n = runtime.NumCPU()
 	}
 
-	resultsChan := make(chan int64, n)
+	resultsChan := make(chan *big.Int, n)
 
 	card := foundSet.GetCardinality()
 	x := card / uint64(n)
@@ -421,63 +582,89 @@ func (b *BSI) MinMax(parallelism int, op Operation, foundSet *Bitmap) int64 {
 	wg.Wait()
 
 	close(resultsChan)
-	var minMax int64
+	var minMax *big.Int
+	minSigned, maxSigned := minMaxSignedInt(b.BitCount() + 1)
 	if op == MAX {
-		minMax = Min64BitSigned
+		minMax = minSigned
 	} else {
-		minMax = Max64BitSigned
+		minMax = maxSigned
 	}
 
 	for val := range resultsChan {
-		if (op == MAX && val > minMax) || (op == MIN && val <= minMax) {
+		//if (op == MAX && val > minMax) || (op == MIN && val <= minMax) {
+		if (op == MAX && val.Cmp(minMax) > 0) || (op == MIN && val.Cmp(minMax) <= 0) {
+//fmt.Printf("VAL = %s > %s = %d\n", val.Text(10), minMax.Text(10), val.Cmp(minMax))
 			minMax = val
 		}
 	}
 	return minMax
 }
 
-func (b *BSI) minOrMax(op Operation, batch []uint64, resultsChan chan int64, wg *sync.WaitGroup) {
+func minMaxSignedInt(bits int) (*big.Int, *big.Int) {
+    // Calculate the maximum value
+    max := new(big.Int).Lsh(big.NewInt(1), uint(bits-1))
+    max.Sub(max, big.NewInt(1))
+
+    // Calculate the minimum value
+    min := new(big.Int).Neg(max)
+    min.Sub(min, big.NewInt(1))
+
+    return min, max
+}
+
+func (b *BSI) minOrMax(op Operation, batch []uint64, resultsChan chan *big.Int, wg *sync.WaitGroup) {
 
 	defer wg.Done()
 
-	x := b.BitCount()
-	var value int64 = Max64BitSigned
+	x := b.BitCount() + 1
+	var value *big.Int
+	minSigned, maxSigned := minMaxSignedInt(x)
 	if op == MAX {
-		value = Min64BitSigned
+		value = minSigned
+	} else {
+		value = maxSigned
 	}
 
 	for i := 0; i < len(batch); i++ {
 		cID := batch[i]
 		eq := true
 		lt, gt := false, false
-		j := b.BitCount() - 1
-		var cVal int64
-		valueIsNegative := uint64(value)&(1<<uint64(x-1)) > 0 && bits.Len64(uint64(value)) == 64
-		isNegative := false
-		if x == 64 {
-			isNegative = b.bA[j].Contains(cID)
-			if isNegative {
-				cVal |= 1 << uint64(j)
-			}
-			j--
-		}
+		j := b.BitCount()
+		cVal := new(big.Int)
+		valueIsNegative := value.Sign() == -1
+		isNegative := b.IsNegative(cID)
+
 		compValue := value
 		if isNegative != valueIsNegative {
-			compValue = ^value + 1
+			// convert compValue to twos complement
+			inverted := new(big.Int).Not(compValue)
+	       	mask := new(big.Int).Lsh(big.NewInt(1), uint(compValue.BitLen()))
+	        inverted.And(inverted, mask.Sub(mask, big.NewInt(1)))
+			inverted.Add(inverted, big.NewInt(1))
 		}
+
+		done := false
 		for ; j >= 0; j-- {
 			sliceContainsBit := b.bA[j].Contains(cID)
 			if sliceContainsBit {
-				cVal |= 1 << uint64(j)
+           		bigBit := big.NewInt(1)
+           		bigBit.Lsh(bigBit, uint(j))
+           		cVal.Or(cVal, bigBit)
+				if isNegative {
+					cVal = negativeTwosComplementToInt(cVal)
+				}
 			}
-			if uint64(compValue)&(1<<uint64(j)) > 0 {
+			if done {
+				continue
+			}
+			if compValue.Bit(j) == 1 {
 				// BIT in value is SET
 				if !sliceContainsBit {
 					if eq {
 						eq = false
 						if op == MAX && valueIsNegative && !isNegative {
 							gt = true
-							break
+							done = true
 						}
 						if op == MIN && (!valueIsNegative || (valueIsNegative == isNegative)) {
 							lt = true
@@ -494,11 +681,13 @@ func (b *BSI) minOrMax(op Operation, batch []uint64, resultsChan chan int64, wg 
 						}
 						if op == MAX && (valueIsNegative || (valueIsNegative == isNegative)) {
 							gt = true
+							done = true
 						}
 					}
 				}
 			}
 		}
+
 		if lt || gt {
 			value = cVal
 		}
@@ -509,19 +698,36 @@ func (b *BSI) minOrMax(op Operation, batch []uint64, resultsChan chan int64, wg 
 
 // Sum all values contained within the foundSet.   As a convenience, the cardinality of the foundSet
 // is also returned (for calculating the average).
-func (b *BSI) Sum(foundSet *Bitmap) (sum int64, count uint64) {
+func (b *BSI) Sum(foundSet *Bitmap) (int64, uint64) {
+	val, count := b.SumBigValues(foundSet)
+	return val.Int64(), count
+}
 
+
+// SumBigValues - Sum all values contained within the foundSet.   As a convenience, the cardinality of the foundSet
+// is also returned (for calculating the average).   This method will sum arbitrarily large values.
+func (b *BSI) SumBigValues(foundSet *Bitmap) (sum *big.Int, count uint64) {
+
+	sum = new(big.Int)
 	count = foundSet.GetCardinality()
+	resultsChan := make(chan int64, b.BitCount())
 	var wg sync.WaitGroup
 	for i := 0; i < b.BitCount(); i++ {
 		wg.Add(1)
 		go func(j int) {
 			defer wg.Done()
-			atomic.AddInt64(&sum, int64(foundSet.AndCardinality(&b.bA[j])<<uint(j)))
+			resultsChan <- int64(foundSet.AndCardinality(&b.bA[j])<<uint(j))
 		}(i)
 	}
 	wg.Wait()
-	return
+	close(resultsChan)
+
+	for val := range resultsChan {
+		sum.Add(sum, big.NewInt(val))
+	}
+	sum.Sub(sum, big.NewInt(int64(foundSet.AndCardinality(&b.bA[b.BitCount()])<<uint(b.BitCount()))))
+	
+	return sum, count
 }
 
 // Transpose calls b.IntersectAndTranspose(0, b.eBM)
@@ -789,8 +995,8 @@ func (b *BSI) ClearValues(foundSet *Bitmap) {
 // NewBSIRetainSet - Construct a new BSI from a clone of existing BSI, retain only values contained in foundSet
 func (b *BSI) NewBSIRetainSet(foundSet *Bitmap) *BSI {
 
-	newBSI := NewBSI(b.MaxValue, b.MinValue)
-	newBSI.bA = make([]Bitmap, b.BitCount())
+	newBSI := NewDefaultBSI()
+	newBSI.bA = make([]Bitmap, b.BitCount() + 1)
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
@@ -826,13 +1032,13 @@ func (b *BSI) Add(other *BSI) {
 
 func (b *BSI) addDigit(foundSet *Bitmap, i int) {
 
-	if i >= len(b.bA) {
+	if i >= b.BitCount() + 1 || b.BitCount() == 0 {
 		b.bA = append(b.bA, Bitmap{})
 	}
 	carry := And(&b.bA[i], foundSet)
 	b.bA[i].Xor(foundSet)
 	if !carry.IsEmpty() {
-		if i+1 >= len(b.bA) {
+		if i+1 >= b.BitCount() {
 			b.bA = append(b.bA, Bitmap{})
 		}
 		b.addDigit(carry, i+1)

--- a/roaring64/bsi64_test.go
+++ b/roaring64/bsi64_test.go
@@ -45,12 +45,12 @@ func TestSetAndGetBigValue(t *testing.T) {
 	bigUUID := big.NewInt(-578664753978847603) // Upper bits
 	bigUUID.Lsh(bigUUID, 64)
 	lowBits := big.NewInt(-5190910309365112881) // Lower bits
-	bigUUID.Add(bigUUID, lowBits) // Lower bits
+	bigUUID.Add(bigUUID, lowBits)               // Lower bits
 
 	bsi.SetBigValue(1, bigUUID)
 	assert.Equal(t, bigUUID.BitLen(), bsi.BitCount())
 	bv, _ := bsi.GetBigValue(1)
-	assert.Equal(t,  bigUUID, bv)
+	assert.Equal(t, bigUUID, bv)
 
 	// Any code past this point will expect a panic error.  This will happen if a large value was set
 	// with SetBigValue() followed by a call to GetValue() where the set value exceeds 64 bits.
@@ -59,7 +59,7 @@ func TestSetAndGetBigValue(t *testing.T) {
 			t.Errorf("The code did not panic")
 		}
 	}()
-	bsi.GetValue(1)  // this should panic.  If so the test will pass.
+	bsi.GetValue(1) // this should panic.  If so the test will pass.
 }
 
 func TestSetAndGetUUIDValue(t *testing.T) {
@@ -72,7 +72,7 @@ func TestSetAndGetUUIDValue(t *testing.T) {
 	bsi.SetBigValue(1, bigUUID)
 	assert.Equal(t, bigUUID.BitLen(), bsi.BitCount())
 	bv, _ := bsi.GetBigValue(1)
-	assert.Equal(t,  bigUUID, bv)
+	assert.Equal(t, bigUUID, bv)
 
 	newUUID, err := uuid.FromBytes(bv.Bytes())
 	assert.Nil(t, err)
@@ -127,16 +127,16 @@ func TestRangeBig(t *testing.T) {
 	}
 
 	start, _ := bsi.GetBigValue(uint64(45)) // starting value at columnID 45
-	end, _ := bsi.GetBigValue(uint64(55))  // ending value at columnID 55
-    set := bsi.CompareBigValue(0, RANGE, start, end, nil)
-    assert.Equal(t, uint64(11), set.GetCardinality())
-    
-    i := set.Iterator()
-    for i.HasNext() {
-        v := i.Next()
-        assert.GreaterOrEqual(t, uint64(v), uint64(45))
-        assert.LessOrEqual(t, uint64(v), uint64(55))
-    }
+	end, _ := bsi.GetBigValue(uint64(55))   // ending value at columnID 55
+	set := bsi.CompareBigValue(0, RANGE, start, end, nil)
+	assert.Equal(t, uint64(11), set.GetCardinality())
+
+	i := set.Iterator()
+	for i.HasNext() {
+		v := i.Next()
+		assert.GreaterOrEqual(t, uint64(v), uint64(45))
+		assert.LessOrEqual(t, uint64(v), uint64(55))
+	}
 	assert.Equal(t, 67, bsi.BitCount())
 }
 

--- a/roaring64/bsi64_test.go
+++ b/roaring64/bsi64_test.go
@@ -502,6 +502,21 @@ func TestAdd(t *testing.T) {
 
 }
 
+func TestBatchValueBig(t *testing.T) {
+	bsi := NewDefaultBSI()
+
+	// create a big value
+	bv := big.NewInt(Max64BitSigned)
+	bv.Mul(bv, big.NewInt(100))
+
+	// Populate large timestamp values
+	for i := 0; i <= 100; i++ {
+		bsi.SetBigValue(uint64(i), bv)
+	}
+	result := bsi.BatchEqualBig(0, []*big.Int{bv})
+	assert.Equal(t, uint64(101), result.GetCardinality())
+}
+
 func TestIncrementSimple(t *testing.T) {
 	bsi := setup()
 	bsi.IncrementAll()


### PR DESCRIPTION
There is no fundamental reason why the BSI library cannot support values exceeding 64 bits.  Why is this necessary?   It would  now be possible to store values like UUID and 96 bit timestamps, as well as advanced string encodings in a BSI.

The BSI library has been modified to preserve the existing int64 interface and has been expanded to leverage the golang big.Int math library.   The original int64 methods now convert incoming values to *big.Int (and vice versa, etc).

Additional test coverage has been added and some of the original tests have been expanded.   

Performance does not seem to be substantially impacted.