### PR TITLE
Optimize BSI CompareValue with bitmap set operations

### DIFF
--- a/BitSliceIndexing/bsi.go
+++ b/BitSliceIndexing/bsi.go
@@ -268,184 +268,189 @@ const (
 )
 
 type task struct {
-	bsi          *BSI
-	op           Operation
-	valueOrStart int64
-	end          int64
-	bits         *roaring.Bitmap
+	bsi *BSI
 }
 
 // CompareValue compares value.
 // Values should be in the range of the BSI (max, min).  If the value is outside the range, the result
-// might erroneous. The operation parameter indicates the type of comparison to be made.
+// might be erroneous. The operation parameter indicates the type of comparison to be made.
 // For all operations with the exception of RANGE, the value to be compared is specified by valueOrStart.
 // For the RANGE parameter the comparison criteria is >= valueOrStart and <= end.
-// The parallelism parameter indicates the number of CPU threads to be applied for processing.  A value
-// of zero indicates that all available CPU resources will be potentially utilized.
+// The parallelism parameter is retained for compatibility. Comparisons operate directly on bit slices
+// instead of partitioning column IDs into worker batches.
 func (b *BSI) CompareValue(parallelism int, op Operation, valueOrStart, end int64,
 	foundSet *roaring.Bitmap) *roaring.Bitmap {
 
-	comp := &task{bsi: b, op: op, valueOrStart: valueOrStart, end: end}
 	if foundSet == nil {
-		return parallelExecutor(parallelism, comp, compareValue, b.eBM)
+		foundSet = b.eBM
 	}
-	return parallelExecutor(parallelism, comp, compareValue, foundSet)
-}
 
-func compareValue(e *task, batch []uint32, resultsChan chan *roaring.Bitmap, wg *sync.WaitGroup) {
+	var results *roaring.Bitmap
+	switch op {
+	case LT, LE, EQ, GE, GT:
+		results = b.compareValueBitmap(valueOrStart, foundSet, op)
+	case RANGE:
+		results = b.compareValueBitmap(valueOrStart, foundSet, GE)
+		results.And(b.compareValueBitmap(end, results, LE))
+	default:
+		panic(fmt.Sprintf("Unknown operation [%v]", op))
+	}
 
-	defer wg.Done()
-
-	results := roaring.NewBitmap()
-	if e.bsi.runOptimized {
+	if b.runOptimized {
 		results.RunOptimize()
 	}
-	if len(batch) == 0 {
-		resultsChan <- results
-		return
+	return results
+}
+
+// compareValueBitmap compares every value represented by foundSet to value.
+// It leaves foundSet unchanged and returns a new bitmap.
+func (b *BSI) compareValueBitmap(value int64, foundSet *roaring.Bitmap, op Operation) *roaring.Bitmap {
+	width := b.BitCount()
+	if valueWidth := bits.Len64(uint64(value)); valueWidth > width {
+		width = valueWidth
 	}
-	//The following code solves the problem of inaccurate results returned by the function when bsi is not set to max or the value of compare exceeds max
-	var x int
-	if e.op == RANGE {
-		//If the operation is range and the number of bits in end is greater than the length of ba, then x is set to the number of bits in end
-		if bits.Len64(uint64(e.end)) > e.bsi.BitCount() {
-			x = bits.Len64(uint64(e.end))
-		} else {
-			x = e.bsi.BitCount()
+
+	if width == 64 {
+		return b.compareSigned(value, foundSet, op)
+	}
+	if op == EQ {
+		return b.equalUnsigned(uint64(value), width, foundSet)
+	}
+	return b.compareUnsigned(uint64(value), width, foundSet.Clone(), op)
+}
+
+// equalUnsigned intersects the bit constraints in an order that shrinks the
+// candidate set early. Equality does not depend on plane order, so it starts
+// with the least-populated set plane before applying the remaining set and
+// clear planes.
+func (b *BSI) equalUnsigned(value uint64, width int, foundSet *roaring.Bitmap) *roaring.Bitmap {
+	bitCount := b.BitCount()
+	firstSetBit := -1
+	for bit := 0; bit < width; bit++ {
+		if !bitIsSet(value, bit) {
+			continue
 		}
+		if bit >= bitCount {
+			return roaring.NewBitmap()
+		}
+		if firstSetBit < 0 || b.bA[bit].GetCardinality() < b.bA[firstSetBit].GetCardinality() {
+			firstSetBit = bit
+		}
+	}
+
+	var equal *roaring.Bitmap
+	if firstSetBit < 0 {
+		equal = foundSet.Clone()
 	} else {
-		//If the operation is not range and the number of value bits is greater than the length of ba, then x is set to the number of value bits
-		if bits.Len64(uint64(e.valueOrStart)) > e.bsi.BitCount() {
-			x = bits.Len64(uint64(e.valueOrStart))
+		equal = roaring.And(foundSet, b.bA[firstSetBit])
+	}
+	for bit := width - 1; bit >= 0 && !equal.IsEmpty(); bit-- {
+		if bit != firstSetBit && bitIsSet(value, bit) {
+			equal.And(b.bA[bit])
+		}
+	}
+	for bit := width - 1; bit >= 0 && !equal.IsEmpty(); bit-- {
+		if !bitIsSet(value, bit) && bit < bitCount {
+			equal.AndNot(b.bA[bit])
+		}
+	}
+	return equal
+}
+
+// compareSigned separates the candidates by sign, then compares the remaining
+// 63 planes as unsigned values. Within a sign, two's-complement order is the
+// same as unsigned order; candidates with the other sign either all match or
+// all miss depending on the operation.
+func (b *BSI) compareSigned(value int64, foundSet *roaring.Bitmap, op Operation) *roaring.Bitmap {
+	equal := foundSet.Clone()
+	targetNegative := value < 0
+	if targetNegative {
+		if b.BitCount() <= 63 {
+			equal.Clear()
 		} else {
-			x = e.bsi.BitCount()
+			equal.And(b.bA[63])
 		}
-	}
-	startIsNegative := x == 64 && uint64(e.valueOrStart)&(1<<uint64(x-1)) > 0
-	endIsNegative := x == 64 && uint64(e.end)&(1<<uint64(x-1)) > 0
-
-	for i := 0; i < len(batch); i++ {
-		cID := batch[i]
-		eq1, eq2 := true, true
-		lt1, lt2, gt1 := false, false, false
-		j := x - 1
-		isNegative := false
-		if x == 64 {
-			if j < e.bsi.BitCount() {
-				isNegative = e.bsi.bA[j].Contains(cID)
-			}
-			j--
-		}
-		compStartValue := e.valueOrStart
-		compEndValue := e.end
-		if isNegative != startIsNegative {
-			compStartValue = ^e.valueOrStart + 1
-		}
-		if isNegative != endIsNegative {
-			compEndValue = ^e.end + 1
-		}
-		for ; j >= 0; j-- {
-			var sliceContainsBit bool
-			//The value of j may be larger than the length of ba, so the following judgment has been added
-			if e.bsi.BitCount() <= j {
-				sliceContainsBit = false
-			} else {
-				sliceContainsBit = e.bsi.bA[j].Contains(cID)
-			}
-			if uint64(compStartValue)&(1<<uint64(j)) > 0 {
-				// BIT in value is SET
-				if !sliceContainsBit {
-					if eq1 {
-						if (e.op == GT || e.op == GE || e.op == RANGE) && startIsNegative && !isNegative {
-							gt1 = true
-						}
-						if e.op == LT || e.op == LE {
-							if !startIsNegative || (startIsNegative == isNegative) {
-								lt1 = true
-							}
-						}
-						eq1 = false
-						break
-					}
-				}
-			} else {
-				// BIT in value is CLEAR
-				if sliceContainsBit {
-					if eq1 {
-						if (e.op == LT || e.op == LE) && isNegative && !startIsNegative {
-							lt1 = true
-						}
-						if e.op == GT || e.op == GE || e.op == RANGE {
-							if startIsNegative || (startIsNegative == isNegative) {
-								gt1 = true
-							}
-						}
-						eq1 = false
-						if e.op != RANGE {
-							break
-						}
-					}
-				}
-			}
-
-			if e.op == RANGE && uint64(compEndValue)&(1<<uint64(j)) > 0 {
-				// BIT in value is SET
-				if !sliceContainsBit {
-					if eq2 {
-						if !endIsNegative || (endIsNegative == isNegative) {
-							lt2 = true
-						}
-						eq2 = false
-						if startIsNegative && !endIsNegative {
-							break
-						}
-					}
-				}
-			} else if e.op == RANGE {
-				// BIT in value is CLEAR
-				if sliceContainsBit {
-					if eq2 {
-						if isNegative && !endIsNegative {
-							lt2 = true
-						}
-						eq2 = false
-						break
-					}
-				}
-			}
-		}
-
-		switch e.op {
-		case LT:
-			if lt1 {
-				results.Add(cID)
-			}
-		case LE:
-			if lt1 || (eq1 && (!startIsNegative || (startIsNegative && isNegative))) {
-				results.Add(cID)
-			}
-		case EQ:
-			if eq1 {
-				results.Add(cID)
-			}
-		case GE:
-			if gt1 || (eq1 && (startIsNegative || (!startIsNegative && !isNegative))) {
-				results.Add(cID)
-			}
-		case GT:
-			if gt1 {
-				results.Add(cID)
-			}
-		case RANGE:
-			if (eq1 || gt1) && (eq2 || lt2) {
-				results.Add(cID)
-			}
-		default:
-			panic(fmt.Sprintf("Unknown operation [%v]", e.op))
-		}
+	} else if b.BitCount() > 63 {
+		equal.AndNot(b.bA[63])
 	}
 
-	resultsChan <- results
+	results := b.compareUnsigned(uint64(value), 63, equal, op)
+	if targetNegative && (op == GT || op == GE) {
+		if b.BitCount() <= 63 {
+			results.Or(foundSet)
+		} else {
+			results.Or(roaring.AndNot(foundSet, b.bA[63]))
+		}
+	} else if !targetNegative && (op == LT || op == LE) && b.BitCount() > 63 {
+		results.Or(roaring.And(foundSet, b.bA[63]))
+	}
+	return results
+}
+
+// compareUnsigned consumes equal, which initially contains the candidates
+// sharing no processed prefix with value. It walks from the most significant
+// bit down, preserving equal and collecting candidates at the first differing
+// bit. Missing planes are zero, which also handles comparisons beyond the BSI's
+// configured width.
+func (b *BSI) compareUnsigned(value uint64, width int, equal *roaring.Bitmap, op Operation) *roaring.Bitmap {
+	bitCount := b.BitCount()
+	switch op {
+	case EQ:
+		for bit := width - 1; bit >= 0 && !equal.IsEmpty(); bit-- {
+			if bitIsSet(value, bit) {
+				if bit >= bitCount {
+					equal.Clear()
+					break
+				}
+				equal.And(b.bA[bit])
+			} else if bit < bitCount {
+				equal.AndNot(b.bA[bit])
+			}
+		}
+		return equal
+	case LT, LE:
+		less := roaring.NewBitmap()
+		for bit := width - 1; bit >= 0 && !equal.IsEmpty(); bit-- {
+			if bitIsSet(value, bit) {
+				if bit >= bitCount {
+					less.Or(equal)
+					return less
+				}
+				less.Or(roaring.AndNot(equal, b.bA[bit]))
+				equal.And(b.bA[bit])
+			} else if bit < bitCount {
+				equal.AndNot(b.bA[bit])
+			}
+		}
+		if op == LE {
+			less.Or(equal)
+		}
+		return less
+	case GT, GE:
+		greater := roaring.NewBitmap()
+		for bit := width - 1; bit >= 0 && !equal.IsEmpty(); bit-- {
+			if bitIsSet(value, bit) {
+				if bit >= bitCount {
+					equal.Clear()
+					break
+				}
+				equal.And(b.bA[bit])
+			} else if bit < bitCount {
+				greater.Or(roaring.And(equal, b.bA[bit]))
+				equal.AndNot(b.bA[bit])
+			}
+		}
+		if op == GE {
+			greater.Or(equal)
+		}
+		return greater
+	default:
+		panic(fmt.Sprintf("Unknown operation [%v]", op))
+	}
+}
+
+func bitIsSet(value uint64, bit int) bool {
+	return bit < 64 && value&(uint64(1)<<uint(bit)) != 0
 }
 
 // MinMax - Find minimum or maximum value.

--- a/BitSliceIndexing/bsi_benchmark_test.go
+++ b/BitSliceIndexing/bsi_benchmark_test.go
@@ -8,6 +8,22 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func BenchmarkCompareValue(b *testing.B) {
+	bsi := setupLargeBSI(b)
+	if bsi == nil {
+		b.Skip("skipping, large BSI setup failed")
+		return
+	}
+	if result := bsi.CompareValue(0, EQ, 55, 0, nil); result.GetCardinality() != 520157 {
+		b.Fatalf("unexpected result cardinality: got %d, want %d", result.GetCardinality(), 520157)
+	}
+
+	b.ResetTimer()
+	for b.Loop() {
+		bsi.CompareValue(0, EQ, 55, 0, nil)
+	}
+}
+
 func BenchmarkBatchEqual(b *testing.B) {
 	bsi := setupLargeBSI(b)
 	if bsi == nil {

--- a/BitSliceIndexing/bsi_test.go
+++ b/BitSliceIndexing/bsi_test.go
@@ -201,6 +201,131 @@ func TestRange(t *testing.T) {
 	}
 }
 
+func TestCompareValueMatchesGetValue(t *testing.T) {
+	type query struct {
+		op    Operation
+		start int64
+		end   int64
+	}
+	tests := []struct {
+		name    string
+		newBSI  func() *BSI
+		values  []int64
+		queries []query
+	}{
+		{
+			name:   "unsigned",
+			newBSI: func() *BSI { return NewBSI(127, 0) },
+			values: []int64{0, 1, 2, 3, 7, 31, 63, 126, 127},
+			queries: []query{
+				{EQ, -1, 0}, {EQ, 0, 0}, {EQ, 127, 0}, {EQ, 128, 0},
+				{LT, 0, 0}, {LE, 0, 0}, {GT, 127, 0}, {GE, 128, 0},
+				{RANGE, -1, 1}, {RANGE, 31, 126}, {RANGE, 127, 126},
+			},
+		},
+		{
+			name:   "signed",
+			newBSI: NewDefaultBSI,
+			values: []int64{Min64BitSigned, -100, -2, -1, 0, 1, 2, 100, Max64BitSigned},
+			queries: []query{
+				{EQ, Min64BitSigned, 0}, {EQ, -1, 0}, {EQ, 1, 0}, {EQ, Max64BitSigned, 0},
+				{LT, Min64BitSigned, 0}, {LT, 1, 0}, {LE, -100, 0}, {LE, 1, 0},
+				{GT, -1, 0}, {GT, Max64BitSigned, 0}, {GE, -1, 0}, {GE, 0, 0},
+				{RANGE, Min64BitSigned, -1}, {RANGE, -2, 2}, {RANGE, 1, -1}, {RANGE, Max64BitSigned, Max64BitSigned},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		for _, optimized := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/run_optimized=%t", tc.name, optimized), func(t *testing.T) {
+				bsi := tc.newBSI()
+				for columnID, value := range tc.values {
+					bsi.SetValue(uint64(columnID), value)
+				}
+				if optimized {
+					bsi.RunOptimize()
+				}
+
+				foundSet := roaring.NewBitmap()
+				for columnID := range tc.values {
+					if columnID%2 == 0 {
+						foundSet.Add(uint32(columnID))
+					}
+				}
+				for _, selection := range []struct {
+					name  string
+					input *roaring.Bitmap
+				}{
+					{name: "existence", input: nil},
+					{name: "subset", input: foundSet},
+				} {
+					for _, parallelism := range []int{0, 1, 3} {
+						for _, q := range tc.queries {
+							got := bsi.CompareValue(parallelism, q.op, q.start, q.end, selection.input)
+							want := compareValueGroundTruth(bsi, q.op, q.start, q.end, selection.input)
+							if !got.Equals(want) {
+								t.Errorf("%s parallelism=%d op=%d start=%d end=%d: got %v, want %v", selection.name, parallelism, q.op, q.start, q.end, got.ToArray(), want.ToArray())
+							}
+						}
+					}
+				}
+
+				before := foundSet.Clone()
+				result := bsi.CompareValue(0, EQ, tc.values[0], 0, foundSet)
+				result.Remove(0)
+				result.Add(1000)
+				assert.True(t, foundSet.Equals(before), "CompareValue must not mutate or share foundSet")
+
+				existenceBefore := bsi.GetExistenceBitmap().Clone()
+				result = bsi.CompareValue(0, EQ, tc.values[0], 0, nil)
+				result.Remove(0)
+				result.Add(1000)
+				assert.True(t, bsi.GetExistenceBitmap().Equals(existenceBefore), "CompareValue must not mutate or share the existence bitmap")
+			})
+		}
+	}
+}
+
+func compareValueGroundTruth(bsi *BSI, op Operation, start, end int64, foundSet *roaring.Bitmap) *roaring.Bitmap {
+	if foundSet == nil {
+		foundSet = bsi.GetExistenceBitmap()
+	}
+
+	result := roaring.NewBitmap()
+	iter := foundSet.Iterator()
+	for iter.HasNext() {
+		columnID := iter.Next()
+		value, exists := bsi.GetValue(uint64(columnID))
+		if !exists {
+			continue
+		}
+
+		matches := false
+		switch op {
+		case LT:
+			matches = value < start
+		case LE:
+			matches = value <= start
+		case EQ:
+			matches = value == start
+		case GE:
+			matches = value >= start
+		case GT:
+			matches = value > start
+		case RANGE:
+			matches = value >= start && value <= end
+		default:
+			panic(fmt.Sprintf("Unknown operation [%v]", op))
+		}
+		if matches {
+			result.Add(columnID)
+		}
+	}
+	return result
+}
+
 func TestExists(t *testing.T) {
 
 	bsi := NewBSI(10, 0)


### PR DESCRIPTION
## Summary

Rework CompareValue to compare bit slices as bitmap sets instead of materializing column-ID batches and probing each bit. Equality starts from a selective set plane, range queries compose lower and upper bitmap comparisons, and signed values are handled by separating sign slices. The parallelism argument remains for API compatibility, but comparisons now operate directly on bitmap slices rather than splitting IDs into worker batches.

## Performance

On workload `large preloaded BSI equality query for value 55`, median metric `ns/op` changed from 1005014636 to 45904728; paired median delta -959257346 (-95.4% of baseline; at least 19/20 confidence interval -1080414403 to -927111616 from 10 pairs).

On workload `large preloaded BSI equality query for value 55`, median metric `B/op` changed from 115856362 to 12982819; paired median delta -102873544 (-88.8% of baseline; at least 19/20 confidence interval -103155793 to -102584776 from 10 pairs).

On workload `large preloaded BSI equality query for value 55`, median metric `allocs/op` changed from 14063 to 5162; paired median delta -8901 (-63.3% of baseline; at least 19/20 confidence interval -9442 to -8354 from 10 pairs).

## Testing

Added a large-fixture benchmark and ground-truth coverage for all comparison operations, signed and unsigned values, subset inputs, run-optimized bitmaps, and result isolation. Ran the full Go suite, the BitSliceIndexing race test, formatting and conversion checks, the appengine build and test, and ARM/ARM64 compilation.

All 5 declared correctness checks passed.

Full verification record: https://app.perfloop.ai/t/oss/case_xw6sb2t5zr