### PR TITLE
`ToArray` with pre-allocated slices: `ToExistingArray`

### DIFF
--- a/roaring.go
+++ b/roaring.go
@@ -438,6 +438,9 @@ func (rb *Bitmap) toArray(array *[]uint32) *[]uint32 {
 	return array
 }
 
+// ToExistingArray stores all of the integers stored in the Bitmap in sorted order in the
+// slice that is given to ToExistingArray. It is the callers duty to make sure the slice
+// has the right size.
 func (rb *Bitmap) ToExistingArray(array *[]uint32) *[]uint32 {
 	return rb.toArray(array)
 }

--- a/roaring.go
+++ b/roaring.go
@@ -421,6 +421,11 @@ func FromBitSet(bitset *bitset.BitSet) *Bitmap {
 // ToArray creates a new slice containing all of the integers stored in the Bitmap in sorted order
 func (rb *Bitmap) ToArray() []uint32 {
 	array := make([]uint32, rb.GetCardinality())
+	ar := rb.toArray(&array)
+	return *ar
+}
+
+func (rb *Bitmap) toArray(array *[]uint32) *[]uint32 {
 	pos := 0
 	pos2 := 0
 
@@ -428,9 +433,13 @@ func (rb *Bitmap) ToArray() []uint32 {
 		hs := uint32(rb.highlowcontainer.getKeyAtIndex(pos)) << 16
 		c := rb.highlowcontainer.getContainerAtIndex(pos)
 		pos++
-		pos2 = c.fillLeastSignificant16bits(array, pos2, hs)
+		pos2 = c.fillLeastSignificant16bits(*array, pos2, hs)
 	}
 	return array
+}
+
+func (rb *Bitmap) ToExistingArray(array *[]uint32) *[]uint32 {
+	return rb.toArray(array)
 }
 
 // GetSizeInBytes estimates the memory usage of the Bitmap. Note that this

--- a/roaring.go
+++ b/roaring.go
@@ -10,7 +10,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"slices"
 	"strconv"
 
 	"github.com/RoaringBitmap/roaring/v2/internal"
@@ -443,9 +442,6 @@ func (rb *Bitmap) toArray(array *[]uint32) *[]uint32 {
 // slice that is given to ToExistingArray. It is the callers duty to make sure the slice
 // has the right size.
 func (rb *Bitmap) ToExistingArray(array *[]uint32) *[]uint32 {
-	size := int(rb.GetCardinality())
-	*array = slices.Grow(*array, size)
-	*array = (*array)[:size]
 	return rb.toArray(array)
 }
 

--- a/roaring.go
+++ b/roaring.go
@@ -10,6 +10,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
+	"slices"
 	"strconv"
 
 	"github.com/RoaringBitmap/roaring/v2/internal"
@@ -442,6 +443,9 @@ func (rb *Bitmap) toArray(array *[]uint32) *[]uint32 {
 // slice that is given to ToExistingArray. It is the callers duty to make sure the slice
 // has the right size.
 func (rb *Bitmap) ToExistingArray(array *[]uint32) *[]uint32 {
+	size := int(rb.GetCardinality())
+	*array = slices.Grow(*array, size)
+	*array = (*array)[:size]
 	return rb.toArray(array)
 }
 

--- a/roaring_test.go
+++ b/roaring_test.go
@@ -1827,6 +1827,20 @@ func TestBitmap(t *testing.T) {
 
 		assert.True(t, valide)
 	})
+
+	t.Run("ToExistingArray-Test", func(t *testing.T) {
+		values := make([]uint32, 0, 110)
+		rb := NewBitmap()
+
+		for i := 10; i < 120; i++ {
+			values = append(values, uint32(i))
+		}
+		rb.AddMany(values)
+		assert.Equal(t, values, rb.ToArray())
+		existing := make([]uint32, len(values))
+		buf := rb.ToExistingArray(&existing)
+		assert.Equal(t, values, *buf)
+	})
 }
 
 func TestXORtest4(t *testing.T) {


### PR DESCRIPTION
I have a use case were I need to call `ToArray` quite often. Every call creates a new slices which creates a lot of pressure for Go's GC. This PR adds a new function - `ToExistingArray` - to `Bitmap` which allows using a pre-allocated slice, that later can be re-used.