### PR TITLE
Fix 459

### DIFF
--- a/roaring64/bsi64.go
+++ b/roaring64/bsi64.go
@@ -402,7 +402,7 @@ func compareValue(e *task, batch []uint64, resultsChan chan *Bitmap, wg *sync.Wa
 		if isNegative != startIsNegative {
 			compStartValue = twosComplement(e.valueOrStart, e.bsi.BitCount()+1)
 		}
-		if isNegative != endIsNegative {
+		if isNegative != endIsNegative && e.end != nil {
 			compEndValue = twosComplement(e.end, e.bsi.BitCount()+1)
 		}
 


### PR DESCRIPTION
For calls to CompareBigValue, there is no need to calculate the value for 'end' for the operations calls LT, GT, GE, LE, etc. The 'end' parameter is only considered for RANGE calls and incurring the costs for defaulting the 'end' value is quite expensive.