### PR TITLE
add a new compare func CompareValueONeil for bsi, which faster than CompareValue

### DIFF
--- a/BitSliceIndexing/bsi_test.go
+++ b/BitSliceIndexing/bsi_test.go
@@ -500,3 +500,77 @@ func TestTransposeWithCountsNil(t *testing.T) {
 	assert.True(t, ok)
 	assert.Equal(t, int64(2), a)
 }
+
+func TestEQONeil(t *testing.T) {
+	bsi := setup()
+	eq := bsi.CompareValue(0, EQ, 50, 0, nil)
+	assert.Equal(t, uint64(1), eq.GetCardinality())
+
+	assert.True(t, eq.ContainsInt(50))
+}
+
+func TestLTONeil(t *testing.T) {
+
+	bsi := setup()
+	lt := bsi.CompareValue(0, LT, 50, 0, nil)
+	assert.Equal(t, uint64(50), lt.GetCardinality())
+
+	i := lt.Iterator()
+	for i.HasNext() {
+		v := i.Next()
+		assert.Less(t, uint64(v), uint64(50))
+	}
+}
+
+func TestGTONeil(t *testing.T) {
+
+	bsi := setup()
+	gt := bsi.CompareValue(0, GT, 50, 0, nil)
+	assert.Equal(t, uint64(49), gt.GetCardinality())
+
+	i := gt.Iterator()
+	for i.HasNext() {
+		v := i.Next()
+		assert.Greater(t, uint64(v), uint64(50))
+	}
+}
+
+func TestGEONeil(t *testing.T) {
+
+	bsi := setup()
+	ge := bsi.CompareValue(0, GE, 50, 0, nil)
+	assert.Equal(t, uint64(50), ge.GetCardinality())
+
+	i := ge.Iterator()
+	for i.HasNext() {
+		v := i.Next()
+		assert.GreaterOrEqual(t, uint64(v), uint64(50))
+	}
+}
+
+func TestLEONeil(t *testing.T) {
+
+	bsi := setup()
+	le := bsi.CompareValue(0, LE, 50, 0, nil)
+	assert.Equal(t, uint64(51), le.GetCardinality())
+
+	i := le.Iterator()
+	for i.HasNext() {
+		v := i.Next()
+		assert.LessOrEqual(t, uint64(v), uint64(50))
+	}
+}
+
+func TestRangeONeil(t *testing.T) {
+
+	bsi := setup()
+	set := bsi.CompareValue(0, RANGE, 45, 55, nil)
+	assert.Equal(t, uint64(11), set.GetCardinality())
+
+	i := set.Iterator()
+	for i.HasNext() {
+		v := i.Next()
+		assert.GreaterOrEqual(t, uint64(v), uint64(45))
+		assert.LessOrEqual(t, uint64(v), uint64(55))
+	}
+}

--- a/roaring64/bsi64_test.go
+++ b/roaring64/bsi64_test.go
@@ -822,3 +822,84 @@ func TestRangeNilBig(t *testing.T) {
 	tmpAll := bsi.CompareBigValue(0, RANGE, bsi.MinMaxBig(0, MIN, nil), bsi.MinMaxBig(0, MAX, nil), nil)
 	assert.Equal(t, tmpAll.GetCardinality(), setAll.GetCardinality())
 }
+
+func TestEQONeil(t *testing.T) {
+
+	bsi := setup()
+	eq := bsi.CompareValueONeil( EQ, 50, 0, nil)
+	assert.Equal(t, uint64(1), eq.GetCardinality())
+
+	assert.True(t, eq.ContainsInt(50))
+}
+
+func TestLTONeil(t *testing.T) {
+
+	bsi := setup()
+	lt := bsi.CompareValueONeil(LT, 50, 0, nil)
+	assert.Equal(t, uint64(50), lt.GetCardinality())
+
+	i := lt.Iterator()
+	for i.HasNext() {
+		v := i.Next()
+		assert.Less(t, uint64(v), uint64(50))
+	}
+}
+
+func TestGTONeil(t *testing.T) {
+
+	bsi := setup()
+	gt := bsi.CompareValueONeil( GT, 50, 0, nil)
+	assert.Equal(t, uint64(50), gt.GetCardinality())
+
+	i := gt.Iterator()
+	for i.HasNext() {
+		v := i.Next()
+		assert.Greater(t, uint64(v), uint64(50))
+	}
+}
+
+func TestGEONeil(t *testing.T) {
+
+	bsi := setup()
+	ge := bsi.CompareValueONeil(GE, 50, 0, nil)
+	assert.Equal(t, uint64(51), ge.GetCardinality())
+
+	i := ge.Iterator()
+	for i.HasNext() {
+		v := i.Next()
+		assert.GreaterOrEqual(t, uint64(v), uint64(50))
+	}
+}
+
+func TestLEONeil(t *testing.T) {
+
+	bsi := setup()
+	le := bsi.CompareValueONeil( LE, 50, 0, nil)
+	assert.Equal(t, uint64(51), le.GetCardinality())
+
+	i := le.Iterator()
+	for i.HasNext() {
+		v := i.Next()
+		assert.LessOrEqual(t, uint64(v), uint64(50))
+	}
+}
+
+func TestRangeSimpleONeil(t *testing.T) {
+
+	bsi := setup()
+	set := bsi.CompareValueONeil( RANGE, 45, 55, nil)
+	assert.Equal(t, uint64(11), set.GetCardinality())
+
+	i := set.Iterator()
+	for i.HasNext() {
+		v := i.Next()
+		assert.GreaterOrEqual(t, uint64(v), uint64(45))
+		assert.LessOrEqual(t, uint64(v), uint64(55))
+	}
+}
+
+func TestRangeBigONeil(t *testing.T) {
+	bsi := setup()
+	set := bsi.CompareValueONeil( RANGE, 0, 103, nil)
+	assert.Equal(t, uint64(101), set.GetCardinality())
+}


### PR DESCRIPTION
According to Java's compare function , I code a new function CompareValueONeil for go version ,and it **only support number which is >= 0** , it is faster than CompareValue. When bsi include 200 million columnIds, using same range query,**CompareValueONeil is cost about 1s when CompareValue cost about 12s**(https://github.com/RoaringBitmap/RoaringBitmap/blob/cca90c986d5c0096bbeabb5f968833bf12c28c0e/bsi/src/main/java/org/roaringbitmap/bsi/longlong/Roaring64BitmapSliceIndex.java#L456)