### PR TITLE
Optimize roaring64 BSI BatchEqual and int64 comparisons

### DIFF
--- a/roaring64/BSI_BENCHMARKS.md
+++ b/roaring64/BSI_BENCHMARKS.md
@@ -36,3 +36,9 @@ Compatibility:
 - True wider-than-64-bit values continue to use the existing generic paths.
 - `BatchEqualBig` now keys values by sign and magnitude so positive and negative
   values with the same magnitude do not collide.
+
+Follow-up:
+
+- This change is scoped to `roaring64`. The 32-bit `BitSliceIndexing` package
+  already has separate `BatchEqual` coverage, and `CompareValue` parity can be
+  addressed in a follow-up PR with its own benchmarks and signed-value tests.

--- a/roaring64/BSI_BENCHMARKS.md
+++ b/roaring64/BSI_BENCHMARKS.md
@@ -1,0 +1,38 @@
+# BSI64 Benchmarks
+
+These notes capture local benchmark results for the BSI64 `BatchEqual` and
+comparison paths. They are intended as reproducible PR evidence, not as
+contractual performance guarantees.
+
+Environment:
+
+- CPU: 12th Gen Intel(R) Core(TM) i7-1255U
+- OS/arch: linux/amd64
+- Package: `github.com/RoaringBitmap/roaring/v2/roaring64`
+
+Commands:
+
+```sh
+go test ./roaring64 -count=1
+go test ./roaring64 -run '^$' -bench 'BenchmarkBSI64BatchEqual' -benchmem -count 3
+go test ./roaring64 -run '^$' -bench 'BenchmarkBSI64Compare(Big)?Value|BenchmarkBSI64BatchEqual(Big)?LargeAgeFixture' -benchmem -count 1
+```
+
+Representative results:
+
+| Benchmark | Before | After | Notes |
+| --- | ---: | ---: | --- |
+| `BenchmarkBSI64BatchEqualLargeAgeFixture` | ~13-14s/op, ~12.4GB/op | ~145-205ms/op, ~25.5MB/op | Avoids row-by-row `GetBigValue` for int64-width values. |
+| `BenchmarkBSI64BatchEqualM128Scattered` | ~1.25s/op, ~458MB/op | ~11-17ms/op, ~12.5MB/op | Detects complete bit-cube value patterns. |
+| `BenchmarkBSI64CompareValueEQLargeAgeFixture` | ~4.44s/op, ~461MB/op | ~100-118ms/op, ~19.7MB/op | `EQ` delegates to optimized `BatchEqual`. |
+| `BenchmarkBSI64CompareValueRangeLargeAgeFixture` | ~7.49s/op, ~501MB/op | ~204-224ms/op, ~122.6MB/op | Uses bitmap-native signed int64 comparison. |
+| `BenchmarkBSI64CompareValueGELargeAgeFixture` | ~3.45s/op, ~500MB/op | ~168-184ms/op, ~82.3MB/op | Uses bitmap-native signed int64 comparison. |
+
+Compatibility:
+
+- Public method signatures are unchanged.
+- `CompareBigValue` and `BatchEqualBig` internally delegate to the optimized
+  int64 paths only when the BSI and query values fit in signed 64-bit space.
+- True wider-than-64-bit values continue to use the existing generic paths.
+- `BatchEqualBig` now keys values by sign and magnitude so positive and negative
+  values with the same magnitude do not collide.

--- a/roaring64/bsi64.go
+++ b/roaring64/bsi64.go
@@ -1004,6 +1004,12 @@ func (b *BSI) BatchEqual(parallelism int, values []int64) *Bitmap {
 	}
 
 	sort.Slice(vals, func(i, j int) bool { return vals[i] < vals[j] })
+	if result, ok := b.matchInt64Cube(vals, bitCount); ok {
+		if b.runOptimized {
+			result.RunOptimize()
+		}
+		return result
+	}
 	result := b.matchInt64Trie(vals, bitCount, &b.eBM, false)
 	if b.runOptimized {
 		result.RunOptimize()
@@ -1026,6 +1032,56 @@ func encodeBSI64Value(value int64, bitCount int) uint64 {
 	}
 	mask := (uint64(1) << uint(bitCount+1)) - 1
 	return uint64(value) & mask
+}
+
+func (b *BSI) matchInt64Cube(vals []uint64, bitCount int) (*Bitmap, bool) {
+	if bitCount >= 63 {
+		return nil, false
+	}
+	widthMask := (uint64(1) << uint(bitCount+1)) - 1
+	fixedOnes := vals[0] & widthMask
+	fixedZeros := ^vals[0] & widthMask
+	for _, v := range vals[1:] {
+		fixedOnes &= v
+		fixedZeros &= ^v & widthMask
+	}
+
+	variableMask := ^(fixedOnes | fixedZeros) & widthMask
+	combinations := uint64(1) << uint(countBSI64Bits(variableMask))
+	if uint64(len(vals)) != combinations {
+		return nil, false
+	}
+	for _, v := range vals {
+		if v&fixedOnes != fixedOnes || (^v)&fixedZeros != fixedZeros {
+			return nil, false
+		}
+	}
+
+	result := b.eBM.Clone()
+	for i := 0; i <= bitCount; i++ {
+		bit := uint64(1) << uint(i)
+		if variableMask&bit != 0 {
+			continue
+		}
+		if fixedOnes&bit != 0 {
+			result.And(&b.bA[i])
+		} else {
+			result.AndNot(&b.bA[i])
+		}
+		if result.IsEmpty() {
+			break
+		}
+	}
+	return result, true
+}
+
+func countBSI64Bits(value uint64) int {
+	count := 0
+	for value != 0 {
+		value &= value - 1
+		count++
+	}
+	return count
 }
 
 func (b *BSI) matchInt64Trie(vals []uint64, p int, prefix *Bitmap, owned bool) *Bitmap {

--- a/roaring64/bsi64.go
+++ b/roaring64/bsi64.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"math/big"
 	"runtime"
+	"sort"
 	"sync"
 )
 
@@ -970,23 +971,134 @@ func (b *BSI) WriteTo(w io.Writer) (n int64, err error) {
 
 // BatchEqual returns a bitmap containing the column IDs where the values are contained within the list of values provided.
 func (b *BSI) BatchEqual(parallelism int, values []int64) *Bitmap {
-	//convert list of int64 values to big.Int(s)
-	bigValues := make([]*big.Int, len(values))
-	for i, v := range values {
-		bigValues[i] = big.NewInt(v)
+	if b.eBM.IsEmpty() || len(values) == 0 {
+		return NewBitmap()
 	}
-	return b.BatchEqualBig(parallelism, bigValues)
+
+	bitCount := b.BitCount()
+	if bitCount >= 64 {
+		// Fall back to the arbitrary-precision path when the BSI has more than
+		// int64's finite bit width. This preserves correctness for big-value BSIs.
+		bigValues := make([]*big.Int, len(values))
+		for i, v := range values {
+			bigValues[i] = big.NewInt(v)
+		}
+		return b.BatchEqualBig(parallelism, bigValues)
+	}
+
+	seen := make(map[uint64]struct{}, len(values))
+	vals := make([]uint64, 0, len(values))
+	for _, v := range values {
+		if !bsi64ValueFitsBitCount(v, bitCount) {
+			continue
+		}
+		encoded := encodeBSI64Value(v, bitCount)
+		if _, ok := seen[encoded]; ok {
+			continue
+		}
+		seen[encoded] = struct{}{}
+		vals = append(vals, encoded)
+	}
+	if len(vals) == 0 {
+		return NewBitmap()
+	}
+
+	sort.Slice(vals, func(i, j int) bool { return vals[i] < vals[j] })
+	result := b.matchInt64Trie(vals, bitCount, &b.eBM, false)
+	if b.runOptimized {
+		result.RunOptimize()
+	}
+	return result
+}
+
+func bsi64ValueFitsBitCount(value int64, bitCount int) bool {
+	if bitCount >= 63 {
+		return true
+	}
+	min := -(int64(1) << uint(bitCount))
+	max := (int64(1) << uint(bitCount)) - 1
+	return value >= min && value <= max
+}
+
+func encodeBSI64Value(value int64, bitCount int) uint64 {
+	if bitCount >= 63 {
+		return uint64(value)
+	}
+	mask := (uint64(1) << uint(bitCount+1)) - 1
+	return uint64(value) & mask
+}
+
+func (b *BSI) matchInt64Trie(vals []uint64, p int, prefix *Bitmap, owned bool) *Bitmap {
+	if prefix.IsEmpty() {
+		if owned {
+			return prefix
+		}
+		return NewBitmap()
+	}
+	if p < 0 || (p < 63 && uint64(len(vals)) == uint64(1)<<uint(p+1)) {
+		if owned {
+			return prefix
+		}
+		return prefix.Clone()
+	}
+
+	mask := uint64(1) << uint(p)
+	cut := sort.Search(len(vals), func(i int) bool { return vals[i]&mask != 0 })
+	lo, hi := vals[:cut], vals[cut:]
+	switch {
+	case len(hi) == 0:
+		return b.matchInt64Trie(lo, p-1, bsi64PlaneChild(prefix, &b.bA[p], false, owned), true)
+	case len(lo) == 0:
+		return b.matchInt64Trie(hi, p-1, bsi64PlaneChild(prefix, &b.bA[p], true, owned), true)
+	default:
+		hiBM := And(prefix, &b.bA[p])
+		result := b.matchInt64Trie(lo, p-1, bsi64PlaneChild(prefix, &b.bA[p], false, owned), true)
+		result.Or(b.matchInt64Trie(hi, p-1, hiBM, true))
+		return result
+	}
+}
+
+func bsi64PlaneChild(prefix, plane *Bitmap, set, owned bool) *Bitmap {
+	if owned {
+		if set {
+			prefix.And(plane)
+		} else {
+			prefix.AndNot(plane)
+		}
+		return prefix
+	}
+	if set {
+		return And(prefix, plane)
+	}
+	return AndNot(prefix, plane)
 }
 
 // BatchEqualBig returns a bitmap containing the column IDs where the values are contained within the list of values provided.
 func (b *BSI) BatchEqualBig(parallelism int, values []*big.Int) *Bitmap {
+	if b.eBM.IsEmpty() || len(values) == 0 {
+		return NewBitmap()
+	}
 
 	valMap := make(map[string]struct{}, len(values))
 	for i := 0; i < len(values); i++ {
-		valMap[string(values[i].Bytes())] = struct{}{}
+		if values[i] == nil {
+			continue
+		}
+		valMap[batchEqualBigKey(values[i])] = struct{}{}
+	}
+	if len(valMap) == 0 {
+		return NewBitmap()
 	}
 	comp := &task{bsi: b, values: valMap}
 	return parallelExecutor(parallelism, comp, batchEqual, &b.eBM)
+}
+
+func batchEqualBigKey(value *big.Int) string {
+	bytes := value.Bytes()
+	key := make([]byte, len(bytes)+1)
+	key[0] = byte(value.Sign() + 1)
+	copy(key[1:], bytes)
+	return string(key)
 }
 
 func batchEqual(e *task, batch []uint64, resultsChan chan *Bitmap,
@@ -1002,7 +1114,7 @@ func batchEqual(e *task, batch []uint64, resultsChan chan *Bitmap,
 	for i := 0; i < len(batch); i++ {
 		cID := batch[i]
 		if value, ok := e.bsi.GetBigValue(cID); ok {
-			if _, yes := e.values[string(value.Bytes())]; yes {
+			if _, yes := e.values[batchEqualBigKey(value)]; yes {
 				results.Add(cID)
 			}
 		}

--- a/roaring64/bsi64.go
+++ b/roaring64/bsi64.go
@@ -128,6 +128,7 @@ func (b *BSI) SetBigValue(columnID uint64, value *big.Int) {
 	b.eBM.Add(columnID)
 }
 
+// SetBigMany sets value for all columns in foundSet.
 func (b *BSI) SetBigMany(foundSet *Bitmap, value *big.Int) {
 	// If max/min values are set to zero then automatically determine bit array size
 	if b.MaxValue == 0 && b.MinValue == 0 {

--- a/roaring64/bsi64.go
+++ b/roaring64/bsi64.go
@@ -349,23 +349,23 @@ type task struct {
 func (b *BSI) CompareValue(parallelism int, op Operation, valueOrStart, end int64,
 	foundSet *Bitmap) *Bitmap {
 
-	if op == EQ {
-		result := b.BatchEqual(parallelism, []int64{valueOrStart})
-		if foundSet != nil {
-			result.And(foundSet)
-		}
-		return result
-	}
-	if result, ok := b.compareInt64Value(op, valueOrStart, end, foundSet); ok {
+	if result, ok := b.compareInt64Value(parallelism, op, valueOrStart, end, foundSet); ok {
 		return result
 	}
 	return b.CompareBigValue(parallelism, op, big.NewInt(valueOrStart), big.NewInt(end), foundSet)
 }
 
-func (b *BSI) compareInt64Value(op Operation, valueOrStart, end int64, foundSet *Bitmap) (*Bitmap, bool) {
+func (b *BSI) compareInt64Value(parallelism int, op Operation, valueOrStart, end int64, foundSet *Bitmap) (*Bitmap, bool) {
 	bitCount := b.BitCount()
 	if bitCount > 63 || !bsi64ValueFitsBitCount(valueOrStart, bitCount) {
 		return nil, false
+	}
+	if op == EQ {
+		result := b.BatchEqual(parallelism, []int64{valueOrStart})
+		if foundSet != nil {
+			result.And(foundSet)
+		}
+		return result, true
 	}
 	if op == RANGE && !bsi64ValueFitsBitCount(end, bitCount) {
 		return nil, false
@@ -456,11 +456,29 @@ func (b *BSI) CompareBigValue(parallelism int, op Operation, valueOrStart, end *
 		end = b.MinMaxBig(parallelism, MAX, &b.eBM)
 	}
 
+	if result, ok := b.compareBigValueAsInt64(parallelism, op, valueOrStart, end, foundSet); ok {
+		return result
+	}
+
 	comp := &task{bsi: b, op: op, valueOrStart: valueOrStart, end: end}
 	if foundSet == nil {
 		return parallelExecutor(parallelism, comp, compareValue, &b.eBM)
 	}
 	return parallelExecutor(parallelism, comp, compareValue, foundSet)
+}
+
+func (b *BSI) compareBigValueAsInt64(parallelism int, op Operation, valueOrStart, end *big.Int, foundSet *Bitmap) (*Bitmap, bool) {
+	if valueOrStart == nil || !valueOrStart.IsInt64() {
+		return nil, false
+	}
+	endValue := int64(0)
+	if op == RANGE {
+		if end == nil || !end.IsInt64() {
+			return nil, false
+		}
+		endValue = end.Int64()
+	}
+	return b.compareInt64Value(parallelism, op, valueOrStart.Int64(), endValue, foundSet)
 }
 
 // Returns a twos complement value given a value, the return will be bit extended to 'bits' length
@@ -1222,6 +1240,10 @@ func (b *BSI) BatchEqualBig(parallelism int, values []*big.Int) *Bitmap {
 		return NewBitmap()
 	}
 
+	if intValues, ok := b.batchEqualBigValuesAsInt64(values); ok {
+		return b.BatchEqual(parallelism, intValues)
+	}
+
 	valMap := make(map[string]struct{}, len(values))
 	for i := 0; i < len(values); i++ {
 		if values[i] == nil {
@@ -1242,6 +1264,26 @@ func batchEqualBigKey(value *big.Int) string {
 	key[0] = byte(value.Sign() + 1)
 	copy(key[1:], bytes)
 	return string(key)
+}
+
+func (b *BSI) batchEqualBigValuesAsInt64(values []*big.Int) ([]int64, bool) {
+	if b.BitCount() > 63 {
+		return nil, false
+	}
+	intValues := make([]int64, 0, len(values))
+	for _, value := range values {
+		if value == nil {
+			continue
+		}
+		if !value.IsInt64() {
+			return nil, false
+		}
+		intValues = append(intValues, value.Int64())
+	}
+	if len(intValues) == 0 {
+		return nil, false
+	}
+	return intValues, true
 }
 
 func batchEqual(e *task, batch []uint64, resultsChan chan *Bitmap,

--- a/roaring64/bsi64.go
+++ b/roaring64/bsi64.go
@@ -349,7 +349,94 @@ type task struct {
 func (b *BSI) CompareValue(parallelism int, op Operation, valueOrStart, end int64,
 	foundSet *Bitmap) *Bitmap {
 
+	if op == EQ {
+		result := b.BatchEqual(parallelism, []int64{valueOrStart})
+		if foundSet != nil {
+			result.And(foundSet)
+		}
+		return result
+	}
+	if result, ok := b.compareInt64Value(op, valueOrStart, end, foundSet); ok {
+		return result
+	}
 	return b.CompareBigValue(parallelism, op, big.NewInt(valueOrStart), big.NewInt(end), foundSet)
+}
+
+func (b *BSI) compareInt64Value(op Operation, valueOrStart, end int64, foundSet *Bitmap) (*Bitmap, bool) {
+	bitCount := b.BitCount()
+	if bitCount > 63 || !bsi64ValueFitsBitCount(valueOrStart, bitCount) {
+		return nil, false
+	}
+	if op == RANGE && !bsi64ValueFitsBitCount(end, bitCount) {
+		return nil, false
+	}
+
+	universe := b.eBM.Clone()
+	if foundSet != nil {
+		universe.And(foundSet)
+	}
+	if universe.IsEmpty() {
+		return universe, true
+	}
+
+	start := transformBSI64SignedEncoding(encodeBSI64Value(valueOrStart, bitCount), bitCount)
+	less, equal := b.compareInt64LessAndEqual(start, universe)
+
+	switch op {
+	case LT:
+		return less, true
+	case LE:
+		less.Or(equal)
+		return less, true
+	case GE:
+		universe.AndNot(less)
+		return universe, true
+	case GT:
+		less.Or(equal)
+		universe.AndNot(less)
+		return universe, true
+	case RANGE:
+		if valueOrStart > end {
+			return NewBitmap(), true
+		}
+		universe.AndNot(less)
+		finish := transformBSI64SignedEncoding(encodeBSI64Value(end, bitCount), bitCount)
+		rangeLess, rangeEqual := b.compareInt64LessAndEqual(finish, universe)
+		rangeLess.Or(rangeEqual)
+		return rangeLess, true
+	default:
+		return nil, false
+	}
+}
+
+func transformBSI64SignedEncoding(encoded uint64, bitCount int) uint64 {
+	return encoded ^ (uint64(1) << uint(bitCount))
+}
+
+func (b *BSI) compareInt64LessAndEqual(target uint64, universe *Bitmap) (*Bitmap, *Bitmap) {
+	less := NewBitmap()
+	equalPrefix := universe.Clone()
+	for i := b.BitCount(); i >= 0; i-- {
+		targetBitSet := target&(uint64(1)<<uint(i)) != 0
+		if targetBitSet {
+			less.Or(b.bsi64TransformedPlaneChild(equalPrefix, i, false, false))
+			equalPrefix = b.bsi64TransformedPlaneChild(equalPrefix, i, true, true)
+		} else {
+			equalPrefix = b.bsi64TransformedPlaneChild(equalPrefix, i, false, true)
+		}
+		if equalPrefix.IsEmpty() {
+			break
+		}
+	}
+	return less, equalPrefix
+}
+
+func (b *BSI) bsi64TransformedPlaneChild(prefix *Bitmap, planeIndex int, set, owned bool) *Bitmap {
+	planeSet := set
+	if planeIndex == b.BitCount() {
+		planeSet = !planeSet
+	}
+	return bsi64PlaneChild(prefix, &b.bA[planeIndex], planeSet, owned)
 }
 
 // CompareBigValue compares value.

--- a/roaring64/bsi64_batch_equal_test.go
+++ b/roaring64/bsi64_batch_equal_test.go
@@ -1,0 +1,198 @@
+package roaring64
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func expectedBSI64BatchEqual(bsi *BSI, query []int64) *Bitmap {
+	expected := NewBitmap()
+	want := make(map[int64]struct{}, len(query))
+	for _, q := range query {
+		want[q] = struct{}{}
+	}
+	iter := bsi.GetExistenceBitmap().Iterator()
+	for iter.HasNext() {
+		col := iter.Next()
+		val, ok := bsi.GetValue(col)
+		if ok {
+			if _, hit := want[val]; hit {
+				expected.Add(col)
+			}
+		}
+	}
+	return expected
+}
+
+func TestBSI64BatchEqualEdgeCases(t *testing.T) {
+	bsi := NewDefaultBSI()
+	res := bsi.BatchEqual(0, nil)
+	assert.True(t, res.IsEmpty())
+
+	res = bsi.BatchEqual(0, []int64{})
+	assert.True(t, res.IsEmpty())
+
+	bsi.SetValue(10, 42)
+	bsi.SetValue(20, 100)
+	bsi.SetValue(30, 42)
+	bsi.SetValue(40, -5)
+	bsi.SetValue(50, 5)
+
+	res = bsi.BatchEqual(0, []int64{42})
+	assert.Equal(t, uint64(2), res.GetCardinality())
+	assert.True(t, res.Contains(10))
+	assert.True(t, res.Contains(30))
+
+	res = bsi.BatchEqual(0, []int64{42, 100, 42, 999})
+	assert.Equal(t, uint64(3), res.GetCardinality())
+	assert.True(t, res.Contains(10))
+	assert.True(t, res.Contains(20))
+	assert.True(t, res.Contains(30))
+
+	res = bsi.BatchEqual(0, []int64{-5})
+	assert.Equal(t, uint64(1), res.GetCardinality())
+	assert.True(t, res.Contains(40))
+	assert.False(t, res.Contains(50), "negative and positive values with the same magnitude must not collide")
+
+	res = bsi.BatchEqual(0, []int64{5})
+	assert.Equal(t, uint64(1), res.GetCardinality())
+	assert.True(t, res.Contains(50))
+	assert.False(t, res.Contains(40), "positive and negative values with the same magnitude must not collide")
+
+	bsi62 := NewBSI(1<<62, 0)
+	bsi62.SetValue(10, 5)
+	res = bsi62.BatchEqual(0, []int64{5})
+	assert.Equal(t, uint64(1), res.GetCardinality())
+	assert.True(t, res.Contains(10))
+}
+
+func TestBSI64BatchEqualSubBitWidthMatchesGetValue(t *testing.T) {
+	bsi := NewBSI(100, 0)
+	assert.Equal(t, 7, bsi.BitCount())
+
+	bsi.SetValue(10, 42)
+	bsi.SetValue(20, 99)
+
+	for _, query := range [][]int64{{-5}, {200}, {-5, 42, 200}} {
+		expected := expectedBSI64BatchEqual(bsi, query)
+		actual := bsi.BatchEqual(0, query)
+		assert.True(t, actual.Equals(expected), "query %v expected %v got %v", query, expected.ToArray(), actual.ToArray())
+	}
+}
+
+func TestBSI64BatchEqualResultIsolation(t *testing.T) {
+	bsi := NewDefaultBSI()
+	bsi.SetValue(10, 42)
+	bsi.SetValue(20, 100)
+
+	res := bsi.BatchEqual(0, []int64{42})
+	assert.True(t, res.Contains(10))
+
+	res.Add(999)
+	res.Remove(10)
+
+	assert.False(t, bsi.GetExistenceBitmap().Contains(999))
+	assert.True(t, bsi.GetExistenceBitmap().Contains(10))
+
+	val, ok := bsi.GetValue(10)
+	assert.True(t, ok)
+	assert.Equal(t, int64(42), val)
+
+	_, ok = bsi.GetValue(999)
+	assert.False(t, ok)
+}
+
+func TestBSI64BatchEqualConsistentWithGetValue(t *testing.T) {
+	rg := rand.New(rand.NewSource(42))
+	for run := 0; run < 15; run++ {
+		bsi := NewDefaultBSI()
+		numCols := rg.Intn(1000) + 10
+		for col := 0; col < numCols; col++ {
+			if rg.Float64() < 0.8 {
+				val := rg.Int63n(500) - 250
+				bsi.SetValue(uint64(col), val)
+			}
+		}
+
+		querySizes := []int{rg.Intn(10) + 1, rg.Intn(50) + 50, rg.Intn(200) + 100}
+		for _, querySize := range querySizes {
+			query := make([]int64, querySize)
+			for i := range query {
+				query[i] = rg.Int63n(600) - 300
+			}
+			expected := expectedBSI64BatchEqual(bsi, query)
+
+			for _, parallelism := range []int{0, 1, 2, 4} {
+				actual := bsi.BatchEqual(parallelism, query)
+				if !actual.Equals(expected) {
+					t.Fatalf("run=%d querySize=%d parallelism=%d query=%v expected=%v actual=%v",
+						run, querySize, parallelism, query, expected.ToArray(), actual.ToArray())
+				}
+			}
+		}
+	}
+}
+
+func TestBSI64BatchEqualExistenceAuthority(t *testing.T) {
+	ebm := BitmapOf(1)
+	plane := BitmapOf(1, 2)
+	ebmData, err := ebm.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+	planeData, err := plane.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+	bsi := NewDefaultBSI()
+	if err := bsi.UnmarshalBinary([][]byte{ebmData, planeData}); err != nil {
+		t.Fatal(err)
+	}
+	res := bsi.BatchEqual(0, []int64{1})
+	assert.True(t, res.Contains(1))
+	assert.False(t, res.Contains(2), "column 2 is not in eBM and must not match")
+
+	large := setupLargeBSI(t)
+	if large == nil {
+		t.Skip("skipping, large BSI setup failed")
+	}
+	for _, vals := range [][]int64{{16}, {55, 57}, {0, 1, 2, 3}} {
+		res := large.BatchEqual(0, vals)
+		outside := AndNot(res, large.GetExistenceBitmap())
+		assert.True(t, outside.IsEmpty(), "BatchEqual(%v) returned %d columns outside eBM", vals, outside.GetCardinality())
+	}
+}
+
+func BenchmarkBSI64BatchEqualLargeAgeFixture(b *testing.B) {
+	bsi := setupLargeBSI(b)
+	if bsi == nil {
+		b.Skip("skipping, large BSI setup failed")
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		res := bsi.BatchEqual(0, []int64{55, 57})
+		_ = res
+	}
+}
+
+func BenchmarkBSI64BatchEqualM128(b *testing.B)          { benchmarkBSI64BatchEqualM(b, 128, 1) }
+func BenchmarkBSI64BatchEqualM128Scattered(b *testing.B) { benchmarkBSI64BatchEqualM(b, 128, 2) }
+func BenchmarkBSI64BatchEqualM200(b *testing.B)          { benchmarkBSI64BatchEqualM(b, 200, 1) }
+
+func benchmarkBSI64BatchEqualM(b *testing.B, m int, stride int64) {
+	bsi := setupLargeBSI(b)
+	if bsi == nil {
+		b.Skip("skipping, large BSI setup failed")
+	}
+	vals := make([]int64, m)
+	for i := range vals {
+		vals[i] = int64(i)*stride + stride - 1
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		res := bsi.BatchEqual(0, vals)
+		_ = res
+	}
+}

--- a/roaring64/bsi64_batch_equal_test.go
+++ b/roaring64/bsi64_batch_equal_test.go
@@ -135,6 +135,22 @@ func TestBSI64BatchEqualConsistentWithGetValue(t *testing.T) {
 	}
 }
 
+func TestBSI64BatchEqualBitCubePattern(t *testing.T) {
+	bsi := NewDefaultBSI()
+	for col := uint64(0); col < 512; col++ {
+		bsi.SetValue(col, int64(col%256))
+	}
+
+	odds := make([]int64, 0, 128)
+	for v := int64(1); v < 256; v += 2 {
+		odds = append(odds, v)
+	}
+
+	expected := expectedBSI64BatchEqual(bsi, odds)
+	actual := bsi.BatchEqual(0, odds)
+	assert.True(t, actual.Equals(expected), "expected %v got %v", expected.ToArray(), actual.ToArray())
+}
+
 func TestBSI64BatchEqualExistenceAuthority(t *testing.T) {
 	ebm := BitmapOf(1)
 	plane := BitmapOf(1, 2)

--- a/roaring64/bsi64_batch_equal_test.go
+++ b/roaring64/bsi64_batch_equal_test.go
@@ -1,6 +1,7 @@
 package roaring64
 
 import (
+	"math/big"
 	"math/rand"
 	"testing"
 
@@ -189,6 +190,19 @@ func BenchmarkBSI64BatchEqualLargeAgeFixture(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		res := bsi.BatchEqual(0, []int64{55, 57})
+		_ = res
+	}
+}
+
+func BenchmarkBSI64BatchEqualBigLargeAgeFixture(b *testing.B) {
+	bsi := setupLargeBSI(b)
+	if bsi == nil {
+		b.Skip("skipping, large BSI setup failed")
+	}
+	values := []*big.Int{big.NewInt(55), big.NewInt(57)}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		res := bsi.BatchEqualBig(0, values)
 		_ = res
 	}
 }

--- a/roaring64/bsi64_compare_benchmark_test.go
+++ b/roaring64/bsi64_compare_benchmark_test.go
@@ -1,6 +1,7 @@
 package roaring64
 
 import (
+	"math/big"
 	"math/rand"
 	"testing"
 
@@ -107,6 +108,19 @@ func BenchmarkBSI64CompareValueEQLargeAgeFixture(b *testing.B) {
 	}
 }
 
+func BenchmarkBSI64CompareBigValueEQLargeAgeFixture(b *testing.B) {
+	bsi := setupLargeBSI(b)
+	if bsi == nil {
+		b.Skip("skipping, large BSI setup failed")
+	}
+	value := big.NewInt(55)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		res := bsi.CompareBigValue(0, EQ, value, nil, nil)
+		_ = res
+	}
+}
+
 func BenchmarkBSI64CompareValueEQFoundSetLargeAgeFixture(b *testing.B) {
 	bsi := setupLargeBSI(b)
 	if bsi == nil {
@@ -116,6 +130,20 @@ func BenchmarkBSI64CompareValueEQFoundSetLargeAgeFixture(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		res := bsi.CompareValue(0, EQ, 55, 0, foundSet)
+		_ = res
+	}
+}
+
+func BenchmarkBSI64CompareBigValueEQFoundSetLargeAgeFixture(b *testing.B) {
+	bsi := setupLargeBSI(b)
+	if bsi == nil {
+		b.Skip("skipping, large BSI setup failed")
+	}
+	foundSet := bsi.CompareBigValue(0, RANGE, big.NewInt(40), big.NewInt(70), nil)
+	value := big.NewInt(55)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		res := bsi.CompareBigValue(0, EQ, value, nil, foundSet)
 		_ = res
 	}
 }
@@ -132,6 +160,20 @@ func BenchmarkBSI64CompareValueRangeLargeAgeFixture(b *testing.B) {
 	}
 }
 
+func BenchmarkBSI64CompareBigValueRangeLargeAgeFixture(b *testing.B) {
+	bsi := setupLargeBSI(b)
+	if bsi == nil {
+		b.Skip("skipping, large BSI setup failed")
+	}
+	start := big.NewInt(40)
+	end := big.NewInt(70)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		res := bsi.CompareBigValue(0, RANGE, start, end, nil)
+		_ = res
+	}
+}
+
 func BenchmarkBSI64CompareValueGELargeAgeFixture(b *testing.B) {
 	bsi := setupLargeBSI(b)
 	if bsi == nil {
@@ -140,6 +182,19 @@ func BenchmarkBSI64CompareValueGELargeAgeFixture(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		res := bsi.CompareValue(0, GE, 55, 0, nil)
+		_ = res
+	}
+}
+
+func BenchmarkBSI64CompareBigValueGELargeAgeFixture(b *testing.B) {
+	bsi := setupLargeBSI(b)
+	if bsi == nil {
+		b.Skip("skipping, large BSI setup failed")
+	}
+	value := big.NewInt(55)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		res := bsi.CompareBigValue(0, GE, value, nil, nil)
 		_ = res
 	}
 }

--- a/roaring64/bsi64_compare_benchmark_test.go
+++ b/roaring64/bsi64_compare_benchmark_test.go
@@ -1,0 +1,145 @@
+package roaring64
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func expectedBSI64CompareValue(bsi *BSI, op Operation, valueOrStart, end int64, foundSet *Bitmap) *Bitmap {
+	expected := NewBitmap()
+	source := bsi.GetExistenceBitmap()
+	if foundSet != nil {
+		source = And(source, foundSet)
+	}
+	iter := source.Iterator()
+	for iter.HasNext() {
+		col := iter.Next()
+		val, ok := bsi.GetValue(col)
+		if !ok {
+			continue
+		}
+		switch op {
+		case LT:
+			if val < valueOrStart {
+				expected.Add(col)
+			}
+		case LE:
+			if val <= valueOrStart {
+				expected.Add(col)
+			}
+		case EQ:
+			if val == valueOrStart {
+				expected.Add(col)
+			}
+		case GE:
+			if val >= valueOrStart {
+				expected.Add(col)
+			}
+		case GT:
+			if val > valueOrStart {
+				expected.Add(col)
+			}
+		case RANGE:
+			if val >= valueOrStart && val <= end {
+				expected.Add(col)
+			}
+		default:
+			panic("unsupported test operation")
+		}
+	}
+	return expected
+}
+
+func TestBSI64CompareValueConsistentWithGetValue(t *testing.T) {
+	rg := rand.New(rand.NewSource(84))
+	for run := 0; run < 15; run++ {
+		bsi := NewDefaultBSI()
+		numCols := rg.Intn(1000) + 10
+		for col := 0; col < numCols; col++ {
+			if rg.Float64() < 0.8 {
+				bsi.SetValue(uint64(col), rg.Int63n(500)-250)
+			}
+		}
+
+		foundSet := NewBitmap()
+		iter := bsi.GetExistenceBitmap().Iterator()
+		for iter.HasNext() {
+			col := iter.Next()
+			if col%3 != 0 {
+				foundSet.Add(col)
+			}
+		}
+
+		cases := []struct {
+			op    Operation
+			start int64
+			end   int64
+		}{
+			{LT, -17, 0},
+			{LE, -17, 0},
+			{EQ, -17, 0},
+			{GE, -17, 0},
+			{GT, -17, 0},
+			{RANGE, -25, 25},
+		}
+		for _, tc := range cases {
+			for _, fs := range []*Bitmap{nil, foundSet} {
+				expected := expectedBSI64CompareValue(bsi, tc.op, tc.start, tc.end, fs)
+				actual := bsi.CompareValue(0, tc.op, tc.start, tc.end, fs)
+				assert.True(t, actual.Equals(expected), "run=%d op=%d foundSet=%v expected=%v actual=%v",
+					run, tc.op, fs != nil, expected.ToArray(), actual.ToArray())
+			}
+		}
+	}
+}
+
+func BenchmarkBSI64CompareValueEQLargeAgeFixture(b *testing.B) {
+	bsi := setupLargeBSI(b)
+	if bsi == nil {
+		b.Skip("skipping, large BSI setup failed")
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		res := bsi.CompareValue(0, EQ, 55, 0, nil)
+		_ = res
+	}
+}
+
+func BenchmarkBSI64CompareValueEQFoundSetLargeAgeFixture(b *testing.B) {
+	bsi := setupLargeBSI(b)
+	if bsi == nil {
+		b.Skip("skipping, large BSI setup failed")
+	}
+	foundSet := bsi.CompareValue(0, RANGE, 40, 70, nil)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		res := bsi.CompareValue(0, EQ, 55, 0, foundSet)
+		_ = res
+	}
+}
+
+func BenchmarkBSI64CompareValueRangeLargeAgeFixture(b *testing.B) {
+	bsi := setupLargeBSI(b)
+	if bsi == nil {
+		b.Skip("skipping, large BSI setup failed")
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		res := bsi.CompareValue(0, RANGE, 40, 70, nil)
+		_ = res
+	}
+}
+
+func BenchmarkBSI64CompareValueGELargeAgeFixture(b *testing.B) {
+	bsi := setupLargeBSI(b)
+	if bsi == nil {
+		b.Skip("skipping, large BSI setup failed")
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		res := bsi.CompareValue(0, GE, 55, 0, nil)
+		_ = res
+	}
+}

--- a/roaring64/bsi64_compare_benchmark_test.go
+++ b/roaring64/bsi64_compare_benchmark_test.go
@@ -96,6 +96,110 @@ func TestBSI64CompareValueConsistentWithGetValue(t *testing.T) {
 	}
 }
 
+func TestBSI64CompareBigValueConsistentWithGetBigValue(t *testing.T) {
+	rg := rand.New(rand.NewSource(85))
+	for run := 0; run < 15; run++ {
+		bsi := NewDefaultBSI()
+		numCols := rg.Intn(1000) + 10
+		for col := 0; col < numCols; col++ {
+			if rg.Float64() < 0.8 {
+				bsi.SetValue(uint64(col), rg.Int63n(500)-250)
+			}
+		}
+
+		foundSet := NewBitmap()
+		iter := bsi.GetExistenceBitmap().Iterator()
+		for iter.HasNext() {
+			col := iter.Next()
+			if col%3 != 0 {
+				foundSet.Add(col)
+			}
+		}
+
+		cases := []struct {
+			op    Operation
+			start int64
+			end   int64
+		}{
+			{LT, -17, 0},
+			{LE, -17, 0},
+			{EQ, -17, 0},
+			{GE, -17, 0},
+			{GT, -17, 0},
+			{RANGE, -25, 25},
+		}
+		for _, tc := range cases {
+			for _, fs := range []*Bitmap{nil, foundSet} {
+				expected := expectedBSI64CompareBigValue(bsi, tc.op, big.NewInt(tc.start), big.NewInt(tc.end), fs)
+				actual := bsi.CompareBigValue(0, tc.op, big.NewInt(tc.start), big.NewInt(tc.end), fs)
+				assert.True(t, actual.Equals(expected), "run=%d op=%d foundSet=%v expected=%v actual=%v",
+					run, tc.op, fs != nil, expected.ToArray(), actual.ToArray())
+			}
+		}
+	}
+}
+
+func expectedBSI64CompareBigValue(bsi *BSI, op Operation, valueOrStart, end *big.Int, foundSet *Bitmap) *Bitmap {
+	expected := NewBitmap()
+	source := bsi.GetExistenceBitmap()
+	if foundSet != nil {
+		source = And(source, foundSet)
+	}
+	iter := source.Iterator()
+	for iter.HasNext() {
+		col := iter.Next()
+		val, ok := bsi.GetBigValue(col)
+		if !ok {
+			continue
+		}
+		switch op {
+		case LT:
+			if val.Cmp(valueOrStart) < 0 {
+				expected.Add(col)
+			}
+		case LE:
+			if val.Cmp(valueOrStart) <= 0 {
+				expected.Add(col)
+			}
+		case EQ:
+			if val.Cmp(valueOrStart) == 0 {
+				expected.Add(col)
+			}
+		case GE:
+			if val.Cmp(valueOrStart) >= 0 {
+				expected.Add(col)
+			}
+		case GT:
+			if val.Cmp(valueOrStart) > 0 {
+				expected.Add(col)
+			}
+		case RANGE:
+			if val.Cmp(valueOrStart) >= 0 && val.Cmp(end) <= 0 {
+				expected.Add(col)
+			}
+		default:
+			panic("unsupported test operation")
+		}
+	}
+	return expected
+}
+
+func TestBSI64CompareBigValueFallsBackForBigWidth(t *testing.T) {
+	bsi := NewDefaultBSI()
+	base := new(big.Int).Lsh(big.NewInt(1), 80)
+	below := new(big.Int).Sub(base, big.NewInt(1))
+	above := new(big.Int).Add(base, big.NewInt(1))
+	bsi.SetBigValue(1, below)
+	bsi.SetBigValue(2, base)
+	bsi.SetBigValue(3, above)
+
+	eq := bsi.CompareBigValue(0, EQ, base, nil, nil)
+	assert.True(t, eq.Equals(BitmapOf(2)))
+
+	rng := bsi.CompareBigValue(0, RANGE, base, above, nil)
+	assert.True(t, rng.Equals(BitmapOf(2, 3)))
+}
+
 func BenchmarkBSI64CompareValueEQLargeAgeFixture(b *testing.B) {
 	bsi := setupLargeBSI(b)
 	if bsi == nil {

--- a/roaring64/roaring64.go
+++ b/roaring64/roaring64.go
@@ -1241,6 +1241,7 @@ func (rb *Bitmap) GetSerializedSizeInBytes() uint64 {
 	return rb.highlowcontainer.serializedSizeInBytes()
 }
 
+// Validate checks whether the bitmap's internal containers are coherent.
 func (rb *Bitmap) Validate() error {
 	return rb.highlowcontainer.validate()
 }

--- a/roaring64/roaringarray64.go
+++ b/roaring64/roaringarray64.go
@@ -14,7 +14,9 @@ type roaringArray64 struct {
 }
 
 var (
-	ErrKeySortOrder          = errors.New("keys were out of order")
+	// ErrKeySortOrder reports that container keys are out of order.
+	ErrKeySortOrder = errors.New("keys were out of order")
+	// ErrCardinalityConstraint reports inconsistent array cardinality metadata.
 	ErrCardinalityConstraint = errors.New("size of arrays was not coherent")
 )
 


### PR DESCRIPTION
## Description

Optimizes `roaring64.BSI` equality, batch equality, and int64-width comparison paths while preserving the existing public API. The BigValue APIs now internally use the optimized int64 paths when safe, while true wider-than-64-bit values continue to use the existing generic behavior.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Performance improvement
- [ ] Code refactoring
- [x] Documentation update
- [x] Test improvements
- [ ] Build/CI changes

## Changes Made

### What was changed?

- Added bitmap-native `BatchEqual` execution for int64-width `roaring64.BSI` values.
- Added a cube-pattern fast path for complete bit-pattern query sets, such as scattered odd-value lists.
- Routed `CompareValue` through bitmap-native signed int64 comparison logic for `LT`, `LE`, `EQ`, `GE`, `GT`, and `RANGE`.
- Updated `CompareBigValue` and `BatchEqualBig` to delegate to optimized int64 paths when the BSI and query values fit in signed 64-bit space.
- Preserved generic fallback behavior for true wider-than-64-bit values.
- Fixed `BatchEqualBig` value matching so positive and negative values with the same magnitude, such as `5` and `-5`, do not collide.
- Added BSI64 correctness tests, BigValue compatibility tests, benchmark coverage, and benchmark notes.
- Cleaned `roaring64` golint comments for touched package readiness.

### Why was this changed?

The existing BSI64 equality and comparison paths materialized or inspected values row-by-row, which was very expensive for common analytical query shapes. These changes keep the public API stable while allowing int64-width operations to use bitmap algebra directly.

### Compatibility

- No public method signatures were changed.
- Existing `CompareValue`, `CompareBigValue`, `BatchEqual`, and `BatchEqualBig` callers continue to work.
- `CompareBigValue` and `BatchEqualBig` only delegate to optimized int64 logic when safe.
- True big values still use the existing generic paths.

### Verification

Run:

    go test ./... -count=1
    golint ./roaring64
    go test ./roaring64 -run '^$' -bench 'BenchmarkBSI64BatchEqual|BenchmarkBSI64Compare(Big)?Value' -benchmem -count 5

Benchmark details are documented in `roaring64/BSI_BENCHMARKS.md`.
- 

### Why was it changed?
- 

### How was it changed?
- 

## Testing

Please add a unit test if you are fixing a bug.

You must run 

```
go test
```

## Formatting

Please run 

```
go fmt
```

## Fuzzing

Please run our fuzzer on your changes.


1. Generate initial smat corpus:
```
go test -tags=gofuzz -run=TestGenerateSmatCorpus
```
You should see a directory `workdir` created with initial corpus files.

2. Run the fuzz test:
```
go test -run='^$' -fuzz=FuzzSmat -fuzztime=300s -timeout=60s
```

Adjust `-fuzztime` as needed for longer or shorter runs. If crashes are found,
check the test output and the reproducer files in the `workdir` directory.
You may copy the reproducers to roaring_tests.go

## Performance Impact

If applicable, describe any performance implications of these changes and include benchmark results.

### Running Benchmarks

This project includes comprehensive benchmarks. Please run relevant benchmarks before and after your changes:

#### Basic Benchmarks
```bash
# Run all benchmarks
go test -bench=. -run=^$

# Run with memory allocation statistics
go test -bench=. -benchmem -run=^$

# Run specific benchmark
go test -bench=BenchmarkIteratorAlloc -run=^$
```

#### Parallel Benchmarks
```bash
# Run parallel processing benchmarks
go test -bench=BenchmarkIntersectionLargeParallel -run=^$
```

#### Real Data Benchmarks
```bash
# Requires real-roaring-datasets (run: go get github.com/RoaringBitmap/real-roaring-datasets)
BENCH_REAL_DATA=1 go test -bench=BenchmarkRealData -run=^$
```

#### Benchmark Results Format
Please include before/after results in the following format:
```
BenchmarkName-8    1000000    1234 ns/op    567 B/op    12 allocs/op
```

### Performance Analysis
- Compare benchmark results before and after changes
- Note any significant improvements or regressions
- Include memory usage changes if relevant
- Mention any trade-offs (e.g., memory vs speed)

## Breaking Changes

If this PR introduces breaking changes, please describe them and the migration path:
- 


## Related Issues

Fixes # (issue number)
Related to # (issue number)

## Additional Notes

Any additional information or context about this pull request.
