### PR TITLE
Use CSEL to compute the NEON popcount inner-loop batch size

### DIFF
--- a/popcnt_neon_arm64.s
+++ b/popcnt_neon_arm64.s
@@ -51,6 +51,23 @@
 // 1024*32 = 32768 stays well under the 65535 lane limit.
 #define INNERMAX $1024
 
+// SPLITBLOCKS carves the next batch off the outstanding block count. On entry R3
+// is the number of 64-byte blocks still to process (always >= 1); on exit R4 is
+// min(R3, INNERMAX), the length of the batch the inner loop is about to run, and
+// R3 is what is left over, max(R3-INNERMAX, 0). R6 is scratch.
+//
+// The SUBS both computes the leftover and sets the flags that choose between the
+// two cases: carry-set means the subtraction did not borrow, i.e. R3 >= INNERMAX
+// unsigned, so CS selects the capped batch and the non-zero remainder while the
+// other case takes R3 whole and leaves nothing behind. Doing it with CSEL keeps
+// the sequence branch-free; the immediate form of SUBS also keeps it off the
+// dependency chain of the MOVD that materializes INNERMAX.
+#define SPLITBLOCKS \
+	SUBS INNERMAX, R3, R6 \
+	MOVD INNERMAX, R4 \
+	CSEL CS, R4, R3, R4 \
+	CSEL CS, R6, ZR, R3
+
 // FOLD4 assumes 64 bytes of input (post-combine) sit in V0..V3 and folds their
 // popcount into the partial accumulators V16/V18. VADD sums the four VCNT
 // results byte-wise (each lane 0..32); VUADDW/VUADDW2 then widen the low/high
@@ -108,12 +125,7 @@ TEXT ·_popcntSliceNEON(SB), NOSPLIT, $0-32
 	LSR $3, R1, R3                 // R3 = len/8 = number of 64-byte blocks
 	CBZ R3, sltail                 // fewer than 8 words: skip the vector loop
 slblock:
-	MOVD INNERMAX, R4              // R4 = min(remaining blocks, INNERMAX)
-	CMP R4, R3
-	BHS slinner
-	MOVD R3, R4
-slinner:
-	SUB R4, R3, R3                 // R3 -= this batch's block count
+	SPLITBLOCKS                    // R4 = this batch, R3 = blocks left after it
 	ZEROPART
 slloop:
 	VLD1.P 64(R0), [V0.B16, V1.B16, V2.B16, V3.B16] // load 8 words (64 bytes)
@@ -148,12 +160,7 @@ TEXT ·_popcntAndSliceNEON(SB), NOSPLIT, $0-56
 	LSR $3, R5, R3
 	CBZ R3, andtail
 andblock:
-	MOVD INNERMAX, R4
-	CMP R4, R3
-	BHS andinner
-	MOVD R3, R4
-andinner:
-	SUB R4, R3, R3
+	SPLITBLOCKS
 	ZEROPART
 andloop:
 	VLD1.P 64(R0), [V0.B16, V1.B16, V2.B16, V3.B16]
@@ -194,12 +201,7 @@ TEXT ·_popcntOrSliceNEON(SB), NOSPLIT, $0-56
 	LSR $3, R5, R3
 	CBZ R3, ortail
 orblock:
-	MOVD INNERMAX, R4
-	CMP R4, R3
-	BHS orinner
-	MOVD R3, R4
-orinner:
-	SUB R4, R3, R3
+	SPLITBLOCKS
 	ZEROPART
 orloop:
 	VLD1.P 64(R0), [V0.B16, V1.B16, V2.B16, V3.B16]
@@ -240,12 +242,7 @@ TEXT ·_popcntXorSliceNEON(SB), NOSPLIT, $0-56
 	LSR $3, R5, R3
 	CBZ R3, xortail
 xorblock:
-	MOVD INNERMAX, R4
-	CMP R4, R3
-	BHS xorinner
-	MOVD R3, R4
-xorinner:
-	SUB R4, R3, R3
+	SPLITBLOCKS
 	ZEROPART
 xorloop:
 	VLD1.P 64(R0), [V0.B16, V1.B16, V2.B16, V3.B16]
@@ -289,12 +286,7 @@ TEXT ·_popcntMaskSliceNEON(SB), NOSPLIT, $0-56
 	LSR $3, R5, R3
 	CBZ R3, masktail
 maskblock:
-	MOVD INNERMAX, R4
-	CMP R4, R3
-	BHS maskinner
-	MOVD R3, R4
-maskinner:
-	SUB R4, R3, R3
+	SPLITBLOCKS
 	ZEROPART
 maskloop:
 	VLD1.P 64(R0), [V0.B16, V1.B16, V2.B16, V3.B16]


### PR DESCRIPTION
Follow-up to a review suggestion on the AVX2 popcount PR, applied to the NEON side.

## What

Each of the five NEON popcount routines opened its outer block loop by clamping the outstanding 64-byte-block count to `INNERMAX` with a compare and a forward branch:

```asm
	MOVD INNERMAX, R4
	CMP R4, R3
	BHS <label>
	MOVD R3, R4
<label>:
	SUB R4, R3, R3
```

This replaces that with a branch-free `CSEL` sequence, factored into a `SPLITBLOCKS` macro to sit alongside the file's existing `FOLD4`/`ZEROPART`/`DRAIN` macros:

```asm
	SUBS INNERMAX, R3, R6
	MOVD INNERMAX, R4
	CSEL CS, R4, R3, R4     // R4 = min(R3, INNERMAX)
	CSEL CS, R6, ZR, R3     // R3 = max(R3-INNERMAX, 0)
```

The `SUBS` computes the leftover count *and* sets the flags that choose between the two cases, so it is four instructions instead of five, branch-free, and it removes five now-unused labels (`slinner`, `andinner`, `orinner`, `xorinner`, `maskinner`).

`R6` is the scratch register rather than `R5`, because `R5` holds the slice length across the vector loop in the four two-input routines.

## Performance: none, and that is expected

This is a code-size/clarity change. The sequence runs once per `INNERMAX` batch; since a roaring bitmap container is 1024 words = 128 blocks and `INNERMAX` is 1024 blocks, that is **once per call**, against an inner loop that saturates the NEON pipes for ~280 cycles. Measured on an arm64 laptop, `-count 6`:

| benchmark | before | after |
|---|---|---|
| `PopcntSlice1024NEON` | 70.3 ns/op | 69.8 ns/op |
| `PopcntAndSlice1024NEON` | 104.0 ns/op | 103.9 ns/op |

Both differences are inside run-to-run noise. Please do not merge this expecting a speedup.

## Testing

`go test ./...` passes on arm64, as does `go vet`.

⚠️ **Worth flagging: the existing tests do not cover this code path.** `neonTestLengths` tops out at 1025 words = 128 blocks, so the outer block loop never iterates more than once and the `CS` side of both `CSEL`s is never taken. I confirmed this by mutation: flipping `CSEL CS` to `CSEL CC` still passes `TestNEONPopcntDifferential`.

I verified this change locally with a temporary test at lengths that cross the batch boundary (8188/8191/8192/8193/8200, 16383–16385, 24576, 32775) plus an all-ones saturated case, differentially against the `popcnt*SliceGo` reference implementations. That temp test passes on this branch and fails on the mutant. It is **not** included here, since the request was to keep this PR to the `CSEL` change alone — happy to add it as a follow-up if you would like the coverage upstream.