### PR TITLE
Only build smat.go when fuzzing

### DIFF
--- a/smat.go
+++ b/smat.go
@@ -1,3 +1,6 @@
+//go:build gofuzz
+// +build gofuzz
+
 /*
 # Instructions for smat testing for roaring
 


### PR DESCRIPTION
## Description

There's a `init` function defined in this file, so it always gets executed, even if the library is not being fuzzed. Mark the file to only be build during fuzzing. This avoids some compiled code and init work being done. 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Test improvements
- [ ] Build/CI changes

## Changes Made

### What was changed?
-  `gofuzz` build tags added to `smat.go` file.

### Why was it changed?
My primary motivation for this change is that it reduces the compiled size of this library by ~240KiB.

### How was it changed?
Adding `gofuzz` as build tag.

## Testing
I'm not able to confirm smat fuzzing still works. Before and after the change, following the steps in the README.md doesn't result in any fuzzing happening on my side.

## Formatting
N/A

## Fuzzing
See above, can't confirm.

## Performance Impact
The `init` function runs in about ~7µs on a Zen 2 CPU which is now avoided on starting a Go binary that uses this library. It's negligible.

### Running Benchmarks
N/A

## Breaking Changes
None, this file does not expose any public API.

## Related Issues
N/A

## Additional Notes
None.
