### PR TITLE
NEON-vectorized union2by2

### DIFF
--- a/roaring_test.go
+++ b/roaring_test.go
@@ -4166,3 +4166,60 @@ func TestBitmapOrBulkMergeCopyOnWriteTailOwnership(t *testing.T) {
 		t.Fatalf("source became invalid after tail mutations: %v", err)
 	}
 }
+
+// Self-union must leave the bitmap unchanged. Spare capacity sends iorArray
+// through its reuse branch, where set2 and the output share a backing array.
+func TestOrSelfInPlace(t *testing.T) {
+	buildRange := func(n int) *Bitmap {
+		rb := New()
+		for v := 0; v < n; v++ {
+			rb.Add(uint32(v))
+		}
+		return rb
+	}
+	cases := []struct {
+		name  string
+		build func() *Bitmap
+	}{
+		{"small", func() *Bitmap {
+			rb := buildRange(1024)
+			rb.RemoveRange(383, 1024)
+			return rb
+		}},
+		{"neon-sized", func() *Bitmap {
+			rb := buildRange(1024)
+			rb.RemoveRange(384, 1024)
+			return rb
+		}},
+		{"strided-exact-cap", func() *Bitmap {
+			rb := buildRange(1024)
+			for v := 1; v < 1024; v += 2 {
+				rb.Remove(uint32(v))
+			}
+			return rb
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rb := tc.build()
+			ac, ok := rb.highlowcontainer.getContainerAtIndex(0).(*arrayContainer)
+			if !ok || cap(ac.content) < 2*len(ac.content) {
+				t.Fatal("container no longer hits iorArray's capacity-reuse branch")
+			}
+			want := rb.ToArray()
+			rb.Or(rb)
+			if err := rb.Validate(); err != nil {
+				t.Fatalf("invalid after self-Or: %v", err)
+			}
+			got := rb.ToArray()
+			if len(got) != len(want) {
+				t.Fatalf("self-Or changed cardinality: got %d want %d", len(got), len(want))
+			}
+			for i := range want {
+				if got[i] != want[i] {
+					t.Fatalf("self-Or corrupted index %d: got %d want %d", i, got[i], want[i])
+				}
+			}
+		})
+	}
+}

--- a/setutil_arm64.go
+++ b/setutil_arm64.go
@@ -46,6 +46,13 @@ func union2by2(set1 []uint16, set2 []uint16, buffer []uint16) int {
 func unionNEON(set1 []uint16, set2 []uint16, buffer []uint16) int {
 	// Callers such as lazyorArray pass a zero-length buffer with capacity.
 	buffer = buffer[:cap(buffer)]
+	// iorArray's in-place self-union passes set2 and buffer sharing a
+	// backing array from offset 0, with set1 a copy of set2. The kernel's
+	// block stores would clobber unread set2; on identical inputs the
+	// scalar merge never writes a position it has not already read.
+	if &buffer[0] == &set2[0] {
+		return union2by2scalar(set1, set2, buffer)
+	}
 	var leftover [16]uint16
 	outLen, pos1, pos2, ll := unionKernelNEON(set1, set2, buffer, &uniqshuf[0], &leftover)
 	// The leftovers and the exhausted input's tail are two sorted runs.

--- a/setutil_arm64.go
+++ b/setutil_arm64.go
@@ -32,8 +32,8 @@ func buildUniqshuf() (t [256 * 16]byte) {
 	return t
 }
 
-// Below this size the scalar path wins (BenchmarkUnion2By2).
-const neonUnionThreshold = 384
+// Below this the kernel's setup cost usually loses to the scalar merge.
+const neonUnionThreshold = 256
 
 func union2by2(set1 []uint16, set2 []uint16, buffer []uint16) int {
 	if len(set1) < neonUnionThreshold || len(set2) < neonUnionThreshold {

--- a/setutil_arm64.go
+++ b/setutil_arm64.go
@@ -4,4 +4,114 @@
 package roaring
 
 //go:noescape
-func union2by2(set1 []uint16, set2 []uint16, buffer []uint16) (size int)
+func union2by2scalar(set1 []uint16, set2 []uint16, buffer []uint16) (size int)
+
+//go:noescape
+func unionKernelNEON(set1, set2, buffer []uint16, shuf *byte, leftover *[16]uint16) (outLen, pos1, pos2, leftoverLen int)
+
+// uniqshuf[m] is the TBL index vector that compacts the lanes not set in
+// mask m to the front. A variable initializer, not init(): package-level
+// initializers in other files run first and would read a zero table.
+var uniqshuf = buildUniqshuf()
+
+func buildUniqshuf() (t [256 * 16]byte) {
+	for m := 0; m < 256; m++ {
+		pos := 0
+		for lane := 0; lane < 8; lane++ {
+			if m&(1<<lane) == 0 {
+				t[m*16+pos*2] = byte(2 * lane)
+				t[m*16+pos*2+1] = byte(2*lane + 1)
+				pos++
+			}
+		}
+		for ; pos < 8; pos++ {
+			t[m*16+pos*2] = 0xFF
+			t[m*16+pos*2+1] = 0xFF
+		}
+	}
+	return t
+}
+
+// Below this size the scalar path wins (BenchmarkUnion2By2).
+const neonUnionThreshold = 384
+
+func union2by2(set1 []uint16, set2 []uint16, buffer []uint16) int {
+	if len(set1) < neonUnionThreshold || len(set2) < neonUnionThreshold {
+		return union2by2scalar(set1, set2, buffer)
+	}
+	return unionNEON(set1, set2, buffer)
+}
+
+// unionNEON requires at least 8 elements in each input.
+func unionNEON(set1 []uint16, set2 []uint16, buffer []uint16) int {
+	// Callers such as lazyorArray pass a zero-length buffer with capacity.
+	buffer = buffer[:cap(buffer)]
+	var leftover [16]uint16
+	outLen, pos1, pos2, ll := unionKernelNEON(set1, set2, buffer, &uniqshuf[0], &leftover)
+	// The leftovers and the exhausted input's tail are two sorted runs.
+	var tmp [16]uint16
+	if pos1 == len(set1)/8 {
+		m := scalarMergeUnion(leftover[:ll], set1[8*pos1:], tmp[:])
+		outLen += mergeUnionLookahead(tmp[:m], set2[8*pos2:], buffer[outLen:])
+	} else {
+		m := scalarMergeUnion(leftover[:ll], set2[8*pos2:], tmp[:])
+		outLen += mergeUnionLookahead(tmp[:m], set1[8*pos1:], buffer[outLen:])
+	}
+	return outLen
+}
+
+// mergeUnionLookahead reads b in 8-element chunks ahead of the writes:
+// iorArray aliases set1 above the write region, and writes can lead the
+// b reads by up to 7 elements there.
+func mergeUnionLookahead(a, b, out []uint16) int {
+	i, k := 0, 0
+	for j := 0; j < len(b); {
+		// The copy cannot pass the read frontier in the aliased case.
+		if i == len(a) {
+			return k + copy(out[k:], b[j:])
+		}
+		var w [8]uint16
+		c := copy(w[:], b[j:])
+		j += c
+		for x := 0; x < c; x++ {
+			for i < len(a) && a[i] < w[x] {
+				out[k] = a[i]
+				i++
+				k++
+			}
+			if i < len(a) && a[i] == w[x] {
+				i++
+			}
+			out[k] = w[x]
+			k++
+		}
+	}
+	for ; i < len(a); i++ {
+		out[k] = a[i]
+		k++
+	}
+	return k
+}
+
+// scalarMergeUnion merges two sorted duplicate-free slices into out.
+func scalarMergeUnion(a, b, out []uint16) int {
+	i, j, k := 0, 0, 0
+	for i < len(a) && j < len(b) {
+		switch {
+		case a[i] < b[j]:
+			out[k] = a[i]
+			i++
+		case b[j] < a[i]:
+			out[k] = b[j]
+			j++
+		default:
+			out[k] = a[i]
+			i++
+			j++
+		}
+		k++
+	}
+	k += copy(out[k:], a[i:])
+	k += copy(out[k:], b[j:])
+	return k
+}

--- a/setutil_arm64.s
+++ b/setutil_arm64.s
@@ -34,7 +34,7 @@
  // Right now it moves the necessary shorts so that the remaining count
  // is a multiple of 4 and then copies 64 bits at a time.
 
-TEXT ·union2by2(SB), NOSPLIT, $0-80
+TEXT ·union2by2scalar(SB), NOSPLIT, $0-80
 	// R0, R1, and R2 for the pointers to the three slices
 	MOVD set1+0(FP), R0
 	MOVD set2+24(FP), R1

--- a/setutil_neon_arm64.s
+++ b/setutil_neon_arm64.s
@@ -1,0 +1,146 @@
+// +build arm64,!gccgo,!appengine
+
+#include "textflag.h"
+
+// NEON-vectorized main loop for union2by2 (issue #288).
+// Port of CRoaring's union_vector16 with a transposed-bitonic merge network
+// and a branchless main-loop block select. Processes full 8-element blocks from both
+// inputs while both have blocks remaining; the Go wrapper handles tails.
+//
+// Register use:
+//   R0/R1 cursors into set1/set2, R3/R4 their full-block end addresses,
+//   R2 output cursor, R5 output base, R6 uniqshuf table, R7 leftover ptr,
+//   R12 = 0x0101010101010101, R13 = 0x0102040810204080, R19 = 8.
+//   V0 carry (8 largest so far), V1 last-stored vector, V2 fresh/min.
+
+// Merge sorted V2 (fresh) with sorted V0 (carry):
+// V2 <- 8 smallest (sorted), V0 <- 8 largest (sorted). Clobbers V3-V7.
+// Transposed bitonic 16-merge. The reversal is applied to the fresh input
+// rather than the carry so it stays off the loop-carried dependency chain.
+#define MERGE \
+	VREV64 V2.H8, V3.H8                \
+	VEXT   $8, V3.B16, V3.B16, V3.B16  \
+	VUMIN  V3.H8, V0.H8, V4.H8         \
+	VUMAX  V3.H8, V0.H8, V5.H8         \
+	VTRN1  V5.D2, V4.D2, V6.D2         \
+	VTRN2  V5.D2, V4.D2, V7.D2         \
+	VUMIN  V7.H8, V6.H8, V4.H8         \
+	VUMAX  V7.H8, V6.H8, V5.H8         \
+	VTRN1  V5.S4, V4.S4, V6.S4         \
+	VTRN2  V5.S4, V4.S4, V7.S4         \
+	VUMIN  V7.H8, V6.H8, V4.H8         \
+	VUMAX  V7.H8, V6.H8, V5.H8         \
+	VTRN1  V5.H8, V4.H8, V6.H8         \
+	VTRN2  V5.H8, V4.H8, V7.H8         \
+	VUMIN  V7.H8, V6.H8, V4.H8         \
+	VUMAX  V7.H8, V6.H8, V5.H8         \
+	VZIP1  V5.H8, V4.H8, V2.H8         \
+	VZIP2  V5.H8, V4.H8, V0.H8
+
+// Store the lanes of V2 that differ from their predecessor (previous lane,
+// or last lane of V1 for lane 0) at (Rout), advancing Rout by 2 bytes per
+// lane kept. Writes a full 16 bytes; the caller guarantees slack.
+// Rcnt receives the number of lanes kept. Clobbers V3-V5, R14, R15, R16.
+#define STOREUNIQ(Rout, Rcnt) \
+	VEXT   $14, V2.B16, V1.B16, V3.B16 \
+	VCMEQ  V3.H8, V2.H8, V4.H8         \
+	VUZP1  V4.B16, V4.B16, V4.B16      \
+	VMOV   V4.D[0], R14                \
+	AND    R12, R14, R14               \
+	MUL    R13, R14, R15               \
+	LSR    $56, R15, R15               \
+	MUL    R12, R14, R14               \
+	LSR    $56, R14, R14               \
+	SUB    R14, R19, Rcnt              \
+	ADD    R15<<4, R6, R16             \
+	VLD1   (R16), [V5.B16]             \
+	VTBL   V5.B16, [V2.B16], V3.B16    \
+	VST1   [V3.B16], (Rout)            \
+	ADD    Rcnt<<1, Rout, Rout
+
+// func unionKernelNEON(set1, set2, buffer []uint16, shuf *byte, leftover *[16]uint16) (outLen, pos1, pos2, leftoverLen int)
+TEXT ·unionKernelNEON(SB), NOSPLIT, $0-120
+	MOVD set1_base+0(FP), R0
+	MOVD set2_base+24(FP), R1
+	MOVD buffer_base+48(FP), R2
+	MOVD set1_len+8(FP), R3
+	MOVD set2_len+32(FP), R4
+	MOVD shuf+72(FP), R6
+	MOVD leftover+80(FP), R7
+
+	// end pointers over whole blocks: base + (len &^ 7) * 2
+	AND $~7, R3, R3
+	AND $~7, R4, R4
+	ADD R3<<1, R0, R3
+	ADD R4<<1, R1, R4
+
+	MOVD R2, R5
+
+	MOVD $0x0101010101010101, R12
+	MOVD $0x0102040810204080, R13
+	MOVD $8, R19
+
+	// prime: merge first block of each input
+	VLD1.P 16(R0), [V2.H8]
+	VLD1.P 16(R1), [V0.H8]
+	MERGE
+	// laststore = all ones (never equal to a first stored lane)
+	VCMEQ V0.H8, V0.H8, V1.H8
+	STOREUNIQ(R2, R17)
+	VORR V2.B16, V2.B16, V1.B16
+
+loop:
+	CMP R3, R0
+	BHS done
+	CMP R4, R1
+	BHS done
+	MOVHU (R0), R8
+	MOVHU (R1), R9
+	CMP  R9, R8
+	CSEL LS, R0, R1, R10   // take set1's block on tie/less
+	CSEL LS, R8, R9, R20
+	VLD1 (R10), [V2.H8]
+	CSET LS, R11
+	ADD  R11<<4, R0, R0
+	EOR  $1, R11, R11
+	ADD  R11<<4, R1, R1
+	// Disjoint fast path: when head >= carry's max the merged result is
+	// just carry then fresh, so skip the network. Boundary equality falls
+	// to the dedup chain, hence >= rather than >.
+	VMOV V0.H[7], R21
+	CMP  R21, R20
+	BHS  disjoint
+	MERGE
+	STOREUNIQ(R2, R17)
+	VORR V2.B16, V2.B16, V1.B16
+	B loop
+
+disjoint:
+	VORR V2.B16, V2.B16, V22.B16   // stash fresh
+	VORR V0.B16, V0.B16, V2.B16    // emit old carry as this round's minimum
+	STOREUNIQ(R2, R17)
+	VORR V2.B16, V2.B16, V1.B16    // laststore = old carry
+	VORR V22.B16, V22.B16, V0.B16  // carry = fresh
+	B loop
+
+done:
+	// flush carry through the dedup into the leftover buffer
+	VORR V0.B16, V0.B16, V2.B16
+	STOREUNIQ(R7, R17)
+	MOVD R17, leftoverLen+112(FP)
+
+	// outLen = (out - outBase) / 2
+	SUB  R5, R2, R2
+	LSR  $1, R2, R2
+	MOVD R2, outLen+88(FP)
+
+	// pos1/pos2 = blocks consumed
+	MOVD set1_base+0(FP), R8
+	SUB  R8, R0, R0
+	LSR  $4, R0, R0
+	MOVD R0, pos1+96(FP)
+	MOVD set2_base+24(FP), R8
+	SUB  R8, R1, R1
+	LSR  $4, R1, R1
+	MOVD R1, pos2+104(FP)
+	RET

--- a/setutil_neon_arm64.s
+++ b/setutil_neon_arm64.s
@@ -37,13 +37,13 @@
 	VZIP1  V5.H8, V4.H8, V2.H8         \
 	VZIP2  V5.H8, V4.H8, V0.H8
 
-// Store the lanes of V2 that differ from their predecessor (previous lane,
+// Store the lanes of Vin that differ from their predecessor (previous lane,
 // or last lane of V1 for lane 0) at (Rout), advancing Rout by 2 bytes per
 // lane kept. Writes a full 16 bytes; the caller guarantees slack.
 // Rcnt receives the number of lanes kept. Clobbers V3-V5, R14, R15, R16.
-#define STOREUNIQ(Rout, Rcnt) \
-	VEXT   $14, V2.B16, V1.B16, V3.B16 \
-	VCMEQ  V3.H8, V2.H8, V4.H8         \
+#define STOREUNIQ(Vin, Rout, Rcnt) \
+	VEXT   $14, Vin.B16, V1.B16, V3.B16 \
+	VCMEQ  V3.H8, Vin.H8, V4.H8         \
 	VUZP1  V4.B16, V4.B16, V4.B16      \
 	VMOV   V4.D[0], R14                \
 	AND    R12, R14, R14               \
@@ -54,7 +54,7 @@
 	SUB    R14, R19, Rcnt              \
 	ADD    R15<<4, R6, R16             \
 	VLD1   (R16), [V5.B16]             \
-	VTBL   V5.B16, [V2.B16], V3.B16    \
+	VTBL   V5.B16, [Vin.B16], V3.B16   \
 	VST1   [V3.B16], (Rout)            \
 	ADD    Rcnt<<1, Rout, Rout
 
@@ -86,7 +86,7 @@ TEXT ·unionKernelNEON(SB), NOSPLIT, $0-120
 	MERGE
 	// laststore = all ones (never equal to a first stored lane)
 	VCMEQ V0.H8, V0.H8, V1.H8
-	STOREUNIQ(R2, R17)
+	STOREUNIQ(V2, R2, R17)
 	VORR V2.B16, V2.B16, V1.B16
 
 loop:
@@ -111,22 +111,52 @@ loop:
 	CMP  R21, R20
 	BHS  disjoint
 	MERGE
-	STOREUNIQ(R2, R17)
+	STOREUNIQ(V2, R2, R17)
 	VORR V2.B16, V2.B16, V1.B16
 	B loop
 
+// Fast-forward loop for consecutive disjoint blocks. The head select is a
+// plain branch: on run-structured data it predicts, keeping the untaken
+// cursor off the loop-carried chain that the main loop's CSEL select
+// serializes. Interleaving input rejoins the main loop after one merge.
 disjoint:
-	VORR V2.B16, V2.B16, V22.B16   // stash fresh
-	VORR V0.B16, V0.B16, V2.B16    // emit old carry as this round's minimum
-	STOREUNIQ(R2, R17)
-	VORR V2.B16, V2.B16, V1.B16    // laststore = old carry
-	VORR V22.B16, V22.B16, V0.B16  // carry = fresh
+	STOREUNIQ(V0, R2, R17)
+	VORR V0.B16, V0.B16, V1.B16    // laststore = old carry
+	VORR V2.B16, V2.B16, V0.B16    // carry = fresh
+
+ffloop:
+	CMP R3, R0
+	BHS done
+	CMP R4, R1
+	BHS done
+	MOVHU (R0), R8
+	MOVHU (R1), R9
+	CMP  R9, R8
+	BHI  fftake2
+	VLD1.P 16(R0), [V2.H8]         // take set1's block on tie/less
+	MOVD R8, R20
+	B    ffcheck
+fftake2:
+	VLD1.P 16(R1), [V2.H8]
+	MOVD R9, R20
+ffcheck:
+	VMOV V0.H[7], R21
+	CMP  R21, R20
+	BLO  ffmerge
+	STOREUNIQ(V0, R2, R17)
+	VORR V0.B16, V0.B16, V1.B16    // laststore = old carry
+	VORR V2.B16, V2.B16, V0.B16    // carry = fresh
+	B ffloop
+
+ffmerge:
+	MERGE
+	STOREUNIQ(V2, R2, R17)
+	VORR V2.B16, V2.B16, V1.B16
 	B loop
 
 done:
 	// flush carry through the dedup into the leftover buffer
-	VORR V0.B16, V0.B16, V2.B16
-	STOREUNIQ(R7, R17)
+	STOREUNIQ(V0, R7, R17)
 	MOVD R17, leftoverLen+112(FP)
 
 	// outLen = (out - outBase) / 2

--- a/setutil_neon_arm64_test.go
+++ b/setutil_neon_arm64_test.go
@@ -9,9 +9,10 @@ import (
 	"testing"
 )
 
+// The oracle is the pre-existing scalar asm, sharing no code with unionNEON.
 func refUnion(a, b []uint16) []uint16 {
 	out := make([]uint16, len(a)+len(b))
-	n := scalarMergeUnion(a, b, out)
+	n := union2by2scalar(a, b, out)
 	return out[:n]
 }
 
@@ -122,6 +123,42 @@ func TestUnion2By2NEONLaneStraddleAndHighEnd(t *testing.T) {
 		low[i] = uint16(65520 + i)
 	}
 	checkKernel(t, low, high, "adjacent-high")
+}
+
+// 20 lands in both the kernel leftovers and set1's tail; the wrapper dedups.
+func TestUnion2By2NEONLeftoverTailDedup(t *testing.T) {
+	a := []uint16{0, 1, 2, 3, 4, 5, 6, 7, 20}
+	b := []uint16{15, 16, 17, 18, 19, 20, 21, 22}
+	checkKernel(t, a, b, "leftover-tail")
+	checkKernel(t, b, a, "leftover-tail-swap")
+}
+
+// laststore initializes to all ones and the random generators cannot
+// emit 0xFFFF. These shapes run it through the merge loop, the disjoint
+// carry, and the wrapper dedup, not just prime-and-flush.
+func TestUnion2By2NEONHighEndMultiBlock(t *testing.T) {
+	span := func(lo, hi, step int) []uint16 {
+		var s []uint16
+		for v := lo; v <= hi; v += step {
+			s = append(s, uint16(v))
+		}
+		return s
+	}
+
+	a := span(65520, 65535, 1)
+	b := append(span(0, 7, 1), span(65528, 65535, 1)...)
+	checkKernel(t, a, b, "high-two-blocks")
+	checkKernel(t, b, a, "high-two-blocks-swap")
+
+	// 0xFFFF shared between the kernel leftovers and set1's tail.
+	c := append(span(0, 7, 1), span(65529, 65535, 1)...)
+	d := span(65528, 65535, 1)
+	checkKernel(t, c, d, "high-leftover-tail")
+	checkKernel(t, d, c, "high-leftover-tail-swap")
+
+	// Identical blocks to 0xFFFF: equality, disjoint, and ffmerge transitions.
+	g := span(65472, 65535, 1)
+	checkKernel(t, g, g, "high-identical-multiblock")
 }
 
 // Every block seam shares its boundary value, pinning the fast path's

--- a/setutil_neon_arm64_test.go
+++ b/setutil_neon_arm64_test.go
@@ -229,3 +229,21 @@ func TestUnion2By2NEONAliasedBuffer(t *testing.T) {
 		}
 	}
 }
+
+// iorArray's self-union geometry: set2 and the output share a backing array.
+func TestUnion2By2NEONSelfAliasedBuffer(t *testing.T) {
+	r := rand.New(rand.NewSource(11))
+	for iter := 0; iter < 200; iter++ {
+		valRange := 256 + r.Intn(65280)
+		set := genSortedUnique(r, 8+r.Intn(2000), valRange)
+
+		n := len(set)
+		shared := make([]uint16, 2*n)
+		copy(shared, set)
+		copy(shared[n:], set)
+		got := shared[:union2by2(shared[n:], shared[:n], shared)]
+		if !reflect.DeepEqual(set, got) {
+			t.Fatalf("self-aliased: n=%d: mismatch (got %d elems)", n, len(got))
+		}
+	}
+}

--- a/setutil_neon_arm64_test.go
+++ b/setutil_neon_arm64_test.go
@@ -1,0 +1,231 @@
+//go:build arm64 && !gccgo && !appengine
+// +build arm64,!gccgo,!appengine
+
+package roaring
+
+import (
+	"math/rand"
+	"reflect"
+	"testing"
+)
+
+func refUnion(a, b []uint16) []uint16 {
+	out := make([]uint16, len(a)+len(b))
+	n := scalarMergeUnion(a, b, out)
+	return out[:n]
+}
+
+func genSortedUnique(r *rand.Rand, n, valRange int) []uint16 {
+	if n > valRange {
+		n = valRange
+	}
+	seen := make(map[uint16]bool, n)
+	for len(seen) < n {
+		seen[uint16(r.Intn(valRange))] = true
+	}
+	out := make([]uint16, 0, n)
+	for v := 0; v < valRange; v++ {
+		if seen[uint16(v)] {
+			out = append(out, uint16(v))
+		}
+	}
+	return out
+}
+
+func checkUnion(t *testing.T, a, b []uint16, label string) {
+	t.Helper()
+	want := refUnion(a, b)
+	buffer := make([]uint16, len(a)+len(b))
+	got := buffer[:union2by2(a, b, buffer)]
+	if !reflect.DeepEqual(want, got) {
+		t.Fatalf("%s: len(a)=%d len(b)=%d: want %d elems, got %d\nwant %v\ngot  %v",
+			label, len(a), len(b), len(want), len(got), want, got)
+	}
+}
+
+func TestUnion2By2NEONAdversarial(t *testing.T) {
+	for n := 8; n <= 2048; n *= 2 {
+		identical := make([]uint16, n)
+		evens := make([]uint16, n)
+		odds := make([]uint16, n)
+		low := make([]uint16, n)
+		high := make([]uint16, n)
+		for i := 0; i < n; i++ {
+			identical[i] = uint16(3 * i)
+			evens[i] = uint16(2 * i)
+			odds[i] = uint16(2*i + 1)
+			low[i] = uint16(i)
+			high[i] = uint16(65535 - n + 1 + i)
+		}
+		checkUnion(t, identical, identical, "identical")
+		checkUnion(t, evens, odds, "interleaved")
+		checkUnion(t, odds, evens, "interleaved-swap")
+		checkUnion(t, low, high, "disjoint-extremes")
+		checkUnion(t, high, low, "disjoint-extremes-swap")
+	}
+}
+
+func TestUnion2By2NEONRandom(t *testing.T) {
+	r := rand.New(rand.NewSource(12345))
+	for iter := 0; iter < 2000; iter++ {
+		valRange := 256 + r.Intn(65280)
+		a := genSortedUnique(r, r.Intn(5000), valRange)
+		b := genSortedUnique(r, r.Intn(5000), valRange)
+		checkUnion(t, a, b, "random")
+	}
+}
+
+func checkKernel(t *testing.T, a, b []uint16, label string) {
+	t.Helper()
+	if len(a) < 8 || len(b) < 8 {
+		checkUnion(t, a, b, label)
+		return
+	}
+	want := refUnion(a, b)
+	buffer := make([]uint16, 0, len(a)+len(b))
+	n := unionNEON(a, b, buffer)
+	got := buffer[:n]
+	if !reflect.DeepEqual(want, got) {
+		t.Fatalf("%s: la=%d lb=%d want %v got %v", label, len(a), len(b), want, got)
+	}
+}
+
+func TestUnion2By2NEONBoundaryMatrix(t *testing.T) {
+	for _, sz := range [][2]int{{1, 1}, {2, 8}, {7, 8}, {8, 8}, {8, 9}, {8, 16}, {15, 16}, {16, 17}} {
+		a := make([]uint16, sz[0])
+		b := make([]uint16, sz[1])
+		for i := range a {
+			a[i] = uint16(2 * i)
+		}
+		for i := range b {
+			b[i] = uint16(3*i + 1)
+		}
+		checkKernel(t, a, b, "boundary")
+		checkKernel(t, b, a, "boundary-swap")
+	}
+}
+
+// A duplicate straddling lanes 7 and 0, and blocks touching 0xFFFF.
+func TestUnion2By2NEONLaneStraddleAndHighEnd(t *testing.T) {
+	a := []uint16{0, 2, 4, 6, 7, 20, 22, 24}
+	b := []uint16{1, 3, 5, 7, 21, 23, 25, 27}
+	checkKernel(t, a, b, "straddle")
+	checkKernel(t, b, a, "straddle-swap")
+
+	high := make([]uint16, 8)
+	for i := range high {
+		high[i] = uint16(65528 + i)
+	}
+	checkKernel(t, high, high, "identical-high")
+	low := make([]uint16, 8)
+	for i := range low {
+		low[i] = uint16(65520 + i)
+	}
+	checkKernel(t, low, high, "adjacent-high")
+}
+
+// Every block seam shares its boundary value, pinning the fast path's
+// choice of >= over >: the duplicate must fall to the dedup chain.
+func TestUnion2By2NEONEqualityStreak(t *testing.T) {
+	for blocks := 2; blocks <= 64; blocks *= 2 {
+		var a, b []uint16
+		next := uint16(0)
+		for i := 0; i < blocks; i++ {
+			for l := 0; l < 8; l++ {
+				a = append(a, next+uint16(l))
+			}
+			next += 7 // b's block starts at a's block's last value
+			for l := 0; l < 8; l++ {
+				b = append(b, next+uint16(l))
+			}
+			next += 7 // and a's next block starts at b's last value
+		}
+		checkKernel(t, a, b, "equality-streak")
+		checkKernel(t, b, a, "equality-streak-swap")
+
+		want := refUnion(a, b)
+		shared := make([]uint16, len(a)+len(b))
+		copy(shared[len(b):], a)
+		n := unionNEON(shared[len(b):], b, shared)
+		if !reflect.DeepEqual(want, shared[:n]) {
+			t.Fatalf("equality-streak aliased, blocks=%d: want %d got %d elems",
+				blocks, len(want), n)
+		}
+	}
+}
+
+// Tightest alias geometry: set1 at output offset len(set2) with a
+// one-block set2, forcing the lookahead tail.
+func TestUnion2By2NEONMinimumGapAlias(t *testing.T) {
+	set2 := []uint16{0, 1, 2, 3, 4, 5, 6, 7}
+	set1 := make([]uint16, 64)
+	for i := range set1 {
+		set1[i] = uint16(100 + i)
+	}
+	want := refUnion(set1, set2)
+	shared := make([]uint16, len(set1)+len(set2))
+	copy(shared[len(set2):], set1)
+	n := unionNEON(shared[len(set2):], set2, shared)
+	if !reflect.DeepEqual(want, shared[:n]) {
+		t.Fatalf("minimum-gap alias: want %d elems got %d", len(want), n)
+	}
+}
+
+// The kernel's 16-byte stores must never touch beyond len(set1)+len(set2).
+func TestUnion2By2NEONBufferCanaries(t *testing.T) {
+	r := rand.New(rand.NewSource(31337))
+	for iter := 0; iter < 300; iter++ {
+		a := genSortedUnique(r, 8+r.Intn(1000), 8192)
+		b := genSortedUnique(r, 8+r.Intn(1000), 8192)
+		need := len(a) + len(b)
+		full := make([]uint16, need+16)
+		for i := need; i < len(full); i++ {
+			full[i] = 0xDEAD
+		}
+		n := unionNEON(a, b, full[0:0:need])
+		if !reflect.DeepEqual(refUnion(a, b), full[:n]) {
+			t.Fatalf("canary iter %d: wrong result", iter)
+		}
+		for i := need; i < len(full); i++ {
+			if full[i] != 0xDEAD {
+				t.Fatalf("canary iter %d: guard word %d clobbered (0x%04X)", iter, i, full[i])
+			}
+		}
+	}
+}
+
+// lazyorArray passes a zero-length buffer with spare capacity.
+func TestUnion2By2NEONZeroLenBuffer(t *testing.T) {
+	r := rand.New(rand.NewSource(99))
+	for iter := 0; iter < 200; iter++ {
+		a := genSortedUnique(r, 8+r.Intn(500), 4096)
+		b := genSortedUnique(r, 8+r.Intn(500), 4096)
+		want := refUnion(a, b)
+		buffer := make([]uint16, 0, len(a)+len(b))
+		n := union2by2(a, b, buffer)
+		got := buffer[:n]
+		if !reflect.DeepEqual(want, got) {
+			t.Fatalf("zero-len buffer: mismatch (want %d got %d elems)", len(want), n)
+		}
+	}
+}
+
+// iorArray's geometry: set1 lives in the upper region of the output array.
+func TestUnion2By2NEONAliasedBuffer(t *testing.T) {
+	r := rand.New(rand.NewSource(7))
+	for iter := 0; iter < 500; iter++ {
+		valRange := 256 + r.Intn(65280)
+		set1 := genSortedUnique(r, 8+r.Intn(2000), valRange)
+		set2 := genSortedUnique(r, 8+r.Intn(2000), valRange)
+		want := refUnion(set1, set2)
+
+		max := len(set1) + len(set2)
+		shared := make([]uint16, max)
+		copy(shared[len(set2):max], set1)
+		got := shared[:union2by2(shared[len(set2):max], set2, shared)]
+		if !reflect.DeepEqual(want, got) {
+			t.Fatalf("aliased: len1=%d len2=%d: mismatch (want %d got %d elems)",
+				len(set1), len(set2), len(want), len(got))
+		}
+	}
+}

--- a/setutil_neon_bench_arm64_test.go
+++ b/setutil_neon_bench_arm64_test.go
@@ -1,0 +1,73 @@
+//go:build arm64 && !gccgo && !appengine
+// +build arm64,!gccgo,!appengine
+
+package roaring
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+)
+
+func benchPairSeed(shape string, n int, seed int64) (a, b []uint16) {
+	r := rand.New(rand.NewSource(int64(42+n) + seed*7919))
+	switch shape {
+	case "dense50":
+		return genSortedUnique(r, n, 2*n), genSortedUnique(r, n, 2*n)
+	case "sparse6":
+		vr := n * 16
+		if vr > 65536 {
+			vr = 65536
+		}
+		return genSortedUnique(r, n, vr), genSortedUnique(r, n, vr)
+	case "runs16":
+		a = make([]uint16, n)
+		b = make([]uint16, n)
+		for i := 0; i < n; i++ {
+			blk, off := i/16, i%16
+			a[i] = uint16(blk*32 + off)
+			b[i] = uint16(blk*32 + 16 + off)
+		}
+		return a, b
+	case "spread": // density mismatch: a confined to 1/8 of b's range
+		vr := 2 * n
+		if vr > 8192 {
+			vr = 8192
+		}
+		return genSortedUnique(r, n, vr), genSortedUnique(r, n, 65536)
+	}
+	panic("unknown shape")
+}
+
+// Rotating fixed-seed variants keeps the branch predictor from memorizing
+// one pair's decision sequence, which flatters the scalar path.
+const benchVariants = 16
+
+func BenchmarkUnion2By2(b *testing.B) {
+	for _, shape := range []string{"dense50", "sparse6", "runs16", "spread"} {
+		for _, n := range []int{256, 384, 512, 1024, 4096} {
+			as := make([][]uint16, benchVariants)
+			bs := make([][]uint16, benchVariants)
+			for v := 0; v < benchVariants; v++ {
+				as[v], bs[v] = benchPairSeed(shape, n, int64(v))
+			}
+			buffer := make([]uint16, 2*n)
+			for _, impl := range []struct {
+				name string
+				fn   func([]uint16, []uint16, []uint16) int
+			}{
+				{"dispatch", union2by2},
+				{"scalar", union2by2scalar},
+			} {
+				b.Run(fmt.Sprintf("%s/%d/%s", shape, n, impl.name), func(b *testing.B) {
+					sink := 0
+					for i := 0; i < b.N; i++ {
+						v := i % benchVariants
+						sink += impl.fn(as[v], bs[v], buffer)
+					}
+					_ = sink
+				})
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Description

NEON implementation of `union2by2` for arm64. When both arrays have at least 256 elements, unions run through a 128-bit SIMD kernel that processes eight values per step; smaller inputs keep using the scalar assembly from #287.

The kernel is based on CRoaring's SSE `union_vector16`, adapted for ARM: a transposed bitonic merge network (the SSE rotate network is latency-bound on modern ARM cores and measured slower than the scalar code), a two-multiply replacement for PMOVMSKB, and a fast path that skips the merge network while incoming blocks do not interleave with the carried values.

## Type of Change

- [x] Performance improvement
- [x] Test improvements

## Changes Made

### What was changed?
- `setutil_neon_arm64.s`: the NEON kernel.
- `setutil_arm64.go`: threshold dispatch, the shuffle table, and scalar tails that keep the existing caller contracts (`iorArray` aliasing, `lazyorArray`'s zero-length buffer).
- `setutil_arm64.s`: #287's routine renamed `union2by2scalar`, unchanged.
- Differential tests against the scalar path: aliasing geometry, buffer guard words, block-boundary duplicates, zero-length buffers.
- `BenchmarkUnion2By2`, following the `popcnt_bench_test.go` layout. It rotates 16 fixed-seed datasets; a single fixed pair lets the branch predictor memorize the scalar path and understates the difference.

### Why was it changed?
Closes #288.

### How was it changed?
Hand-written NEON assembly in Go's assembler syntax plus a small Go wrapper, same approach as `popcnt_neon_arm64.s`.

## Testing

`go test` passes.

## Formatting

`go fmt` clean.

## Fuzzing

`-fuzz=FuzzSmat` cannot run as written: the function is referenced by this template, the README, and smat.go, but its definition is not in the tree (it seems to have been lost in the October 2025 fuzzer rework). I ran the smat state machine through a small `smat.Fuzz` wrapper instead: 300 seconds, 1,373,418 executions on Graviton 4, no failures. Happy to send the wrapper as a follow-up PR.

## Performance Impact

Measured on Graviton 4 (c8g.xlarge), Go 1.26.5, medians of repeated runs.

`BenchmarkUnion2By2` from this PR; scalar rows are the #287 code:

```
BenchmarkUnion2By2/dense50/1024/dispatch-4     1374 ns/op    0 B/op   0 allocs/op
BenchmarkUnion2By2/dense50/1024/scalar-4       3412 ns/op    0 B/op   0 allocs/op
BenchmarkUnion2By2/dense50/4096/dispatch-4     5469 ns/op
BenchmarkUnion2By2/dense50/4096/scalar-4      22554 ns/op
BenchmarkUnion2By2/sparse6/4096/dispatch-4     5666 ns/op
BenchmarkUnion2By2/sparse6/4096/scalar-4      24693 ns/op
BenchmarkUnion2By2/runs16/1024/dispatch-4       396 ns/op
BenchmarkUnion2By2/runs16/1024/scalar-4        1476 ns/op
BenchmarkUnion2By2/runs16/4096/dispatch-4      1441 ns/op
BenchmarkUnion2By2/runs16/4096/scalar-4        5889 ns/op
BenchmarkUnion2By2/spread/4096/dispatch-4      3465 ns/op
BenchmarkUnion2By2/spread/4096/scalar-4        5016 ns/op
```

2.5x to 4x on random and run-structured shapes, no allocation changes.

On the real-roaring-datasets corpus (`BENCH_REAL_DATA=1 go test -bench=BenchmarkRealDataFastOr`), census1881 improves 1.25x. It is the one dataset dominated by large, mostly disjoint array unions, which is the shape this kernel targets. The other eleven datasets stay within a few percent of master; their unions are small, dense, or rare, so the kernel barely runs.

Trade-off: when the arrays share most of their values with the differences interleaved, the scalar loop consumes both elements per equal pair and does about half the work, so that shape favors scalar (about 0.6x in local benchmarks with 7/8 of the values shared). Aligned near-identical arrays stay on the fast path at scalar speed or better. None of the existing datasets that I benchmarked on have this shape.

## Breaking Changes

None. arm64 only; output is identical to the scalar path.

## Related Issues

Closes #288.
Related to #287.
