### PR TITLE
fix(bsi): sign-extend existing negatives when bA grows in NewDefaultBSI

### DIFF
--- a/roaring64/bsi64.go
+++ b/roaring64/bsi64.go
@@ -100,8 +100,20 @@ func (b *BSI) SetBigValue(columnID uint64, value *big.Int) {
 		if minBits == 1 {
 			minBits = 2
 		}
-		for len(b.bA) < minBits {
-			b.bA = append(b.bA, Bitmap{})
+		if len(b.bA) < minBits {
+			oldSignPos := len(b.bA) - 1
+			for len(b.bA) < minBits {
+				b.bA = append(b.bA, Bitmap{})
+			}
+			// When bA grows, the sign slot shifts from oldSignPos to the new end
+			// of bA. For existing negative entries (whose sign bit is set in
+			// bA[oldSignPos]), sign-extension requires that all intermediate bit
+			// positions between oldSignPos and the new sign position also be set.
+			// Copy the old sign bitmap into every new slot (sign extension).
+			newSignPos := len(b.bA) - 1
+			for i := oldSignPos + 1; i <= newSignPos; i++ {
+				b.bA[i].Or(&b.bA[oldSignPos])
+			}
 		}
 	}
 
@@ -122,8 +134,16 @@ func (b *BSI) SetBigMany(foundSet *Bitmap, value *big.Int) {
 		if minBits == 1 {
 			minBits = 2
 		}
-		for len(b.bA) < minBits {
-			b.bA = append(b.bA, Bitmap{})
+		if len(b.bA) < minBits {
+			oldSignPos := len(b.bA) - 1
+			for len(b.bA) < minBits {
+				b.bA = append(b.bA, Bitmap{})
+			}
+			// Sign-extend existing negative entries into the new bit slots.
+			newSignPos := len(b.bA) - 1
+			for i := oldSignPos + 1; i <= newSignPos; i++ {
+				b.bA[i].Or(&b.bA[oldSignPos])
+			}
 		}
 	}
 	for i := b.BitCount(); i >= 0; i-- {

--- a/roaring64/bsi64_test.go
+++ b/roaring64/bsi64_test.go
@@ -870,3 +870,26 @@ func BenchmarkClearValues(b *testing.B) {
 		b2.ClearValues(resultA)
 	}
 }
+
+// TestGetValueNegativeAfterGrowth checks that negative values stored in a
+// NewDefaultBSI are returned correctly after bA grows because a larger positive
+// value is added later. Previously, the sign bit was stranded at the old slot
+// when bA was extended, causing wrong-sign results.
+// See https://github.com/RoaringBitmap/roaring/issues/462
+func TestGetValueNegativeAfterGrowth(t *testing.T) {
+	bsi := NewDefaultBSI()
+	for i := int64(-15); i <= 15; i++ {
+		bsi.SetValue(uint64(i+15), i)
+	}
+
+	val, exists := bsi.GetValue(0)
+	require.True(t, exists)
+	assert.Equal(t, int64(-15), val, "before growth")
+
+	// Adding 16 requires an extra bit and grows bA, shifting the sign slot.
+	bsi.SetValue(uint64(16+15), 16)
+
+	val, exists = bsi.GetValue(0)
+	require.True(t, exists)
+	assert.Equal(t, int64(-15), val, "after growth")
+}


### PR DESCRIPTION
## Description

`NewDefaultBSI` uses a dynamic `bA` slice whose last element is the sign bit. When a new value is stored with a larger `BitLen`, `SetBigValue`/`SetBigMany` append new elements to `bA`, shifting the sign position to a higher index. Existing negative entries have their sign bit at the old index, which becomes a plain data bit after the grow. This corrupts all previously stored negative values.

Fixes #462

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

### What was changed?
- `SetBigValue` and `SetBigMany` in `roaring64/bsi64.go`
- Added `TestGetValueNegativeAfterGrowth` to `roaring64/bsi64_test.go`

### Why was it changed?
When `bA` grows, the sign-bit slot shifts from `oldLen-1` to `newLen-1`. All intermediate slots must be set for existing negative entries (two's complement sign extension), otherwise `IsNegative` reads the new sign slot as 0 and `GetBigValue` returns the wrong sign.

### How was it changed?
Before the append loop, the old sign position is recorded. After the grow, the old sign bitmap is OR'd into every newly appended slot (sign extension). The old slot is left unchanged since it was already correct for the 5-bit (or N-bit) encoding.

## Testing

```
go test ./roaring64/ -run TestGetValueNegativeAfterGrowth -v
# PASS

go test ./roaring64/ -timeout 60s
# ok (all existing BSI tests pass)
```

Reproduction: set values -15..15 with `NewDefaultBSI`, confirm `GetValue(0) == -15`, then add value 16 (forces a grow) and confirm `GetValue(0)` is still -15. Before this fix it returned 17.

## Formatting

`gofmt` reports no changes.

## Fuzzing

Fuzz corpus not re-generated (fix is in the non-fuzz path; existing fuzz tests pass).

## Performance Impact

None expected; the sign-extension loop runs once per `SetBigValue`/`SetBigMany` call only when `bA` actually grows, and only for `NewDefaultBSI` (auto-size mode).

## Breaking Changes

None.

## Related Issues

Fixes #462