### PR TITLE
ClearBits with AndNot

### DIFF
--- a/BitSliceIndexing/bsi.go
+++ b/BitSliceIndexing/bsi.go
@@ -754,11 +754,7 @@ func batchEqual(e *task, batch []uint32, resultsChan chan *roaring.Bitmap,
 
 // ClearBits cleared the bits that exist in the target if they are also in the found set.
 func ClearBits(foundSet, target *roaring.Bitmap) {
-	iter := foundSet.Iterator()
-	for iter.HasNext() {
-		cID := iter.Next()
-		target.Remove(cID)
-	}
+	target.AndNot(foundSet)
 }
 
 // ClearValues removes the values found in foundSet
@@ -768,13 +764,13 @@ func (b *BSI) ClearValues(foundSet *roaring.Bitmap) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		ClearBits(foundSet, b.eBM)
+		b.eBM.AndNot(foundSet)
 	}()
 	for i := 0; i < b.BitCount(); i++ {
 		wg.Add(1)
 		go func(j int) {
 			defer wg.Done()
-			ClearBits(foundSet, b.bA[j])
+			b.bA[j].AndNot(foundSet)
 		}(i)
 	}
 	wg.Wait()

--- a/roaring64/bsi64.go
+++ b/roaring64/bsi64.go
@@ -738,7 +738,7 @@ func (b *BSI) ParOr(parallelism int, bsis ...*BSI) {
 	bits := len(b.bA)
 	for i := 0; i < len(bsis); i++ {
 		if len(bsis[i].bA) > bits {
-			bits = len(bsis[i].bA )
+			bits = len(bsis[i].bA)
 		}
 	}
 
@@ -942,11 +942,7 @@ func batchEqual(e *task, batch []uint64, resultsChan chan *Bitmap,
 
 // ClearBits cleared the bits that exist in the target if they are also in the found set.
 func ClearBits(foundSet, target *Bitmap) {
-	iter := foundSet.Iterator()
-	for iter.HasNext() {
-		cID := iter.Next()
-		target.Remove(cID)
-	}
+	target.AndNot(foundSet)
 }
 
 // ClearValues removes the values found in foundSet
@@ -956,13 +952,13 @@ func (b *BSI) ClearValues(foundSet *Bitmap) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		ClearBits(foundSet, &b.eBM)
+		b.eBM.AndNot(foundSet)
 	}()
 	for i := 0; i < b.BitCount(); i++ {
 		wg.Add(1)
 		go func(j int) {
 			defer wg.Done()
-			ClearBits(foundSet, &b.bA[j])
+			b.bA[j].AndNot(foundSet)
 		}(i)
 	}
 	wg.Wait()


### PR DESCRIPTION
I am not entirely sure why we had the iterator set up.

Clearing bits with AndNot feels correct.

Let me know if there's some case that I've missed here.

Did not remove the `ClearBits` functions as they're exported public API.