### PR TITLE
roaring64: Use roaring.ParOr when all keys on the roaringArray64 are same

### DIFF
--- a/roaring64/roaring64.go
+++ b/roaring64/roaring64.go
@@ -1248,9 +1248,13 @@ func (rb *Bitmap) Validate() error {
 // Roaring32AsRoaring64 inserts a 32-bit roaring bitmap into
 // a 64-bit roaring bitmap. No copy is made.
 func Roaring32AsRoaring64(bm32 *roaring.Bitmap) *Bitmap {
+	return roaring32AsRoaring64(bm32, 0)
+}
+
+func roaring32AsRoaring64(bm32 *roaring.Bitmap, key uint32) *Bitmap {
 	rb := NewBitmap()
 	rb.highlowcontainer.resize(0)
-	rb.highlowcontainer.keys = append(rb.highlowcontainer.keys, 0)
+	rb.highlowcontainer.keys = append(rb.highlowcontainer.keys, key)
 	rb.highlowcontainer.containers = append(rb.highlowcontainer.containers, bm32)
 	rb.highlowcontainer.needCopyOnWrite = append(rb.highlowcontainer.needCopyOnWrite, false)
 	return rb


### PR DESCRIPTION
We'd love to use the 64-bit variant to keep the implementation consistent across various use cases.

The merge performance of `roaring64.ParOr` suffers when all the bitmaps share the same upper 32 bits.

PS: I believe this behavior is correct. If it's not, let me know 😇