### PR TITLE
roaring64: honor copy-on-write in Bitmap.Or

### DIFF
--- a/roaring64/roaring64.go
+++ b/roaring64/roaring64.go
@@ -700,7 +700,7 @@ main:
 				}
 				s2 = x2.highlowcontainer.getKeyAtIndex(pos2)
 			} else {
-				rb.highlowcontainer.getContainerAtIndex(pos1).Or(x2.highlowcontainer.getContainerAtIndex(pos2))
+				rb.highlowcontainer.getWritableContainerAtIndex(pos1).Or(x2.highlowcontainer.getContainerAtIndex(pos2))
 				pos1++
 				pos2++
 				if (pos1 == length1) || (pos2 == length2) {

--- a/roaring64/roaring64cow_test.go
+++ b/roaring64/roaring64cow_test.go
@@ -1768,3 +1768,32 @@ func TestCloneCOWContainers(t *testing.T) {
 
 	//assert.EqualValues(t, rb.ToArray(), newRb1.ToArray())
 }
+
+// TestOrCOWSharedContainer verifies that in-place Or on a CoW-cloned bitmap
+// does not mutate containers shared with the clone source.
+func TestOrCOWSharedContainer(t *testing.T) {
+	rb1 := NewBitmap()
+	rb1.SetCopyOnWrite(true)
+	// Populate a single high-key container with values in [0, 1000).
+	for i := uint64(0); i < 1000; i++ {
+		rb1.Add(i)
+	}
+
+	// Clone: rb2 shares rb1's container, with needCopyOnWrite set on both sides.
+	rb2 := rb1.Clone()
+
+	// x has values in the same high-key container that are not already in rb1/rb2.
+	x := NewBitmap()
+	for i := uint64(1000); i < 2000; i++ {
+		x.Add(i)
+	}
+
+	// In-place Or into rb1. Must NOT mutate the container shared with rb2.
+	rb1.Or(x)
+
+	assert.EqualValues(t, 2000, rb1.GetCardinality())
+	assert.EqualValues(t, 1000, rb2.GetCardinality(),
+		"rb2 was corrupted: Or on rb1 mutated a CoW-shared container")
+	assert.False(t, rb2.Contains(1500),
+		"rb2 was corrupted: contains a value that was only added to rb1")
+}


### PR DESCRIPTION
## Description

When two bitmaps share a container key, the in-place Or was calling getContainerAtIndex, which returns the raw container without consulting needCopyOnWrite. If rb's container at that index was shared with another bitmap (e.g. produced by Clone() on a CoW-enabled bitmap), the Or would mutate the shared container in place and silently corrupt the other bitmap.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Test improvements
- [ ] Build/CI changes

## Changes Made

Switch to getWritableContainerAtIndex, which clones the container first when needCopyOnWrite is set. This matches what the sibling AndNot/And methods in the same file already do, and what the 32-bit Bitmap.Or does via getUnionedWritableContainer.

## Testing

Added a unit test reproducing the issue that fails without the fix.

You must run 

```
go test
```

## Formatting

Please run 

```
go fmt
```

## Fuzzing

Please run our fuzzer on your changes.


1. Generate initial smat corpus:
```
go test -tags=gofuzz -run=TestGenerateSmatCorpus
```
You should see a directory `workdir` created with initial corpus files.

2. Run the fuzz test:
```
go test -run='^$' -fuzz=FuzzSmat -fuzztime=300s -timeout=60s
```

Adjust `-fuzztime` as needed for longer or shorter runs. If crashes are found,
check the test output and the reproducer files in the `workdir` directory.
You may copy the reproducers to roaring_tests.go

## Performance Impact

If applicable, describe any performance implications of these changes and include benchmark results.

### Running Benchmarks

This project includes comprehensive benchmarks. Please run relevant benchmarks before and after your changes:

#### Basic Benchmarks
```bash
# Run all benchmarks
go test -bench=. -run=^$

# Run with memory allocation statistics
go test -bench=. -benchmem -run=^$

# Run specific benchmark
go test -bench=BenchmarkIteratorAlloc -run=^$
```

#### Parallel Benchmarks
```bash
# Run parallel processing benchmarks
go test -bench=BenchmarkIntersectionLargeParallel -run=^$
```

#### Real Data Benchmarks
```bash
# Requires real-roaring-datasets (run: go get github.com/RoaringBitmap/real-roaring-datasets)
BENCH_REAL_DATA=1 go test -bench=BenchmarkRealData -run=^$
```

#### Benchmark Results Format
Please include before/after results in the following format:
```
BenchmarkName-8    1000000    1234 ns/op    567 B/op    12 allocs/op
```

### Performance Analysis
- Compare benchmark results before and after changes
- Note any significant improvements or regressions
- Include memory usage changes if relevant
- Mention any trade-offs (e.g., memory vs speed)

## Breaking Changes

If this PR introduces breaking changes, please describe them and the migration path:
- 


## Related Issues

Fixes # (issue number)
Related to # (issue number)

## Additional Notes

Any additional information or context about this pull request.
