### PR TITLE
fix AdvanceIfNeeded on UnsetIterator

### DIFF
--- a/iter_test.go
+++ b/iter_test.go
@@ -417,6 +417,24 @@ func TestUnsetIteratorPeekable(t *testing.T) {
 		assert.False(t, it.HasNext())
 	})
 
+	t.Run("advance if needed on current value", func(t *testing.T) {
+		b := New()
+		b.AddRange(0, 0x10000)
+		iter := b.UnsetIterator(0, 0x10002)
+		var got []uint32
+		prev := uint32(0)
+		for len(got) < 10 {
+			iter.AdvanceIfNeeded(prev)
+			if !iter.HasNext() {
+				break
+			}
+			x := iter.Next()
+			got = append(got, x)
+			prev = x
+		}
+		assert.Equal(t, []uint32{0x10000, 0x10001, 0x10002}, got)
+	})
+
 	t.Run("peek next on empty iterator", func(t *testing.T) {
 		b := New()
 		b.AddInt(5) // Set bit in middle of range

--- a/roaring.go
+++ b/roaring.go
@@ -814,8 +814,8 @@ func (ui *unsetIterator) PeekNext() uint32 {
 
 // AdvanceIfNeeded advances the iterator so that the next value is at least minval
 func (ui *unsetIterator) AdvanceIfNeeded(minval uint32) {
-	if minval <= ui.min {
-		return // Already at or before the start of our range
+	if uint64(minval) <= ui.current {
+		return // Already at or past minval
 	}
 
 	if minval > ui.max {


### PR DESCRIPTION
## Description

The bounds check in AdvanceIfNeeded appeared to be wrong. This PR fixes that.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Test improvements
- [ ] Build/CI changes

## Changes Made

### What was changed?
- fix bug in AdvanceIfNeeded on UnsetIterator

## Related Issues

Fixes #495
