### PR TITLE
Avoid goroutine fan-out in SumBigValues

### DIFF
--- a/roaring64/bsi64.go
+++ b/roaring64/bsi64.go
@@ -1131,22 +1131,16 @@ func (b *BSI) SumBigValues(foundSet *Bitmap) (sum *big.Int, count uint64) {
 	}
 	sum = new(big.Int)
 	count = foundSet.GetCardinality()
-	resultsChan := make(chan int64, b.BitCount())
-	var wg sync.WaitGroup
-	for i := 0; i < b.BitCount(); i++ {
-		wg.Add(1)
-		go func(j int) {
-			defer wg.Done()
-			resultsChan <- int64(foundSet.AndCardinality(&b.bA[j]) << uint(j))
-		}(i)
+	bitCount := b.BitCount()
+	var temp big.Int
+	for i := 0; i < bitCount; i++ {
+		temp.SetUint64(foundSet.AndCardinality(&b.bA[i]))
+		temp.Lsh(&temp, uint(i))
+		sum.Add(sum, &temp)
 	}
-	wg.Wait()
-	close(resultsChan)
-
-	for val := range resultsChan {
-		sum.Add(sum, big.NewInt(val))
-	}
-	sum.Sub(sum, big.NewInt(int64(foundSet.AndCardinality(&b.bA[b.BitCount()])<<uint(b.BitCount()))))
+	temp.SetUint64(foundSet.AndCardinality(&b.bA[bitCount]))
+	temp.Lsh(&temp, uint(bitCount))
+	sum.Sub(sum, &temp)
 
 	return sum, count
 }

--- a/roaring64/bsi64_test.go
+++ b/roaring64/bsi64_test.go
@@ -822,6 +822,47 @@ func TestSumWithNil(t *testing.T) {
 	assert.Equal(t, int64(0), sum)
 }
 
+func TestSumBigValues(t *testing.T) {
+	positive := new(big.Int).Lsh(big.NewInt(1), 149)
+	positive.Add(positive, big.NewInt(7))
+	negative := new(big.Int).Lsh(big.NewInt(1), 120)
+	negative.Neg(negative)
+	negative.Sub(negative, big.NewInt(11))
+	values := []struct {
+		columnID uint64
+		value    *big.Int
+	}{
+		{1, big.NewInt(-9)},
+		{2, positive},
+		{3, negative},
+		{4, big.NewInt(7)},
+	}
+
+	bsi := NewDefaultBSI()
+	want := new(big.Int)
+	for _, value := range values {
+		bsi.SetBigValue(value.columnID, value.value)
+		want.Add(want, value.value)
+	}
+
+	filteredWant := new(big.Int).Add(values[0].value, values[2].value)
+	for _, test := range []struct {
+		name     string
+		foundSet *Bitmap
+		want     *big.Int
+		count    uint64
+	}{
+		{"all", nil, want, uint64(len(values))},
+		{"filtered", BitmapOf(1, 3), filteredWant, 2},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			sum, count := bsi.SumBigValues(test.foundSet)
+			assert.Equal(t, test.count, count)
+			assert.Zero(t, sum.Cmp(test.want))
+		})
+	}
+}
+
 func BenchmarkBSI64SumBigValues(b *testing.B) {
 	const valueCount = 128
 

--- a/roaring64/bsi64_test.go
+++ b/roaring64/bsi64_test.go
@@ -822,6 +822,31 @@ func TestSumWithNil(t *testing.T) {
 	assert.Equal(t, int64(0), sum)
 }
 
+func BenchmarkBSI64SumBigValues(b *testing.B) {
+	const valueCount = 128
+
+	bsi := NewBSI(Max64BitSigned, 0)
+	foundSet := bsi.GetExistenceBitmap()
+	want := new(big.Int)
+	for columnID := uint64(0); columnID < valueCount; columnID++ {
+		value := int64(columnID)
+		bsi.SetValue(columnID, value)
+		want.Add(want, big.NewInt(value))
+	}
+	if bsi.BitCount() != 63 {
+		b.Fatalf("BitCount() = %d, want 63", bsi.BitCount())
+	}
+
+	var sum *big.Int
+	var count uint64
+	for b.Loop() {
+		sum, count = bsi.SumBigValues(foundSet)
+	}
+	if count != valueCount || sum.Cmp(want) != 0 {
+		b.Fatalf("SumBigValues() = (%v, %d), want (%v, %d)", sum, count, want, valueCount)
+	}
+}
+
 func TestTransposeWithCountsNil(t *testing.T) {
 	bsi := setup()
 	bsi.SetValue(101, 50)


### PR DESCRIPTION
## Description

Avoids creating a goroutine for every bit slice in `roaring64.BSI.SumBigValues`.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [x] Test improvements
- [ ] Build/CI changes

## Changes Made

### What was changed?
- Traverse bit slices synchronously and reuse one `big.Int` term.
- Added coverage for filtered, wide signed sums and a focused benchmark.

### Why was it changed?
- Per-bit cardinality intersections are small, so goroutine, channel, and closure setup costs more than the work.

### How was it changed?
- Shift each cardinality into the reusable term, add ordinary bit planes, and subtract the sign plane.

## Testing

`go test ./...`

Checks: 3 passed.

## Formatting

`gofmt -s -l` reports no files.

## Fuzzing

Not run; this only changes aggregate arithmetic and scheduling.

## Performance Impact

The benchmark uses a 63-bit BSI with 128 values. The traversal is intentionally serial, favoring small per-bit intersections over per-bit scheduling.

**Workload:** `SumBigValues on a 63-bit BSI with 128 values`

| Metric | Before | After | Change |
| --- | --- | --- | --- |
| `ns/op` | 34102 | 1872 | 94.5% lower |
| `B/op` | 5297 | 144 | 97.3% lower |
| `allocs/op` | 132 | 5 | 96.2% lower |

### Running Benchmarks

`go test ./roaring64 -run '^$' -bench '^BenchmarkBSI64SumBigValues$' -benchmem`

### Performance Analysis

Reusing the term avoids building a result channel and a separate `big.Int` for each bit plane.

## Breaking Changes

None.

## Related Issues

None.

## Additional Notes

None.

---

Generated by [Perfloop](https://app.perfloop.co). [Measurements and checks](https://app.perfloop.co/t/perfloop/case_gz6s2brq6q).