### PR TITLE
Optimize bitmap container batch iteration

### DIFF
--- a/bitmapcontainer.go
+++ b/bitmapcontainer.go
@@ -187,10 +187,17 @@ func (bcmi *bitmapContainerManyIterator) nextMany(hs uint32, buf []uint32) int {
 			bitset = bcmi.ptr.bitmap[base]
 			continue
 		}
-		t := bitset & -bitset
-		buf[n] = uint32(((base * 64) + bits.OnesCount64(t-1))) | hs
-		n = n + 1
-		bitset ^= t
+		if len(buf)-n >= 64 {
+			for bitset != 0 {
+				buf[n] = uint32((base*64)+bits.TrailingZeros64(bitset)) | hs
+				n++
+				bitset &= bitset - 1
+			}
+			continue
+		}
+		buf[n] = uint32((base*64)+bits.TrailingZeros64(bitset)) | hs
+		n++
+		bitset &= bitset - 1
 	}
 
 	bcmi.base = base
@@ -215,10 +222,17 @@ func (bcmi *bitmapContainerManyIterator) nextMany64(hs uint64, buf []uint64) int
 			bitset = bcmi.ptr.bitmap[base]
 			continue
 		}
-		t := bitset & -bitset
-		buf[n] = uint64(((base * 64) + bits.OnesCount64(t-1))) | hs
-		n = n + 1
-		bitset ^= t
+		if len(buf)-n >= 64 {
+			for bitset != 0 {
+				buf[n] = uint64((base*64)+bits.TrailingZeros64(bitset)) | hs
+				n++
+				bitset &= bitset - 1
+			}
+			continue
+		}
+		buf[n] = uint64((base*64)+bits.TrailingZeros64(bitset)) | hs
+		n++
+		bitset &= bitset - 1
 	}
 
 	bcmi.base = base

--- a/roaring64/manyiterator_bench_test.go
+++ b/roaring64/manyiterator_bench_test.go
@@ -1,0 +1,49 @@
+package roaring64
+
+import "testing"
+
+const benchmarkRoaring64BatchCardinality = 1 << 15
+
+func benchmarkRoaring64BatchBitmap() *Bitmap {
+	values := make([]uint64, benchmarkRoaring64BatchCardinality)
+	for i := range values {
+		values[i] = uint64(i * 2)
+	}
+
+	bitmap := New()
+	bitmap.AddMany(values)
+	return bitmap
+}
+
+func BenchmarkRoaring64ToArray(b *testing.B) {
+	bitmap := benchmarkRoaring64BatchBitmap()
+	last := uint64((benchmarkRoaring64BatchCardinality - 1) * 2)
+
+	for b.Loop() {
+		values := bitmap.ToArray()
+		if len(values) != benchmarkRoaring64BatchCardinality || values[0] != 0 || values[len(values)-1] != last {
+			b.Fatal("unexpected bitmap contents")
+		}
+	}
+}
+
+func BenchmarkRoaring64ManyIterator(b *testing.B) {
+	bitmap := benchmarkRoaring64BatchBitmap()
+	values := make([]uint64, benchmarkRoaring64BatchCardinality)
+	last := uint64((benchmarkRoaring64BatchCardinality - 1) * 2)
+
+	for b.Loop() {
+		iterator := bitmap.ManyIterator()
+		n := 0
+		for n < len(values) {
+			count := iterator.NextMany(values[n:])
+			if count == 0 {
+				break
+			}
+			n += count
+		}
+		if n != len(values) || values[0] != 0 || values[n-1] != last {
+			b.Fatal("unexpected iterator contents")
+		}
+	}
+}


### PR DESCRIPTION
## Description

Optimize bitmap-container batch decoding for `ManyIterator` and `ToArray`.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Test improvements
- [ ] Build/CI changes

## Changes Made

### What was changed?
- Replaced popcount-based bit extraction in `bitmapContainerManyIterator.nextMany` and `nextMany64` with `bits.TrailingZeros64` and lowest-set-bit clearing.
- Added benchmarks for public 64-bit `ToArray` and `ManyIterator` decoding paths.

### Why was it changed?
- Batch decoding did extra work to locate each set bit and rechecked output capacity for every value.

### How was it changed?
- A bitmap word is drained through a tight loop when at least 64 output slots remain. Partial buffers keep the bounded path.

## Testing

- `go test -v`
- `go test -v ./roaring64`
- `go test -v ./BitSliceIndexing`
- `go tool unconvert ./...`

Checks: 4 passed.

## Formatting

- Ran `gofmt` on the changed Go files.

## Fuzzing

- Not run; the change is confined to in-memory bitmap iteration.

## Performance Impact

- The benchmarks decode 32,768 values from one bitmap container and verify the returned values.
- The fast path is used only with at least 64 remaining output slots; partial buffers retain the bounded path.

**Workload:** `roaring64ToArray`

| Metric | Before | After | Change |
| --- | --- | --- | --- |
| `ns/op` | 92718 | 61471 | 33.7% lower |

**Workload:** `roaring64ManyIterator`

| Metric | Before | After | Change |
| --- | --- | --- | --- |
| `ns/op` | 60844 | 31408 | 48.4% lower |

## Breaking Changes

- None.

## Related Issues

- None.

## Additional Notes

- No API changes.

---

Generated by [Perfloop](https://app.perfloop.co). [Measurements and checks](https://app.perfloop.co/t/perfloop/case_zn75h6djz8).