### PR TITLE
Fix issue 457.

### DIFF
--- a/roaring64/bsi64.go
+++ b/roaring64/bsi64.go
@@ -97,6 +97,9 @@ func (b *BSI) SetBigValue(columnID uint64, value *big.Int) {
 	// If max/min values are set to zero then automatically determine bit array size
 	if b.MaxValue == 0 && b.MinValue == 0 {
 		minBits := value.BitLen() + 1
+		if minBits == 1 {
+			minBits = 2
+		}
 		for len(b.bA) < minBits {
 			b.bA = append(b.bA, Bitmap{})
 		}

--- a/roaring64/bsi64_test.go
+++ b/roaring64/bsi64_test.go
@@ -112,6 +112,13 @@ func TestSetAndGetBigTimestamp(t *testing.T) {
 	assert.Equal(t, 67, bsi.BitCount())
 }
 
+// This tests a corner case where a zero value is set on an empty BSI.  The bit count should never be zero.
+func TestSetInitialValueZero(t *testing.T) {
+	bsi := NewDefaultBSI()
+	bsi.SetBigValue(1, big.NewInt(0))
+	assert.Equal(t, 1, bsi.BitCount())
+}
+
 func TestRangeBig(t *testing.T) {
 
 	bsi := NewDefaultBSI()
@@ -262,13 +269,9 @@ func TestNewBSI(t *testing.T) {
 	bsi = NewDefaultBSI()
 	assert.Equal(t, 0, bsi.BitCount())
 	bsi.SetValue(1, int64(0))
-	assert.Equal(t, 0, bsi.BitCount())
+	assert.Equal(t, 1, bsi.BitCount())
 	bsi.SetValue(1, int64(-1))
 	assert.Equal(t, 1, bsi.BitCount())
-}
-
-func TestStuff(t *testing.T) {
-
 }
 
 func TestGE(t *testing.T) {


### PR DESCRIPTION
After calling NewDefaultBSI() and calling SetBigValue() with the value "0". The value is not inserted. This fails silently and only occurs then the BSI is empty. This is an edge case that was overlooked.