### PR TITLE
Fixed a bug with AndAny, a case of uint16 overflow

### DIFF
--- a/arraycontainer.go
+++ b/arraycontainer.go
@@ -966,8 +966,8 @@ func (ac *arrayContainer) resetTo(a container) {
 		ac.realloc(card)
 		cur := 0
 		for _, r := range x.iv {
-			for val := r.start; val <= r.last(); val++ {
-				ac.content[cur] = val
+			for val := int(r.start); val <= int(r.last()); val++ {
+				ac.content[cur] = uint16(val)
 				cur++
 			}
 		}


### PR DESCRIPTION
When AndAny is used with bitmaps that are using runcontainers that contain a range [x,65535], the resetTo arrayContainer panic with 'panic: runtime error: index out of range [length] with length [length]'.

This is because the loop in line 'arraycontainer.go#L969'  val is a uint16 and will overflow and will never be > r.last() as r.last() is MaxUint16.
