### PR TITLE
add UnsetIterator, Ranges and InvertRanges

### DIFF
--- a/arraycontainer.go
+++ b/arraycontainer.go
@@ -56,6 +56,58 @@ func (ac *arrayContainer) getManyIterator() manyIterable {
 	return &shortIterator{ac.content, 0}
 }
 
+type arrayContainerUnsetIterator struct {
+	content []uint16
+	pos     int
+	nextVal int
+}
+
+func (acui *arrayContainerUnsetIterator) next() uint16 {
+	val := acui.nextVal
+	acui.nextVal++
+	for acui.pos < len(acui.content) && uint16(acui.nextVal) == acui.content[acui.pos] {
+		acui.nextVal++
+		acui.pos++
+	}
+	return uint16(val)
+}
+
+func (acui *arrayContainerUnsetIterator) hasNext() bool {
+	return acui.nextVal < 65536
+}
+
+func (acui *arrayContainerUnsetIterator) peekNext() uint16 {
+	return uint16(acui.nextVal)
+}
+
+func (acui *arrayContainerUnsetIterator) advanceIfNeeded(minval uint16) {
+	if !acui.hasNext() || acui.peekNext() >= minval {
+		return
+	}
+	acui.nextVal = int(minval)
+	acui.pos = binarySearch(acui.content, minval)
+	if acui.pos < 0 {
+		acui.pos = -acui.pos - 1
+	}
+	for acui.pos < len(acui.content) && uint16(acui.nextVal) == acui.content[acui.pos] {
+		acui.nextVal++
+		acui.pos++
+	}
+}
+
+func newArrayContainerUnsetIterator(a *arrayContainer) *arrayContainerUnsetIterator {
+	acui := &arrayContainerUnsetIterator{content: a.content, pos: 0, nextVal: 0}
+	for acui.pos < len(acui.content) && uint16(acui.nextVal) == acui.content[acui.pos] {
+		acui.nextVal++
+		acui.pos++
+	}
+	return acui
+}
+
+func (ac *arrayContainer) getUnsetIterator() shortPeekable {
+	return newArrayContainerUnsetIterator(ac)
+}
+
 func (ac *arrayContainer) minimum() uint16 {
 	return ac.content[0] // assume not empty
 }

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -541,6 +541,53 @@ func BenchmarkIterateRoaring(b *testing.B) {
 			}
 		}
 	})
+	b.Run("ranges", func(b *testing.B) {
+		b.ReportAllocs()
+
+		s := newBitmap()
+
+		b.ResetTimer()
+
+		for j := 0; j < b.N; j++ {
+			c9 = uint(0)
+			for range s.Ranges() {
+				c9++
+			}
+		}
+	})
+	b.Run("unsetIterator", func(b *testing.B) {
+		b.ReportAllocs()
+
+		s := Flip(newBitmap(), 0, 0x100000000)
+
+		b.ResetTimer()
+
+		for j := 0; j < b.N; j++ {
+			c9 = uint(0)
+			i := s.UnsetIterator()
+			for i.HasNext() {
+				i.Next()
+				c9++
+			}
+		}
+	})
+	b.Run("unsetIteratorWithFlip", func(b *testing.B) {
+		b.ReportAllocs()
+
+		s := Flip(newBitmap(), 0, 0x100000000)
+
+		b.ResetTimer()
+
+		for j := 0; j < b.N; j++ {
+			c9 = uint(0)
+
+			i := Flip(s, 0, 0x100000000).Iterator()
+			for i.HasNext() {
+				i.Next()
+				c9++
+			}
+		}
+	})
 
 	b.Run("iterate-compressed", func(b *testing.B) {
 		b.ReportAllocs()

--- a/bitmapcontainer.go
+++ b/bitmapcontainer.go
@@ -236,6 +236,39 @@ func (bc *bitmapContainer) getManyIterator() manyIterable {
 	return newBitmapContainerManyIterator(bc)
 }
 
+type bitmapContainerUnsetIterator struct {
+	ptr *bitmapContainer
+	i   int
+}
+
+func (bcui *bitmapContainerUnsetIterator) next() uint16 {
+	j := bcui.i
+	bcui.i = bcui.ptr.NextUnsetBit(uint(bcui.i) + 1)
+	return uint16(j)
+}
+
+func (bcui *bitmapContainerUnsetIterator) hasNext() bool {
+	return bcui.i >= 0 && bcui.i < 65536
+}
+
+func (bcui *bitmapContainerUnsetIterator) peekNext() uint16 {
+	return uint16(bcui.i)
+}
+
+func (bcui *bitmapContainerUnsetIterator) advanceIfNeeded(minval uint16) {
+	if bcui.hasNext() && bcui.peekNext() < minval {
+		bcui.i = bcui.ptr.NextUnsetBit(uint(minval))
+	}
+}
+
+func newBitmapContainerUnsetIterator(a *bitmapContainer) *bitmapContainerUnsetIterator {
+	return &bitmapContainerUnsetIterator{a, a.NextUnsetBit(0)}
+}
+
+func (bc *bitmapContainer) getUnsetIterator() shortPeekable {
+	return newBitmapContainerUnsetIterator(bc)
+}
+
 func (bc *bitmapContainer) getSizeInBytes() int {
 	return len(bc.bitmap) * 8 // + bcBaseBytes
 }
@@ -1086,6 +1119,29 @@ func (bc *bitmapContainer) NextSetBit(i uint) int {
 		}
 	}
 	return -1
+}
+
+func (bc *bitmapContainer) NextUnsetBit(i uint) int {
+	var (
+		x      = i / 64
+		length = uint(len(bc.bitmap))
+	)
+	if x >= length {
+		return int(i)
+	}
+	w := bc.bitmap[x]
+	w = w >> uint(i%64)
+	w = ^w
+	if w != 0 {
+		return int(i) + countTrailingZeros(w)
+	}
+	x++
+	for ; x < length; x++ {
+		if bc.bitmap[x] != 0xFFFFFFFFFFFFFFFF {
+			return int(x*64) + countTrailingZeros(^bc.bitmap[x])
+		}
+	}
+	return int(length * 64)
 }
 
 func (bc *bitmapContainer) PrevSetBit(i int) int {

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,15 @@
 module github.com/RoaringBitmap/roaring
 
-go 1.14
+go 1.24
 
 require (
 	github.com/bits-and-blooms/bitset v1.12.0
 	github.com/mschoch/smat v0.2.0
 	github.com/stretchr/testify v1.7.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/roaringarray.go
+++ b/roaringarray.go
@@ -43,6 +43,7 @@ type container interface {
 	iterate(cb func(x uint16) bool) bool
 	getReverseIterator() shortIterable
 	getManyIterator() manyIterable
+	getUnsetIterator() shortPeekable
 	contains(i uint16) bool
 	maximum() uint16
 	minimum() uint16

--- a/runcontainer.go
+++ b/runcontainer.go
@@ -1946,6 +1946,61 @@ func (rc *runContainer16) getManyIterator() manyIterable {
 	return rc.newManyRunIterator16()
 }
 
+type runUnsetIterator16 struct {
+	rc       *runContainer16
+	curIndex int
+	nextVal  int
+}
+
+func (rc *runContainer16) newRunUnsetIterator16() *runUnsetIterator16 {
+	rui := &runUnsetIterator16{rc: rc, curIndex: 0, nextVal: 0}
+	if len(rc.iv) > 0 && rc.iv[0].start == 0 {
+		rui.nextVal = int(rc.iv[0].start) + int(rc.iv[0].length) + 1
+		rui.curIndex = 1
+	}
+	return rui
+}
+
+func (rui *runUnsetIterator16) hasNext() bool {
+	return rui.nextVal < 65536
+}
+
+func (rui *runUnsetIterator16) next() uint16 {
+	val := rui.nextVal
+	rui.nextVal++
+	if rui.curIndex < len(rui.rc.iv) && uint16(rui.nextVal) == rui.rc.iv[rui.curIndex].start {
+		rui.nextVal = int(rui.rc.iv[rui.curIndex].start) + int(rui.rc.iv[rui.curIndex].length) + 1
+		rui.curIndex++
+	}
+	return uint16(val)
+}
+
+func (rui *runUnsetIterator16) peekNext() uint16 {
+	return uint16(rui.nextVal)
+}
+
+func (rui *runUnsetIterator16) advanceIfNeeded(minval uint16) {
+	if !rui.hasNext() || rui.peekNext() >= minval {
+		return
+	}
+	rui.nextVal = int(minval)
+	for rui.curIndex < len(rui.rc.iv) {
+		if rui.rc.iv[rui.curIndex].start+rui.rc.iv[rui.curIndex].length < minval {
+			rui.curIndex++
+		} else if rui.rc.iv[rui.curIndex].start <= minval {
+			rui.nextVal = int(rui.rc.iv[rui.curIndex].start) + int(rui.rc.iv[rui.curIndex].length) + 1
+			rui.curIndex++
+			break
+		} else {
+			break
+		}
+	}
+}
+
+func (rc *runContainer16) getUnsetIterator() shortPeekable {
+	return rc.newRunUnsetIterator16()
+}
+
 // add the values in the range [firstOfRange, endx). endx
 // is still abe to express 2^16 because it is an int not an uint16.
 func (rc *runContainer16) iaddRange(firstOfRange, endx int) container {

--- a/unset_iterator_test.go
+++ b/unset_iterator_test.go
@@ -1,0 +1,208 @@
+package roaring
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnsetIterator(t *testing.T) {
+	t.Run("empty bitmap", func(t *testing.T) {
+		bm := New()
+		iter := bm.UnsetIterator()
+
+		// First few unset values should be 0, 1, 2...
+		assert.True(t, iter.HasNext())
+		assert.Equal(t, uint32(0), iter.Next())
+		assert.Equal(t, uint32(1), iter.Next())
+		assert.Equal(t, uint32(2), iter.Next())
+	})
+
+	t.Run("bitmap with some values", func(t *testing.T) {
+		bm := New()
+		bm.Add(1)
+		bm.Add(3)
+		bm.Add(5)
+
+		iter := bm.UnsetIterator()
+		expected := []uint32{0, 2, 4, 6, 7, 8, 9, 10}
+		for _, exp := range expected {
+			assert.True(t, iter.HasNext())
+			assert.Equal(t, exp, iter.Next())
+		}
+	})
+
+	t.Run("bitmap with range", func(t *testing.T) {
+		bm := New()
+		bm.AddRange(10, 20)
+
+		iter := bm.UnsetIterator()
+		// First 10 should be unset
+		for i := uint32(0); i < 10; i++ {
+			assert.True(t, iter.HasNext())
+			assert.Equal(t, i, iter.Next())
+		}
+		// 20-29 should be unset
+		for i := uint32(20); i < 30; i++ {
+			assert.True(t, iter.HasNext())
+			assert.Equal(t, i, iter.Next())
+		}
+	})
+
+	t.Run("bitmap with multiple containers", func(t *testing.T) {
+		bm := New()
+		// Add some values in first container (0-65535)
+		bm.Add(100)
+		bm.Add(200)
+		// Add some values in second container (65536-131071)
+		bm.Add(65636)
+		bm.Add(65736)
+
+		iter := bm.UnsetIterator()
+		// Check first few unset values
+		for i := uint32(0); i < 100; i++ {
+			assert.True(t, iter.HasNext())
+			assert.Equal(t, i, iter.Next())
+		}
+		// 100 is set, so skip it
+		assert.Equal(t, uint32(101), iter.Next())
+		// Continue to 199
+		for i := uint32(102); i < 200; i++ {
+			assert.Equal(t, i, iter.Next())
+		}
+		// 200 is set, skip it
+		assert.Equal(t, uint32(201), iter.Next())
+	})
+
+	t.Run("bitmap with gap containers", func(t *testing.T) {
+		bm := New()
+		// Add value in container 0
+		bm.Add(100)
+		// Add value in container 2 (skip container 1)
+		bm.Add(131072)
+
+		iter := bm.UnsetIterator()
+		// First 100 values are unset
+		for i := uint32(0); i < 100; i++ {
+			assert.True(t, iter.HasNext())
+			assert.Equal(t, i, iter.Next())
+		}
+		// 100 is set, so next unset is 101
+		assert.Equal(t, uint32(101), iter.Next())
+
+		// Skip ahead to check gap container
+		iter.AdvanceIfNeeded(65536)
+		// All of container 1 (65536-131071) should be unset
+		assert.True(t, iter.HasNext())
+		assert.Equal(t, uint32(65536), iter.Next())
+		assert.Equal(t, uint32(65537), iter.Next())
+	})
+}
+
+func TestUnsetIteratorPeekNext(t *testing.T) {
+	bm := New()
+	bm.Add(1)
+	bm.Add(3)
+	bm.Add(5)
+
+	iter := bm.UnsetIterator()
+	assert.True(t, iter.HasNext())
+
+	for iter.HasNext() {
+		peek := iter.PeekNext()
+		next := iter.Next()
+		assert.Equal(t, peek, next)
+		if next > 100 {
+			break
+		}
+	}
+}
+
+func TestUnsetIteratorAdvanceIfNeeded(t *testing.T) {
+	bm := New()
+	bm.Add(10)
+	bm.Add(100)
+	bm.Add(1000)
+
+	cases := []struct {
+		minval   uint32
+		expected uint32
+	}{
+		{0, 0},
+		{5, 5},
+		{10, 11}, // 10 is set
+		{50, 50},
+		{100, 101}, // 100 is set
+		{500, 500},
+		{1000, 1001}, // 1000 is set
+	}
+
+	for _, c := range cases {
+		t.Run("", func(t *testing.T) {
+			iter := bm.UnsetIterator()
+			iter.AdvanceIfNeeded(c.minval)
+			assert.True(t, iter.HasNext())
+			assert.Equal(t, c.expected, iter.Next())
+		})
+	}
+}
+
+func TestUnsetIteratorComplement(t *testing.T) {
+	// Test that Iterator and UnsetIterator are complementary
+	bm := New()
+	for i := uint32(0); i < 1000; i += 3 {
+		bm.Add(i)
+	}
+
+	// Collect all set values
+	setValues := make(map[uint32]bool)
+	iter := bm.Iterator()
+	for iter.HasNext() {
+		setValues[iter.Next()] = true
+	}
+
+	// Verify unset iterator returns complement up to 1000
+	unsetIter := bm.UnsetIterator()
+	count := 0
+	for count < 1000 && unsetIter.HasNext() {
+		val := unsetIter.Next()
+		if val >= 1000 {
+			break
+		}
+		assert.False(t, setValues[val])
+		count++
+	}
+}
+
+func TestUnsetIteratorLargeRange(t *testing.T) {
+	// This test demonstrates the bug where UnsetIterator returns set bits as unset
+	bm := New()
+	bm.AddRange(0, 0x10000) // All bits from 0 to 65535 are set
+
+	// Debug: check what type of container was created
+	if len(bm.highlowcontainer.containers) != 1 {
+		t.Fatalf("expected 1 container, got %d", len(bm.highlowcontainer.containers))
+	}
+	container := bm.highlowcontainer.containers[0]
+	t.Logf("Container type: %T", container)
+	t.Logf("Container cardinality: %d", container.getCardinality())
+
+	unsetIter := bm.UnsetIterator()
+	// Check initial state
+	if unsetIter.HasNext() {
+		t.Logf("Initial PeekNext: %d", unsetIter.PeekNext())
+	}
+
+	// Advance to position 100, which is in the middle of the set range
+	unsetIter.AdvanceIfNeeded(100)
+
+	if !unsetIter.HasNext() {
+		t.Fatal("iterator should have next")
+	}
+	// Check state after advance
+	t.Logf("After AdvanceIfNeeded(100), PeekNext: %d", unsetIter.PeekNext())
+
+	// The next unset bit should be 65536 (0x10000), not 100
+	val := unsetIter.Next()
+	assert.Equal(t, uint32(0x10000), val, "expected first unset bit after range, got bit within set range")
+}


### PR DESCRIPTION

## Description

This WIP proof-of-concept implements two new features: the ability
to iterate over unset bits (avoiding the need to use Flip) and the ability
to iterate over contiguous bit ranges, giving an iterator that guarantees
the number of iterations is same as (or close to) the number of contiguous bit
ranges.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Test improvements
- [ ] Build/CI changes

## Changes Made

### What was changed?
Added Bitset.UnsetIterator, Bitset.Ranges and InvertRanges.

### Why was it changed?

### How was it changed?

Almost all the code was written with Claude Code. Take with a very large pinch of salt!

## Fuzzing

N/A

## Performance Impact

N/A
### Running Benchmarks

| Property    | Value                              |
| ----------- | ---------------------------------- |
| **GOOS**    | linux                              |
| **GOARCH**  | amd64                              |
| **Package** | `github.com/RoaringBitmap/roaring` |
| **CPU**     | Intel(R) Core(TM) Ultra 7 155U     |

---
| Benchmark                               | `/tmp/b1` (sec/op) | ±  |
| --------------------------------------- | ------------------ | -- |
| IterateRoaring/iterator-compressed-14   | 244.0µ             | 3% |
| IterateRoaring/iterator-14              | 247.0µ             | 5% |
| IterateRoaring/ranges-14                | 1.124m             | 2% |
| IterateRoaring/unsetIterator-14         | 706.6µ             | 4% |
| IterateRoaring/unsetIteratorWithFlip-14 | 7.723m             | 2% |
| IterateRoaring/iterate-compressed-14    | 215.5µ             | 2% |
| IterateRoaring/iterate-14               | 219.0µ             | 3% |
| SparseIterateRoaring-14                 | 229.3µ             | 7% |
| **geomean**                             | **501.5µ**         | —  |

---

### **Allocations per Operation (`allocs/op`)**

| Benchmark                               | `/tmp/b1` (allocs/op) | ±  |
| --------------------------------------- | --------------------- | -- |
| IterateRoaring/iterator-compressed-14   | 1.000                 | 0% |
| IterateRoaring/iterator-14              | 1.000                 | 0% |
| IterateRoaring/ranges-14                | 2.000                 | 0% |
| IterateRoaring/unsetIterator-14         | 1.000                 | 0% |
| IterateRoaring/unsetIteratorWithFlip-14 | 262.1k                | 0% |
| IterateRoaring/iterate-compressed-14    | 0.000                 | 0% |
| IterateRoaring/iterate-14               | 0.000                 | 0% |
| **geomean**                             | —                     | —  |

> ¹ Summaries must be >0 to compute geomean.

As this is all new code, other benchmarks should be unaffected.

## Related Issues

Fixes #491 
Fixes #22 

