### PR TITLE
docs: add godoc for Values and Backward

### DIFF
--- a/iter.go
+++ b/iter.go
@@ -1,5 +1,8 @@
 package roaring
 
+// Values returns an iterator that yields the elements of the bitmap in
+// increasing order. Starting with Go 1.23, users can use a for loop to iterate
+// over it.
 func Values(b *Bitmap) func(func(uint32) bool) {
 	return func(yield func(uint32) bool) {
 		it := b.Iterator()
@@ -11,6 +14,9 @@ func Values(b *Bitmap) func(func(uint32) bool) {
 	}
 }
 
+// Backward returns an iterator that yields the elements of the bitmap in
+// decreasing order. Starting with Go 1.23, users can use a for loop to iterate
+// over it.
 func Backward(b *Bitmap) func(func(uint32) bool) {
 	return func(yield func(uint32) bool) {
 		it := b.ReverseIterator()

--- a/roaring64/iter.go
+++ b/roaring64/iter.go
@@ -1,5 +1,8 @@
 package roaring64
 
+// Values returns an iterator that yields the elements of the bitmap in
+// increasing order. Starting with Go 1.23, users can use a for loop to iterate
+// over it.
 func Values(b *Bitmap) func(func(uint64) bool) {
 	return func(yield func(uint64) bool) {
 		it := b.Iterator()
@@ -11,6 +14,9 @@ func Values(b *Bitmap) func(func(uint64) bool) {
 	}
 }
 
+// Backward returns an iterator that yields the elements of the bitmap in
+// decreasing order. Starting with Go 1.23, users can use a for loop to iterate
+// over it.
 func Backward(b *Bitmap) func(func(uint64) bool) {
 	return func(yield func(uint64) bool) {
 		it := b.ReverseIterator()


### PR DESCRIPTION
Add the go doc comment, because the previous PR #475 did not include that.